### PR TITLE
[applicant] 신원본인인증시 authentication의 provider_id와 provider_name이 바뀌는 오류 해결

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/CreateApplicantService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/CreateApplicantService.java
@@ -34,13 +34,7 @@ public class CreateApplicantService {
 
         AuthenticationCode code = commonCodeService.validateAndGetRecentCode(authenticationId, reqDto.code(), reqDto.phoneNumber());
 
-        Authentication roleUpdatedAuthentication = authenticationRepository.save(
-                new Authentication(
-                        authentication.getId(),
-                        authentication.getProviderName(),
-                        authentication.getProviderId(),
-                        Role.APPLICANT
-                ));
+        Authentication roleUpdatedAuthentication = authenticationRepository.save(authentication.roleUpdatedAuthentication());
 
         Applicant newApplicant = new Applicant(
                 null,

--- a/src/main/java/team/themoment/hellogsmv3/domain/auth/entity/Authentication.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/auth/entity/Authentication.java
@@ -24,7 +24,7 @@ public class Authentication {
 
     public Authentication roleUpdatedAuthentication() {
         this.role = Role.APPLICANT;
-        return role;
+        return this;
     }
 
     @PrePersist

--- a/src/main/java/team/themoment/hellogsmv3/domain/auth/entity/Authentication.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/auth/entity/Authentication.java
@@ -1,16 +1,14 @@
 package team.themoment.hellogsmv3.domain.auth.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import team.themoment.hellogsmv3.domain.auth.type.Role;
 
 @Getter
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 public class Authentication {
 
     @Id
@@ -23,6 +21,11 @@ public class Authentication {
 
     @Enumerated(EnumType.STRING)
     private Role role;
+
+    public Authentication roleUpdatedAuthentication() {
+        this.role = Role.APPLICANT;
+        return role;
+    }
 
     @PrePersist
     private void prePersist() {


### PR DESCRIPTION
## 개요

신원 본인인증시 authentication의 provider_id와 provider_name이 바뀌어서 저장되는 오류가 발생하여 해결하였습니다.

- 신원본인인증시 authentication의 role이 APPLICANT로 변경되어 저장되는 로직을 authentication 엔티티 내부의 메서드를 사용하도록 변경하였습니다.