### PR TITLE
[member] 인증코드 전송 기능 구현

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/controller/ApplicantController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/controller/ApplicantController.java
@@ -12,8 +12,8 @@ import team.themoment.hellogsmv3.domain.applicant.dto.request.AuthenticateCodeRe
 import team.themoment.hellogsmv3.domain.applicant.dto.request.GenerateCodeReqDto;
 import team.themoment.hellogsmv3.domain.applicant.service.AuthenticateCodeService;
 import team.themoment.hellogsmv3.domain.applicant.service.ModifyApplicantService;
-import team.themoment.hellogsmv3.domain.applicant.service.impl.GenerateCodeServiceImpl;
-import team.themoment.hellogsmv3.domain.applicant.service.impl.GenerateTestCodeServiceImpl;
+import team.themoment.hellogsmv3.domain.applicant.service.impl.GenerateApplicantCodeServiceImpl;
+import team.themoment.hellogsmv3.domain.applicant.service.impl.GenerateApplicantTestCodeServiceImpl;
 import team.themoment.hellogsmv3.domain.member.entity.type.Role;
 import team.themoment.hellogsmv3.global.common.handler.annotation.AuthRequest;
 import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
@@ -28,8 +28,8 @@ public class ApplicantController {
     private final ModifyApplicantService modifyApplicantService;
     private final QueryApplicantByIdService queryApplicantByIdService;
     private final AuthenticateCodeService authenticateCodeService;
-    private final GenerateTestCodeServiceImpl generateTestCodeService;
-    private final GenerateCodeServiceImpl generateCodeService;
+    private final GenerateApplicantTestCodeServiceImpl generateTestCodeService;
+    private final GenerateApplicantCodeServiceImpl generateCodeService;
     private final AuthenticatedUserManager manager;
 
     @PostMapping("/applicant/me/send-code")

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/entity/ApplicantAuthenticationCode.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/entity/ApplicantAuthenticationCode.java
@@ -1,0 +1,45 @@
+package team.themoment.hellogsmv3.domain.applicant.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RedisHash(timeToLive = 3600L)
+public class ApplicantAuthenticationCode {
+    @Id
+    @Indexed
+    private Long authenticationId;
+    @Indexed
+    private String code;
+    private Boolean authenticated;
+    private String phoneNumber;
+    private LocalDateTime createdAt;
+    private int count;
+
+    public ApplicantAuthenticationCode updatedCode(String code, LocalDateTime createdAt, Boolean isTest) {
+        this.code = code;
+        this.createdAt = createdAt;
+        this.count = !isTest ? (count + 1) : 0; // 테스트 상황이라면 count가 증가하지 않음
+        return this;
+    }
+
+    public ApplicantAuthenticationCode(Long authenticationId, String code, String phoneNumber, LocalDateTime createdAt) {
+        this.authenticationId = authenticationId;
+        this.code = code;
+        this.authenticated = false;
+        this.phoneNumber = phoneNumber;
+        this.createdAt = createdAt;
+        this.count = 1;
+    }
+
+    public void authenticatedAuthenticationCode() {
+        this.authenticated = true;
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/repo/ApplicantCodeRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/repo/ApplicantCodeRepository.java
@@ -1,0 +1,11 @@
+package team.themoment.hellogsmv3.domain.applicant.repo;
+
+import org.springframework.data.repository.CrudRepository;
+import team.themoment.hellogsmv3.domain.applicant.entity.ApplicantAuthenticationCode;
+
+import java.util.Optional;
+
+public interface ApplicantCodeRepository extends CrudRepository<ApplicantAuthenticationCode, String> {
+    Optional<ApplicantAuthenticationCode> findByAuthenticationId(Long authenticationId);
+    Optional<ApplicantAuthenticationCode> findByCode(String code);
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/AuthenticateCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/AuthenticateCodeService.java
@@ -5,8 +5,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.applicant.dto.request.AuthenticateCodeReqDto;
-import team.themoment.hellogsmv3.domain.applicant.entity.AuthenticationCode;
-import team.themoment.hellogsmv3.domain.applicant.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/AuthenticateCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/AuthenticateCodeService.java
@@ -5,8 +5,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.applicant.dto.request.AuthenticateCodeReqDto;
-import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
-import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.applicant.entity.ApplicantAuthenticationCode;
+import team.themoment.hellogsmv3.domain.applicant.repo.ApplicantCodeRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
@@ -14,11 +14,11 @@ import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 @Transactional
 public class AuthenticateCodeService {
 
-    private final CodeRepository codeRepository;
+    private final ApplicantCodeRepository codeRepository;
 
     public void execute(Long userId, AuthenticateCodeReqDto reqDto) {
 
-        AuthenticationCode code = codeRepository.findByAuthenticationId(userId)
+        ApplicantAuthenticationCode code = codeRepository.findByAuthenticationId(userId)
                 .orElseThrow(() -> new ExpectedException("사용자의 code가 존재하지 않습니다. 사용자의 ID : " + userId, HttpStatus.BAD_REQUEST));
 
         if (!code.getCode().equals(reqDto.code()))

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/CommonCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/CommonCodeService.java
@@ -3,18 +3,18 @@ package team.themoment.hellogsmv3.domain.applicant.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
-import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.applicant.entity.ApplicantAuthenticationCode;
+import team.themoment.hellogsmv3.domain.applicant.repo.ApplicantCodeRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
 @RequiredArgsConstructor
 public class CommonCodeService {
 
-    private final CodeRepository codeRepository;
+    private final ApplicantCodeRepository codeRepository;
 
-    public AuthenticationCode validateAndGetRecentCode(Long authenticationId, String inputCode, String inputPhoneNumber) {
-        AuthenticationCode code = codeRepository.findByAuthenticationId(authenticationId)
+    public ApplicantAuthenticationCode validateAndGetRecentCode(Long authenticationId, String inputCode, String inputPhoneNumber) {
+        ApplicantAuthenticationCode code = codeRepository.findByAuthenticationId(authenticationId)
                 .orElseThrow(() -> new ExpectedException("사용자의 code가 존재하지 않습니다. 사용자의 ID : " + authenticationId, HttpStatus.BAD_REQUEST));
 
         if (!code.getAuthenticated()) {
@@ -32,7 +32,7 @@ public class CommonCodeService {
         return code;
     }
 
-    public void deleteCode(AuthenticationCode code) {
+    public void deleteCode(ApplicantAuthenticationCode code) {
         codeRepository.delete(code);
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/CommonCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/CommonCodeService.java
@@ -3,12 +3,9 @@ package team.themoment.hellogsmv3.domain.applicant.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import team.themoment.hellogsmv3.domain.applicant.entity.AuthenticationCode;
-import team.themoment.hellogsmv3.domain.applicant.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
-
-import java.util.Comparator;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/CreateApplicantService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/CreateApplicantService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.applicant.dto.request.ApplicantReqDto;
 import team.themoment.hellogsmv3.domain.applicant.entity.Applicant;
-import team.themoment.hellogsmv3.domain.applicant.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 import team.themoment.hellogsmv3.domain.applicant.repo.ApplicantRepository;
 import team.themoment.hellogsmv3.domain.auth.entity.Authentication;
 import team.themoment.hellogsmv3.domain.auth.repo.AuthenticationRepository;

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/CreateApplicantService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/CreateApplicantService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.applicant.dto.request.ApplicantReqDto;
 import team.themoment.hellogsmv3.domain.applicant.entity.Applicant;
-import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.applicant.entity.ApplicantAuthenticationCode;
 import team.themoment.hellogsmv3.domain.applicant.repo.ApplicantRepository;
 import team.themoment.hellogsmv3.domain.auth.entity.Authentication;
 import team.themoment.hellogsmv3.domain.auth.repo.AuthenticationRepository;
@@ -30,7 +30,7 @@ public class CreateApplicantService {
         if (applicantRepository.existsByAuthenticationId(authenticationId))
             throw new ExpectedException("이미 존재하는 Applicant 입니다", HttpStatus.BAD_REQUEST);
 
-        AuthenticationCode code = commonCodeService.validateAndGetRecentCode(authenticationId, reqDto.code(), reqDto.phoneNumber());
+        ApplicantAuthenticationCode code = commonCodeService.validateAndGetRecentCode(authenticationId, reqDto.code(), reqDto.phoneNumber());
 
         Authentication roleUpdatedAuthentication = authenticationRepository.save(authentication.roleUpdatedAuthentication());
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/GenerateApplicantCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/GenerateApplicantCodeService.java
@@ -1,32 +1,32 @@
 package team.themoment.hellogsmv3.domain.applicant.service;
 
 import team.themoment.hellogsmv3.domain.applicant.dto.request.GenerateCodeReqDto;
-import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
-import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.applicant.entity.ApplicantAuthenticationCode;
+import team.themoment.hellogsmv3.domain.applicant.repo.ApplicantCodeRepository;
 
 import java.time.LocalDateTime;
 import java.util.Random;
 
-public abstract class GenerateCodeService {
+public abstract class GenerateApplicantCodeService {
     protected static final int DIGIT_NUMBER = 6;
     protected static final int LIMIT_COUNT_CODE_REQUEST = 5;
     protected static final int MAX = (int) Math.pow(10, DIGIT_NUMBER) - 1;
 
     protected abstract String execute(Long authenticationId, GenerateCodeReqDto reqDto);
 
-    protected AuthenticationCode createAuthenticationCode(
-            AuthenticationCode authCode,
+    protected ApplicantAuthenticationCode createAuthenticationCode(
+            ApplicantAuthenticationCode authCode,
             Long authenticationId,
             String code,
             String phoneNumber,
             boolean isTest) {
 
         return authCode == null ?
-                new AuthenticationCode(authenticationId, code, phoneNumber, LocalDateTime.now()) :
+                new ApplicantAuthenticationCode(authenticationId, code, phoneNumber, LocalDateTime.now()) :
                 authCode.updatedCode(code, LocalDateTime.now(), isTest);
     }
 
-    protected String generateUniqueCode(Random RANDOM, CodeRepository codeRepository) {
+    protected String generateUniqueCode(Random RANDOM, ApplicantCodeRepository codeRepository) {
         String code;
         do {
             code = getRandomCode(RANDOM);
@@ -34,7 +34,7 @@ public abstract class GenerateCodeService {
         return code;
     }
 
-    protected Boolean isDuplicate(String code, CodeRepository codeRepository) {
+    protected Boolean isDuplicate(String code, ApplicantCodeRepository codeRepository) {
         return codeRepository.findByCode(code).isPresent();
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/GenerateCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/GenerateCodeService.java
@@ -1,8 +1,8 @@
 package team.themoment.hellogsmv3.domain.applicant.service;
 
 import team.themoment.hellogsmv3.domain.applicant.dto.request.GenerateCodeReqDto;
-import team.themoment.hellogsmv3.domain.applicant.entity.AuthenticationCode;
-import team.themoment.hellogsmv3.domain.applicant.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
 
 import java.time.LocalDateTime;
 import java.util.Random;

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/ModifyApplicantService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/ModifyApplicantService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.applicant.dto.request.ApplicantReqDto;
 import team.themoment.hellogsmv3.domain.applicant.entity.Applicant;
-import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.applicant.entity.ApplicantAuthenticationCode;
 import team.themoment.hellogsmv3.domain.applicant.repo.ApplicantRepository;
 import team.themoment.hellogsmv3.domain.auth.repo.AuthenticationRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
@@ -27,7 +27,7 @@ public class ModifyApplicantService {
 
         Applicant savedApplicant = applicantService.findOrThrowByAuthId(authenticationId);
 
-        AuthenticationCode code = commonCodeService.validateAndGetRecentCode(authenticationId, reqDto.code(), reqDto.phoneNumber());
+        ApplicantAuthenticationCode code = commonCodeService.validateAndGetRecentCode(authenticationId, reqDto.code(), reqDto.phoneNumber());
 
         Applicant newApplicant = new Applicant(
                 savedApplicant.getId(),

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/ModifyApplicantService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/ModifyApplicantService.java
@@ -6,12 +6,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.applicant.dto.request.ApplicantReqDto;
 import team.themoment.hellogsmv3.domain.applicant.entity.Applicant;
-import team.themoment.hellogsmv3.domain.applicant.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 import team.themoment.hellogsmv3.domain.applicant.repo.ApplicantRepository;
 import team.themoment.hellogsmv3.domain.auth.repo.AuthenticationRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
-
-import java.util.List;
 
 @Service
 @Transactional

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/QueryApplicantByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/QueryApplicantByIdService.java
@@ -1,6 +1,5 @@
 package team.themoment.hellogsmv3.domain.applicant.service;
 
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.applicant.dto.response.FoundApplicantResDto;

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/impl/GenerateApplicantCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/impl/GenerateApplicantCodeServiceImpl.java
@@ -4,24 +4,24 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.applicant.dto.request.GenerateCodeReqDto;
-import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
-import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
-import team.themoment.hellogsmv3.domain.applicant.service.GenerateCodeService;
+import team.themoment.hellogsmv3.domain.applicant.entity.ApplicantAuthenticationCode;
+import team.themoment.hellogsmv3.domain.applicant.repo.ApplicantCodeRepository;
+import team.themoment.hellogsmv3.domain.applicant.service.GenerateApplicantCodeService;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.util.Random;
 
 @Service
 @RequiredArgsConstructor
-public class GenerateCodeServiceImpl extends GenerateCodeService {
+public class GenerateApplicantCodeServiceImpl extends GenerateApplicantCodeService {
 
-    private final CodeRepository codeRepository;
+    private final ApplicantCodeRepository codeRepository;
     private static final Random RANDOM = new Random();
 
     @Override
     public String execute(Long authenticationId, GenerateCodeReqDto reqDto) {
 
-        AuthenticationCode authenticationCode = codeRepository.findByAuthenticationId(authenticationId)
+        ApplicantAuthenticationCode authenticationCode = codeRepository.findByAuthenticationId(authenticationId)
                 .orElse(null);
 
         if (isLimitedRequest(authenticationCode))
@@ -43,7 +43,7 @@ public class GenerateCodeServiceImpl extends GenerateCodeService {
         return code;
     }
 
-    private boolean isLimitedRequest(AuthenticationCode authenticationCode) {
+    private boolean isLimitedRequest(ApplicantAuthenticationCode authenticationCode) {
         return authenticationCode != null && authenticationCode.getCount() >= LIMIT_COUNT_CODE_REQUEST;
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/impl/GenerateApplicantTestCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/impl/GenerateApplicantTestCodeServiceImpl.java
@@ -3,25 +3,25 @@ package team.themoment.hellogsmv3.domain.applicant.service.impl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.applicant.dto.request.GenerateCodeReqDto;
-import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
-import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
-import team.themoment.hellogsmv3.domain.applicant.service.GenerateCodeService;
+import team.themoment.hellogsmv3.domain.applicant.entity.ApplicantAuthenticationCode;
+import team.themoment.hellogsmv3.domain.applicant.repo.ApplicantCodeRepository;
+import team.themoment.hellogsmv3.domain.applicant.service.GenerateApplicantCodeService;
 
 import java.time.LocalDateTime;
 import java.util.Random;
 
 @Service
 @RequiredArgsConstructor
-public class GenerateTestCodeServiceImpl extends GenerateCodeService {
+public class GenerateApplicantTestCodeServiceImpl extends GenerateApplicantCodeService {
 
-    private final CodeRepository codeRepository;
+    private final ApplicantCodeRepository codeRepository;
     private static final Random RANDOM = new Random();
 
     @Override
     public String execute(Long authenticationId, GenerateCodeReqDto reqDto) {
         final String code = generateUniqueCode(RANDOM, codeRepository);
 
-        AuthenticationCode authenticationCode = codeRepository.findByAuthenticationId(authenticationId)
+        ApplicantAuthenticationCode authenticationCode = codeRepository.findByAuthenticationId(authenticationId)
                 .orElse(null);
 
         codeRepository.save(createAuthenticationCode(
@@ -31,7 +31,7 @@ public class GenerateTestCodeServiceImpl extends GenerateCodeService {
                 reqDto.phoneNumber(),
                 true));
 
-        codeRepository.save(new AuthenticationCode(authenticationId, code, reqDto.phoneNumber(), LocalDateTime.now()));
+        codeRepository.save(new ApplicantAuthenticationCode(authenticationId, code, reqDto.phoneNumber(), LocalDateTime.now()));
 
         return code;
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/impl/GenerateCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/impl/GenerateCodeServiceImpl.java
@@ -4,12 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.applicant.dto.request.GenerateCodeReqDto;
-import team.themoment.hellogsmv3.domain.applicant.entity.AuthenticationCode;
-import team.themoment.hellogsmv3.domain.applicant.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
 import team.themoment.hellogsmv3.domain.applicant.service.GenerateCodeService;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
-import java.time.LocalDateTime;
 import java.util.Random;
 
 @Service

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/impl/GenerateTestCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/impl/GenerateTestCodeServiceImpl.java
@@ -3,8 +3,8 @@ package team.themoment.hellogsmv3.domain.applicant.service.impl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.applicant.dto.request.GenerateCodeReqDto;
-import team.themoment.hellogsmv3.domain.applicant.entity.AuthenticationCode;
-import team.themoment.hellogsmv3.domain.applicant.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
 import team.themoment.hellogsmv3.domain.applicant.service.GenerateCodeService;
 
 import java.time.LocalDateTime;

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
@@ -20,7 +20,10 @@ public class MemberController {
     private final QueryMemberByIdService queryMemberByIdService;
 
     @PostMapping("/member/me/send-code")
-    public CommonApiResponse sendCode(@AuthRequest Long memberId, @RequestBody GenerateCodeReqDto reqDto) {
+    public CommonApiResponse sendCode(
+        @AuthRequest Long memberId, 
+        @RequestBody GenerateCodeReqDto reqDto
+    ) {
         generateCodeService.execute(memberId, reqDto);
         return CommonApiResponse.success("전송되었습니다.");
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
@@ -2,16 +2,26 @@ package team.themoment.hellogsmv3.domain.member.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-import team.themoment.hellogsmv3.domain.member.dto.FoundMemberResDto;
+import team.themoment.hellogsmv3.domain.member.dto.request.GenerateCodeReqDto;
+import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberResDto;
 import team.themoment.hellogsmv3.domain.member.service.QueryMemberByIdService;
+import team.themoment.hellogsmv3.domain.member.service.impl.GenerateCodeServiceImpl;
 import team.themoment.hellogsmv3.global.common.handler.annotation.AuthRequest;
+import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 
 @RestController
 @RequestMapping("/member/v3")
 @RequiredArgsConstructor
 public class MemberController {
 
+    private final GenerateCodeServiceImpl generateCodeService;
     private final QueryMemberByIdService queryMemberByIdService;
+
+    @PostMapping("/send-code")
+    public CommonApiResponse sendCode(@AuthRequest Long memberId, @RequestBody GenerateCodeReqDto reqDto) {
+        generateCodeService.execute(memberId, reqDto);
+        return CommonApiResponse.success("전송되었습니다.");
+    }
 
     @GetMapping("/member/me")
     public FoundMemberResDto find(

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
@@ -6,6 +6,7 @@ import team.themoment.hellogsmv3.domain.member.dto.request.GenerateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberResDto;
 import team.themoment.hellogsmv3.domain.member.service.QueryMemberByIdService;
 import team.themoment.hellogsmv3.domain.member.service.impl.GenerateCodeServiceImpl;
+import team.themoment.hellogsmv3.domain.member.service.impl.GenerateTestCodeServiceImpl;
 import team.themoment.hellogsmv3.global.common.handler.annotation.AuthRequest;
 import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 
@@ -15,12 +16,19 @@ import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 public class MemberController {
 
     private final GenerateCodeServiceImpl generateCodeService;
+    private final GenerateTestCodeServiceImpl generateTestCodeService;
     private final QueryMemberByIdService queryMemberByIdService;
 
-    @PostMapping("/send-code")
+    @PostMapping("/me/send-code")
     public CommonApiResponse sendCode(@AuthRequest Long memberId, @RequestBody GenerateCodeReqDto reqDto) {
         generateCodeService.execute(memberId, reqDto);
         return CommonApiResponse.success("전송되었습니다.");
+    }
+
+    @PostMapping("/me/send-code-test")
+    public CommonApiResponse sendCodeTest(@AuthRequest Long memberId, @RequestBody GenerateCodeReqDto reqDto) {
+        String code = generateTestCodeService.execute(memberId, reqDto);
+        return CommonApiResponse.success("전송되었습니다. : " + code);
     }
 
     @GetMapping("/member/me")

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
@@ -19,13 +19,13 @@ public class MemberController {
     private final GenerateTestCodeServiceImpl generateTestCodeService;
     private final QueryMemberByIdService queryMemberByIdService;
 
-    @PostMapping("/me/send-code")
+    @PostMapping("/member/me/send-code")
     public CommonApiResponse sendCode(@AuthRequest Long memberId, @RequestBody GenerateCodeReqDto reqDto) {
         generateCodeService.execute(memberId, reqDto);
         return CommonApiResponse.success("전송되었습니다.");
     }
 
-    @PostMapping("/me/send-code-test")
+    @PostMapping("/member/me/send-code-test")
     public CommonApiResponse sendCodeTest(@AuthRequest Long memberId, @RequestBody GenerateCodeReqDto reqDto) {
         String code = generateTestCodeService.execute(memberId, reqDto);
         return CommonApiResponse.success("전송되었습니다. : " + code);

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/dto/request/GenerateCodeReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/dto/request/GenerateCodeReqDto.java
@@ -1,0 +1,10 @@
+package team.themoment.hellogsmv3.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record GenerateCodeReqDto(
+        @Pattern(regexp = "^0(?:\\d|\\d{2})(?:\\d{3}|\\d{4})\\d{4}$")
+        @NotNull String phoneNumber
+) {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/dto/response/FoundMemberResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/dto/response/FoundMemberResDto.java
@@ -1,4 +1,4 @@
-package team.themoment.hellogsmv3.domain.member.dto;
+package team.themoment.hellogsmv3.domain.member.dto.response;
 
 import lombok.Builder;
 import team.themoment.hellogsmv3.domain.member.entity.type.Gender;

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/entity/AuthenticationCode.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/entity/AuthenticationCode.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 public class AuthenticationCode {
     @Id
     @Indexed
-    private Long authenticationId;
+    private Long memberId;
     @Indexed
     private String code;
     private Boolean authenticated;
@@ -30,8 +30,8 @@ public class AuthenticationCode {
         return this;
     }
 
-    public AuthenticationCode(Long authenticationId, String code, String phoneNumber, LocalDateTime createdAt) {
-        this.authenticationId = authenticationId;
+    public AuthenticationCode(Long memberId, String code, String phoneNumber, LocalDateTime createdAt) {
+        this.memberId = memberId;
         this.code = code;
         this.authenticated = false;
         this.phoneNumber = phoneNumber;

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/entity/AuthenticationCode.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/entity/AuthenticationCode.java
@@ -1,12 +1,10 @@
-package team.themoment.hellogsmv3.domain.applicant.entity;
+package team.themoment.hellogsmv3.domain.member.entity;
 
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
-import org.springframework.data.redis.core.TimeToLive;
 import org.springframework.data.redis.core.index.Indexed;
 
 import java.time.LocalDateTime;

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/repo/CodeRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/repo/CodeRepository.java
@@ -6,6 +6,6 @@ import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 import java.util.Optional;
 
 public interface CodeRepository extends CrudRepository<AuthenticationCode, String> {
-    Optional<AuthenticationCode> findByAuthenticationId(Long authenticationId);
+    Optional<AuthenticationCode> findByMemberId(Long memberId);
     Optional<AuthenticationCode> findByCode(String code);
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/repo/CodeRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/repo/CodeRepository.java
@@ -1,9 +1,8 @@
-package team.themoment.hellogsmv3.domain.applicant.repo;
+package team.themoment.hellogsmv3.domain.member.repo;
 
 import org.springframework.data.repository.CrudRepository;
-import team.themoment.hellogsmv3.domain.applicant.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface CodeRepository extends CrudRepository<AuthenticationCode, String> {

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/GenerateCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/GenerateCodeService.java
@@ -1,6 +1,6 @@
 package team.themoment.hellogsmv3.domain.member.service;
 
-import team.themoment.hellogsmv3.domain.applicant.dto.request.GenerateCodeReqDto;
+import team.themoment.hellogsmv3.domain.member.dto.request.GenerateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/GenerateCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/GenerateCodeService.java
@@ -12,17 +12,17 @@ public abstract class GenerateCodeService {
     protected static final int LIMIT_COUNT_CODE_REQUEST = 5;
     protected static final int MAX = (int) Math.pow(10, DIGIT_NUMBER) - 1;
 
-    protected abstract String execute(Long authenticationId, GenerateCodeReqDto reqDto);
+    protected abstract String execute(Long memberId, GenerateCodeReqDto reqDto);
 
     protected AuthenticationCode createAuthenticationCode(
             AuthenticationCode authCode,
-            Long authenticationId,
+            Long memberId,
             String code,
             String phoneNumber,
             boolean isTest) {
 
         return authCode == null ?
-                new AuthenticationCode(authenticationId, code, phoneNumber, LocalDateTime.now()) :
+                new AuthenticationCode(memberId, code, phoneNumber, LocalDateTime.now()) :
                 authCode.updatedCode(code, LocalDateTime.now(), isTest);
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/GenerateCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/GenerateCodeService.java
@@ -1,0 +1,44 @@
+package team.themoment.hellogsmv3.domain.member.service;
+
+import team.themoment.hellogsmv3.domain.applicant.dto.request.GenerateCodeReqDto;
+import team.themoment.hellogsmv3.domain.applicant.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.applicant.repo.CodeRepository;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+
+public abstract class GenerateCodeService {
+    protected static final int DIGIT_NUMBER = 6;
+    protected static final int LIMIT_COUNT_CODE_REQUEST = 5;
+    protected static final int MAX = (int) Math.pow(10, DIGIT_NUMBER) - 1;
+
+    protected abstract String execute(Long authenticationId, GenerateCodeReqDto reqDto);
+
+    protected AuthenticationCode createAuthenticationCode(
+            AuthenticationCode authCode,
+            Long authenticationId,
+            String code,
+            String phoneNumber,
+            boolean isTest) {
+
+        return authCode == null ?
+                new AuthenticationCode(authenticationId, code, phoneNumber, LocalDateTime.now()) :
+                authCode.updatedCode(code, LocalDateTime.now(), isTest);
+    }
+
+    protected String generateUniqueCode(Random RANDOM, CodeRepository codeRepository) {
+        String code;
+        do {
+            code = getRandomCode(RANDOM);
+        } while (isDuplicate(code, codeRepository));
+        return code;
+    }
+
+    protected Boolean isDuplicate(String code, CodeRepository codeRepository) {
+        return codeRepository.findByCode(code).isPresent();
+    }
+
+    protected String getRandomCode(Random RANDOM) {
+        return String.format("%0" + DIGIT_NUMBER + "d", RANDOM.nextInt(0, MAX + 1));
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/GenerateCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/GenerateCodeService.java
@@ -1,8 +1,8 @@
 package team.themoment.hellogsmv3.domain.member.service;
 
 import team.themoment.hellogsmv3.domain.applicant.dto.request.GenerateCodeReqDto;
-import team.themoment.hellogsmv3.domain.applicant.entity.AuthenticationCode;
-import team.themoment.hellogsmv3.domain.applicant.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
 
 import java.time.LocalDateTime;
 import java.util.Random;

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import team.themoment.hellogsmv3.domain.member.dto.FoundMemberResDto;
+import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberResDto;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImpl.java
@@ -4,8 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.applicant.dto.request.GenerateCodeReqDto;
-import team.themoment.hellogsmv3.domain.applicant.entity.AuthenticationCode;
-import team.themoment.hellogsmv3.domain.applicant.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
 import team.themoment.hellogsmv3.domain.applicant.service.GenerateCodeService;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImpl.java
@@ -3,10 +3,10 @@ package team.themoment.hellogsmv3.domain.member.service.impl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import team.themoment.hellogsmv3.domain.applicant.dto.request.GenerateCodeReqDto;
+import team.themoment.hellogsmv3.domain.member.dto.request.GenerateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
-import team.themoment.hellogsmv3.domain.applicant.service.GenerateCodeService;
+import team.themoment.hellogsmv3.domain.member.service.GenerateCodeService;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.util.Random;

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImpl.java
@@ -19,9 +19,9 @@ public class GenerateCodeServiceImpl extends GenerateCodeService {
     private static final Random RANDOM = new Random();
 
     @Override
-    public String execute(Long authenticationId, GenerateCodeReqDto reqDto) {
+    public String execute(Long memberId, GenerateCodeReqDto reqDto) {
 
-        AuthenticationCode authenticationCode = codeRepository.findByAuthenticationId(authenticationId)
+        AuthenticationCode authenticationCode = codeRepository.findByMemberId(memberId)
                 .orElse(null);
 
         if (isLimitedRequest(authenticationCode))
@@ -33,7 +33,7 @@ public class GenerateCodeServiceImpl extends GenerateCodeService {
 
         codeRepository.save(createAuthenticationCode(
                 authenticationCode,
-                authenticationId,
+                memberId,
                 code,
                 reqDto.phoneNumber(),
                 false));

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImpl.java
@@ -1,0 +1,49 @@
+package team.themoment.hellogsmv3.domain.member.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import team.themoment.hellogsmv3.domain.applicant.dto.request.GenerateCodeReqDto;
+import team.themoment.hellogsmv3.domain.applicant.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.applicant.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.applicant.service.GenerateCodeService;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class GenerateCodeServiceImpl extends GenerateCodeService {
+
+    private final CodeRepository codeRepository;
+    private static final Random RANDOM = new Random();
+
+    @Override
+    public String execute(Long authenticationId, GenerateCodeReqDto reqDto) {
+
+        AuthenticationCode authenticationCode = codeRepository.findByAuthenticationId(authenticationId)
+                .orElse(null);
+
+        if (isLimitedRequest(authenticationCode))
+            throw new ExpectedException(String.format(
+                    "너무 많은 요청이 발생했습니다. 잠시 후 다시 시도해주세요. 특정 시간 내 제한 횟수인 %d회를 초과하였습니다.",
+                    LIMIT_COUNT_CODE_REQUEST), HttpStatus.FORBIDDEN);
+
+        final String code = generateUniqueCode(RANDOM, codeRepository);
+
+        codeRepository.save(createAuthenticationCode(
+                authenticationCode,
+                authenticationId,
+                code,
+                reqDto.phoneNumber(),
+                false));
+
+        // TODO 문자 발송 로직
+
+        return code;
+    }
+
+    private boolean isLimitedRequest(AuthenticationCode authenticationCode) {
+        return authenticationCode != null && authenticationCode.getCount() >= LIMIT_COUNT_CODE_REQUEST;
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImpl.java
@@ -27,7 +27,7 @@ public class GenerateCodeServiceImpl extends GenerateCodeService {
         if (isLimitedRequest(authenticationCode))
             throw new ExpectedException(String.format(
                     "너무 많은 요청이 발생했습니다. 잠시 후 다시 시도해주세요. 특정 시간 내 제한 횟수인 %d회를 초과하였습니다.",
-                    LIMIT_COUNT_CODE_REQUEST), HttpStatus.FORBIDDEN);
+                    LIMIT_COUNT_CODE_REQUEST), HttpStatus.BAD_REQUEST);
 
         final String code = generateUniqueCode(RANDOM, codeRepository);
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImpl.java
@@ -7,7 +7,6 @@ import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
 import team.themoment.hellogsmv3.domain.member.service.GenerateCodeService;
 
-import java.time.LocalDateTime;
 import java.util.Random;
 
 @Service
@@ -30,8 +29,6 @@ public class GenerateTestCodeServiceImpl extends GenerateCodeService {
                 code,
                 reqDto.phoneNumber(),
                 true));
-
-        codeRepository.save(new AuthenticationCode(memberId, code, reqDto.phoneNumber(), LocalDateTime.now()));
 
         return code;
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImpl.java
@@ -2,10 +2,10 @@ package team.themoment.hellogsmv3.domain.member.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import team.themoment.hellogsmv3.domain.applicant.dto.request.GenerateCodeReqDto;
+import team.themoment.hellogsmv3.domain.member.dto.request.GenerateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
-import team.themoment.hellogsmv3.domain.applicant.service.GenerateCodeService;
+import team.themoment.hellogsmv3.domain.member.service.GenerateCodeService;
 
 import java.time.LocalDateTime;
 import java.util.Random;

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImpl.java
@@ -1,0 +1,38 @@
+package team.themoment.hellogsmv3.domain.member.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.themoment.hellogsmv3.domain.applicant.dto.request.GenerateCodeReqDto;
+import team.themoment.hellogsmv3.domain.applicant.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.applicant.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.applicant.service.GenerateCodeService;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class GenerateTestCodeServiceImpl extends GenerateCodeService {
+
+    private final CodeRepository codeRepository;
+    private static final Random RANDOM = new Random();
+
+    @Override
+    public String execute(Long authenticationId, GenerateCodeReqDto reqDto) {
+        final String code = generateUniqueCode(RANDOM, codeRepository);
+
+        AuthenticationCode authenticationCode = codeRepository.findByAuthenticationId(authenticationId)
+                .orElse(null);
+
+        codeRepository.save(createAuthenticationCode(
+                authenticationCode,
+                authenticationId,
+                code,
+                reqDto.phoneNumber(),
+                true));
+
+        codeRepository.save(new AuthenticationCode(authenticationId, code, reqDto.phoneNumber(), LocalDateTime.now()));
+
+        return code;
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImpl.java
@@ -18,20 +18,20 @@ public class GenerateTestCodeServiceImpl extends GenerateCodeService {
     private static final Random RANDOM = new Random();
 
     @Override
-    public String execute(Long authenticationId, GenerateCodeReqDto reqDto) {
+    public String execute(Long memberId, GenerateCodeReqDto reqDto) {
         final String code = generateUniqueCode(RANDOM, codeRepository);
 
-        AuthenticationCode authenticationCode = codeRepository.findByAuthenticationId(authenticationId)
+        AuthenticationCode authenticationCode = codeRepository.findByMemberId(memberId)
                 .orElse(null);
 
         codeRepository.save(createAuthenticationCode(
                 authenticationCode,
-                authenticationId,
+                memberId,
                 code,
                 reqDto.phoneNumber(),
                 true));
 
-        codeRepository.save(new AuthenticationCode(authenticationId, code, reqDto.phoneNumber(), LocalDateTime.now()));
+        codeRepository.save(new AuthenticationCode(memberId, code, reqDto.phoneNumber(), LocalDateTime.now()));
 
         return code;
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImpl.java
@@ -3,8 +3,8 @@ package team.themoment.hellogsmv3.domain.member.service.impl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.applicant.dto.request.GenerateCodeReqDto;
-import team.themoment.hellogsmv3.domain.applicant.entity.AuthenticationCode;
-import team.themoment.hellogsmv3.domain.applicant.repo.CodeRepository;
+import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
 import team.themoment.hellogsmv3.domain.applicant.service.GenerateCodeService;
 
 import java.time.LocalDateTime;

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -181,15 +181,13 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/member/v3/member/{memberId}").hasAnyAuthority(
                         Role.ADMIN.name()
                 )
-                .requestMatchers(HttpMethod.POST,
-                        "/member/v3/member/me/send-code").hasAnyAuthority(
+                .requestMatchers(HttpMethod.POST, "/member/v3/member/me/send-code").hasAnyAuthority(
                         Role.UNAUTHENTICATED.name(),
                         Role.APPLICANT.name(),
                         Role.ADMIN.name(),
                         Role.ROOT.name()
                 )
-                .requestMatchers(HttpMethod.POST,
-                        "/member/v3/member/me/send-code-test").hasAnyAuthority(
+                .requestMatchers(HttpMethod.POST, "/member/v3/member/me/send-code-test").hasAnyAuthority(
                         Role.ROOT.name()
                 )
 

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -170,6 +170,20 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.PUT, "application/v3/status/{applicantId}").hasAnyAuthority(
                         Role.ADMIN.name()
                 )
+
+                // member
+                .requestMatchers(HttpMethod.POST,
+                        "/member/v3/member/me/send-code").hasAnyAuthority(
+                        Role.UNAUTHENTICATED.name(),
+                        Role.APPLICANT.name(),
+                        Role.ADMIN.name(),
+                        Role.ROOT.name()
+                )
+                .requestMatchers(HttpMethod.POST,
+                        "/member/v3/member/me/send-code-test").hasAnyAuthority(
+                        Role.ROOT.name()
+                )
+
                 .anyRequest().permitAll()
         );
     }


### PR DESCRIPTION
## 개요

인증코드 전송 기능을 추가하였습니다.

## 본문

- 인증코드 전송, 테스트 전송 API를 개발하였습니다.

## 기타

기존에 구현되어있는 비즈니스 로직 클래스를 member 도메인으로 복사하였습니다. 이렇게 되면서 두 클래스의 이름이 동일하여 빈 이름이 중복되어 Applicant 도메인에 있는 관련된 클래스의 이름 앞에 Applicant prefix를 붙혀 빈 이름이 겹치지 않게 하였습니다.

위의 작업을 진행하면서 기존 로직의 클래스 네이밍 수정, import를 수정하면서 file changed가 늘어나게 되었습니다.
리뷰를 진행해주실 때 해당 부분은 건너뛰고 member 도메인의 로직을 확인해주시면 감사하겠습니다.