### PR TITLE
[member] 성별 enum class 이름 변경

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/dto/request/ApplicantReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/dto/request/ApplicantReqDto.java
@@ -3,7 +3,7 @@ package team.themoment.hellogsmv3.domain.applicant.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
-import team.themoment.hellogsmv3.domain.member.entity.type.Gender;
+import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
 
 import java.time.LocalDate;
 
@@ -13,7 +13,7 @@ public record ApplicantReqDto(
         @NotBlank String name,
         @Pattern(regexp = "^0(?:\\d|\\d{2})(?:\\d{3}|\\d{4})\\d{4}$")
         @NotBlank String phoneNumber,
-        @NotNull Gender gender,
+        @NotNull Sex sex,
         @NotNull LocalDate birth
 ) {
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/dto/response/FoundApplicantResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/dto/response/FoundApplicantResDto.java
@@ -1,7 +1,7 @@
 package team.themoment.hellogsmv3.domain.applicant.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import team.themoment.hellogsmv3.domain.member.entity.type.Gender;
+import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
 
 import java.time.LocalDate;
 
@@ -12,7 +12,7 @@ public record FoundApplicantResDto(
         String phoneNumber,
         @JsonFormat(pattern="yyyy-MM-dd")
         LocalDate birth,
-        Gender gender,
+        Sex sex,
         Long authenticationId
 ) {
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/entity/Applicant.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/entity/Applicant.java
@@ -6,7 +6,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import team.themoment.hellogsmv3.domain.member.entity.type.Gender;
+import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
 
 import java.time.LocalDate;
 
@@ -34,7 +34,7 @@ public class Applicant {
     @NotNull
     @Enumerated(EnumType.STRING)
     @Column(name = "gender")
-    private Gender gender;
+    private Sex sex;
 
     @NotNull
     @Column(name = "authentication_id", unique = true)

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/CreateApplicantService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/CreateApplicantService.java
@@ -39,7 +39,7 @@ public class CreateApplicantService {
                 reqDto.name(),
                 reqDto.phoneNumber(),
                 reqDto.birth(),
-                reqDto.gender(),
+                reqDto.sex(),
                 authenticationId
         );
         applicantRepository.save(newApplicant);

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/ModifyApplicantService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/ModifyApplicantService.java
@@ -11,8 +11,6 @@ import team.themoment.hellogsmv3.domain.applicant.repo.ApplicantRepository;
 import team.themoment.hellogsmv3.domain.auth.repo.AuthenticationRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
-import java.util.List;
-
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -36,7 +34,7 @@ public class ModifyApplicantService {
                 reqDto.name(),
                 reqDto.phoneNumber(),
                 reqDto.birth(),
-                reqDto.gender(),
+                reqDto.sex(),
                 authenticationId
         );
         applicantRepository.save(newApplicant);

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/QueryApplicantByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/QueryApplicantByIdService.java
@@ -21,7 +21,7 @@ public class QueryApplicantByIdService {
                 applicant.getName(),
                 applicant.getPhoneNumber(),
                 applicant.getBirth(),
-                applicant.getGender(),
+                applicant.getSex(),
                 authenticationId
         );
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/dto/response/GedAdmissionInfoResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/dto/response/GedAdmissionInfoResDto.java
@@ -1,7 +1,7 @@
 package team.themoment.hellogsmv3.domain.application.dto.response;
 
 import lombok.Builder;
-import team.themoment.hellogsmv3.domain.member.entity.type.Gender;
+import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
@@ -11,7 +11,7 @@ import java.time.LocalDate;
 @Builder
 public record GedAdmissionInfoResDto(
         String applicantName,
-        Gender applicantGender,
+        Sex applicantSex,
         LocalDate applicantBirth,
         String address,
         String detailAddress,

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/dto/response/GeneralAdmissionInfoResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/dto/response/GeneralAdmissionInfoResDto.java
@@ -2,7 +2,7 @@ package team.themoment.hellogsmv3.domain.application.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
-import team.themoment.hellogsmv3.domain.member.entity.type.Gender;
+import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
@@ -12,7 +12,7 @@ import java.time.LocalDate;
 @Builder
 public record GeneralAdmissionInfoResDto(
         String applicantName,
-        Gender applicantGender,
+        Sex applicantSex,
         @JsonFormat(pattern="yyyy-MM-dd")
         LocalDate applicantBirth,
         String address,

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/service/QueryApplicationByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/service/QueryApplicationByIdService.java
@@ -66,7 +66,7 @@ public class QueryApplicationByIdService {
 
         return GedAdmissionInfoResDto.builder()
                 .applicantName(applicant.getName())
-                .applicantGender(applicant.getGender())
+                .applicantGender(applicant.getSex())
                 .applicantBirth(applicant.getBirth())
                 .address(personalInformation.getAddress())
                 .detailAddress(personalInformation.getDetailAddress())
@@ -99,7 +99,7 @@ public class QueryApplicationByIdService {
 
         return GeneralAdmissionInfoResDto.builder()
                 .applicantName(applicant.getName())
-                .applicantGender(applicant.getGender())
+                .applicantGender(applicant.getSex())
                 .applicantBirth(applicant.getBirth())
                 .address(personalInformation.getAddress())
                 .detailAddress(personalInformation.getDetailAddress())

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/entity/Member.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/entity/Member.java
@@ -5,9 +5,9 @@ import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import team.themoment.hellogsmv3.domain.member.entity.type.Gender;
 import team.themoment.hellogsmv3.domain.member.entity.type.Role;
 import team.themoment.hellogsmv3.domain.member.entity.type.AuthReferrerType;
+import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -44,7 +44,7 @@ public class Member {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "sex")
-    private Gender sex;
+    private Sex sex;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "role")

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/entity/type/Sex.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/entity/type/Sex.java
@@ -1,6 +1,6 @@
 package team.themoment.hellogsmv3.domain.member.entity.type;
 
-public enum Gender {
+public enum Sex {
     MALE,
     FEMALE
 }


### PR DESCRIPTION
## 본문

성별 column name이 `gender -> sex` 로 변경됨에 따라 성별 enum class 이름도 `Gender -> Sex` 로 변경하였습니다.