### PR TITLE
[member] oauth정보 기반 member생성 method 이름 변경

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/member/entity/Member.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/entity/Member.java
@@ -58,7 +58,7 @@ public class Member {
     @Column(name = "updated_time", nullable = false)
     private LocalDateTime updatedTime;
 
-    public static Member buildNewMember(String email, AuthReferrerType authRefType) {
+    public static Member buildMemberWithOauthInfo(String email, AuthReferrerType authRefType) {
         return Member.builder()
                 .email(email)
                 .authReferrerType(authRefType)

--- a/src/main/java/team/themoment/hellogsmv3/global/security/oauth/CustomOauth2UserService.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/oauth/CustomOauth2UserService.java
@@ -9,7 +9,6 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
-import team.themoment.hellogsmv3.domain.auth.entity.Authentication;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.entity.type.AuthReferrerType;
 import team.themoment.hellogsmv3.domain.member.entity.type.Role;
@@ -83,6 +82,6 @@ public class CustomOauth2UserService implements OAuth2UserService {
 
     private Member getUser(String providerId, AuthReferrerType authRefType) {
         return memberRepository.findByAuthReferrerTypeAndEmail(authRefType, providerId)
-                .orElseGet(() -> memberRepository.save(Member.buildNewMember(providerId, authRefType)));
+                .orElseGet(() -> memberRepository.save(Member.buildMemberWithOauthInfo(providerId, authRefType)));
     }
 }


### PR DESCRIPTION
## 개요

개발과정에서 모호한 이름떄문에 헷갈리는 상황이 발생하였고 이를 해결하기 위해 이름을 직관적으로 변경하였습니다.

oauth정보를 기반으로 member를 생성하는 method이름을 `buildNewMember`에서 `buildMemberWithOauthInfo`로 변경하였습니다.
