### PR TITLE
[member] Gender enum 사용처 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/application/service/QueryApplicationByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/service/QueryApplicationByIdService.java
@@ -66,7 +66,7 @@ public class QueryApplicationByIdService {
 
         return GedAdmissionInfoResDto.builder()
                 .applicantName(applicant.getName())
-                .applicantGender(applicant.getSex())
+                .applicantSex(applicant.getSex())
                 .applicantBirth(applicant.getBirth())
                 .address(personalInformation.getAddress())
                 .detailAddress(personalInformation.getDetailAddress())
@@ -99,7 +99,7 @@ public class QueryApplicationByIdService {
 
         return GeneralAdmissionInfoResDto.builder()
                 .applicantName(applicant.getName())
-                .applicantGender(applicant.getSex())
+                .applicantSex(applicant.getSex())
                 .applicantBirth(applicant.getBirth())
                 .address(personalInformation.getAddress())
                 .detailAddress(personalInformation.getDetailAddress())

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/dto/response/FoundMemberResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/dto/response/FoundMemberResDto.java
@@ -1,7 +1,7 @@
 package team.themoment.hellogsmv3.domain.member.dto.response;
 
 import lombok.Builder;
-import team.themoment.hellogsmv3.domain.member.entity.type.Gender;
+import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
 
 import java.time.LocalDate;
 
@@ -12,6 +12,6 @@ public record FoundMemberResDto(
         String name,
         String phoneNumber,
         LocalDate birth,
-        Gender sex
+        Sex sex
 ) {
 }


### PR DESCRIPTION
## 개요

구 버전의 성별 enum인 `Gender`를 사용하던 곳을 새로운 성별 enum인 `Sex`를 사용하도록 수정하였습니다.