### PR TITLE
[member] 인증코드 인증 기능 구현

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/controller/ApplicantController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/controller/ApplicantController.java
@@ -10,7 +10,7 @@ import team.themoment.hellogsmv3.domain.applicant.service.CreateApplicantService
 import team.themoment.hellogsmv3.domain.applicant.service.QueryApplicantByIdService;
 import team.themoment.hellogsmv3.domain.applicant.dto.request.AuthenticateCodeReqDto;
 import team.themoment.hellogsmv3.domain.applicant.dto.request.GenerateCodeReqDto;
-import team.themoment.hellogsmv3.domain.applicant.service.AuthenticateCodeService;
+import team.themoment.hellogsmv3.domain.applicant.service.ApplicantAuthenticateCodeService;
 import team.themoment.hellogsmv3.domain.applicant.service.ModifyApplicantService;
 import team.themoment.hellogsmv3.domain.applicant.service.impl.GenerateApplicantCodeServiceImpl;
 import team.themoment.hellogsmv3.domain.applicant.service.impl.GenerateApplicantTestCodeServiceImpl;
@@ -27,7 +27,7 @@ public class ApplicantController {
     private final CreateApplicantService createApplicantService;
     private final ModifyApplicantService modifyApplicantService;
     private final QueryApplicantByIdService queryApplicantByIdService;
-    private final AuthenticateCodeService authenticateCodeService;
+    private final ApplicantAuthenticateCodeService authenticateCodeService;
     private final GenerateApplicantTestCodeServiceImpl generateTestCodeService;
     private final GenerateApplicantCodeServiceImpl generateCodeService;
     private final AuthenticatedUserManager manager;

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/ApplicantAuthenticateCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/ApplicantAuthenticateCodeService.java
@@ -12,7 +12,7 @@ import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class AuthenticateCodeService {
+public class ApplicantAuthenticateCodeService {
 
     private final ApplicantCodeRepository codeRepository;
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
@@ -35,7 +35,7 @@ public class MemberController {
         return CommonApiResponse.success("전송되었습니다. : " + code);
     }
 
-    @PostMapping("/applicant/me/auth-code")
+    @PostMapping("/member/me/auth-code")
     public CommonApiResponse authCode(
             @AuthRequest Long memberId,
             @RequestBody @Valid AuthenticateCodeReqDto reqDto

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
@@ -1,9 +1,12 @@
 package team.themoment.hellogsmv3.domain.member.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import team.themoment.hellogsmv3.domain.member.dto.request.AuthenticateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.dto.request.GenerateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberResDto;
+import team.themoment.hellogsmv3.domain.member.service.AuthenticateCodeService;
 import team.themoment.hellogsmv3.domain.member.service.QueryMemberByIdService;
 import team.themoment.hellogsmv3.domain.member.service.impl.GenerateCodeServiceImpl;
 import team.themoment.hellogsmv3.domain.member.service.impl.GenerateTestCodeServiceImpl;
@@ -17,6 +20,7 @@ public class MemberController {
 
     private final GenerateCodeServiceImpl generateCodeService;
     private final GenerateTestCodeServiceImpl generateTestCodeService;
+    private final AuthenticateCodeService authenticateCodeService;
     private final QueryMemberByIdService queryMemberByIdService;
 
     @PostMapping("/member/me/send-code")
@@ -29,6 +33,15 @@ public class MemberController {
     public CommonApiResponse sendCodeTest(@AuthRequest Long memberId, @RequestBody GenerateCodeReqDto reqDto) {
         String code = generateTestCodeService.execute(memberId, reqDto);
         return CommonApiResponse.success("전송되었습니다. : " + code);
+    }
+
+    @PostMapping("/applicant/me/auth-code")
+    public CommonApiResponse authCode(
+            @AuthRequest Long memberId,
+            @RequestBody @Valid AuthenticateCodeReqDto reqDto
+    ) {
+        authenticateCodeService.execute(memberId, reqDto);
+        return CommonApiResponse.success("인증되었습니다.");
     }
 
     @GetMapping("/member/me")

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/dto/request/AuthenticateCodeReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/dto/request/AuthenticateCodeReqDto.java
@@ -1,0 +1,8 @@
+package team.themoment.hellogsmv3.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AuthenticateCodeReqDto(
+        @NotBlank String code
+) {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/AuthenticateCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/AuthenticateCodeService.java
@@ -11,15 +11,15 @@ import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class AuthenticateCodeService {
 
     private final CodeRepository codeRepository;
 
+    @Transactional
     public void execute(Long memberId, AuthenticateCodeReqDto reqDto) {
 
         AuthenticationCode code = codeRepository.findByMemberId(memberId)
-                .orElseThrow(() -> new ExpectedException("사용자의 code가 존재하지 않습니다. member ID : " + memberId, HttpStatus.BAD_REQUEST));
+                .orElseThrow(() -> new ExpectedException("사용자의 code가 존재하지 않습니다. member ID : " + memberId, HttpStatus.NOT_FOUND));
 
         if (!code.getCode().equals(reqDto.code()))
             throw new ExpectedException("유효하지 않은 code 이거나 이전 혹은 잘못된 code 입니다.", HttpStatus.BAD_REQUEST);

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/AuthenticateCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/AuthenticateCodeService.java
@@ -1,0 +1,31 @@
+package team.themoment.hellogsmv3.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.hellogsmv3.domain.member.dto.request.AuthenticateCodeReqDto;
+import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthenticateCodeService {
+
+    private final CodeRepository codeRepository;
+
+    public void execute(Long memberId, AuthenticateCodeReqDto reqDto) {
+
+        AuthenticationCode code = codeRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new ExpectedException("사용자의 code가 존재하지 않습니다. member ID : " + memberId, HttpStatus.BAD_REQUEST));
+
+        if (!code.getCode().equals(reqDto.code()))
+            throw new ExpectedException("유효하지 않은 code 이거나 이전 혹은 잘못된 code 입니다.", HttpStatus.BAD_REQUEST);
+
+        code.authenticatedAuthenticationCode();
+
+        codeRepository.save(code);
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -173,7 +173,8 @@ public class SecurityConfig {
 
                 // member
                 .requestMatchers(HttpMethod.POST,
-                        "/member/v3/member/me/send-code").hasAnyAuthority(
+                        "/member/v3/member/me/send-code",
+                        "/member/v3/member/me/auth-code").hasAnyAuthority(
                         Role.UNAUTHENTICATED.name(),
                         Role.APPLICANT.name(),
                         Role.ADMIN.name(),


### PR DESCRIPTION
## 개요

전송된 인증코드를 인증하는 기능을 구현하였습니다.

## 본문

- 전송한 인증코드를 인증 요청시 `AuthenticationCode`의 `authenticated`컬럼의 값이 true가 되어 추후 작성될 본인인증이 요청이 가능하도록 합니다.

## 기타
- 기존 로직과 빈 이름이 겹처 빈 등록 충돌이 발생하여 기존 로직 클래스명에 `Applicant~` prefix를 붙혀서 해결해두었습니다.
추후에 개선이 필요해보입니다.