### PR TITLE
[application] 원서 도메인 enum 타입 필드 EnumType String으로 변경

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/application/entity/abs/AbstractApplication.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/entity/abs/AbstractApplication.java
@@ -74,6 +74,7 @@ public abstract class AbstractApplication {
     protected DesiredMajors desiredMajors;
 
     @Nullable
+    @Enumerated(EnumType.STRING)
     protected Major finalMajor;
 
     @NotNull

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/entity/abs/AbstractPersonalInformation.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/entity/abs/AbstractPersonalInformation.java
@@ -32,6 +32,7 @@ public abstract class AbstractPersonalInformation implements Cloneable{
 
     @NotNull
     @Column(name = "graduation")
+    @Enumerated(EnumType.STRING)
     protected GraduationStatus graduation;
 
     @NotNull

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/type/EvaluationResult.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/type/EvaluationResult.java
@@ -1,6 +1,8 @@
 package team.themoment.hellogsmv3.domain.application.type;
 
 import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,10 +20,13 @@ import java.util.Objects;
 @Builder
 public class EvaluationResult {
 
+    @Enumerated(EnumType.STRING)
     private EvaluationStatus evaluationStatus;
 
+    @Enumerated(EnumType.STRING)
     private Screening preScreeningEvaluation;
 
+    @Enumerated(EnumType.STRING)
     private Screening postScreeningEvaluation;
 
     private BigDecimal score;


### PR DESCRIPTION
## 개요

원서 도메인의 enum 타입 필드의 EnumType을 String으로 변경하였습니다

## 작업내용
원서 도메인에서 enum 타입의 필드 중 EnumType이 String이 아닌 필드가 존재하였습니다.

JPA에서 `@Enumrated` 어노테이션으로 EnumType을 설정해주지 않으면 기본적으로 `ORDINAL` 속성이 지정됩니다. 이는 enum 속성의 순서를 (정수값) 데이터베이스에 저장하기 때문에 만약에 해당 enum에 필드가 수정된다면 전혀 다른 값이 들어가는 문제가 발생할 수 있기 때문에 `STRING` 속성으로 변경하였습니다.