### PR TITLE
[oneseo] 원서 추가 기능 구현

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/application/annotation/ApplicationDesiredMajorsValidator.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/annotation/ApplicationDesiredMajorsValidator.java
@@ -1,0 +1,35 @@
+package team.themoment.hellogsmv3.domain.application.annotation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import team.themoment.hellogsmv3.domain.application.dto.request.ApplicationReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ApplicationDesiredMajorsValidator implements ConstraintValidator<ApplicationValidDesiredMajors, ApplicationReqDto> {
+    @Override
+    public boolean isValid(ApplicationReqDto dto, ConstraintValidatorContext context) {
+
+        boolean hasNullMajor = dto.firstDesiredMajor() == null || dto.secondDesiredMajor() == null || dto.thirdDesiredMajor() == null;
+        if (hasNullMajor) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("모든 필드는 NULL일 수 없습니다.").addConstraintViolation();
+            return false;
+        }
+
+        Set<Major> majorsSet = new HashSet<>();
+        majorsSet.add(dto.firstDesiredMajor());
+        majorsSet.add(dto.secondDesiredMajor());
+        majorsSet.add(dto.thirdDesiredMajor());
+
+        if (majorsSet.size() != 3) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("중복된 전공이 입력되었습니다.").addConstraintViolation();
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/annotation/ApplicationValidDesiredMajors.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/annotation/ApplicationValidDesiredMajors.java
@@ -1,0 +1,18 @@
+package team.themoment.hellogsmv3.domain.application.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = ApplicationDesiredMajorsValidator.class)
+@Target({ ElementType.FIELD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApplicationValidDesiredMajors {
+    String message() default "유효하지 않은 전공이 입력되었습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/dto/request/ApplicationReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/dto/request/ApplicationReqDto.java
@@ -3,12 +3,12 @@ package team.themoment.hellogsmv3.domain.application.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
-import team.themoment.hellogsmv3.domain.application.annotation.ValidDesiredMajors;
+import team.themoment.hellogsmv3.domain.application.annotation.ApplicationValidDesiredMajors;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 
-@ValidDesiredMajors
+@ApplicationValidDesiredMajors
 public record ApplicationReqDto(
         @NotBlank
         String guardianName,

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/annotation/DesiredMajorsValidator.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/annotation/DesiredMajorsValidator.java
@@ -1,16 +1,16 @@
-package team.themoment.hellogsmv3.domain.application.annotation;
+package team.themoment.hellogsmv3.domain.oneseo.annotation;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-import team.themoment.hellogsmv3.domain.application.dto.request.ApplicationReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
 
 import java.util.HashSet;
 import java.util.Set;
 
-public class DesiredMajorsValidator implements ConstraintValidator<ValidDesiredMajors, ApplicationReqDto> {
+public class DesiredMajorsValidator implements ConstraintValidator<ValidDesiredMajors, OneseoReqDto> {
     @Override
-    public boolean isValid(ApplicationReqDto dto, ConstraintValidatorContext context) {
+    public boolean isValid(OneseoReqDto dto, ConstraintValidatorContext context) {
 
         boolean hasNullMajor = dto.firstDesiredMajor() == null || dto.secondDesiredMajor() == null || dto.thirdDesiredMajor() == null;
         if (hasNullMajor) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/annotation/ValidDesiredMajors.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/annotation/ValidDesiredMajors.java
@@ -1,4 +1,4 @@
-package team.themoment.hellogsmv3.domain.application.annotation;
+package team.themoment.hellogsmv3.domain.oneseo.annotation;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -1,0 +1,11 @@
+package team.themoment.hellogsmv3.domain.oneseo.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/oneseo/v3")
+@RequiredArgsConstructor
+public class OneseoController {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -1,11 +1,30 @@
 package team.themoment.hellogsmv3.domain.oneseo.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.service.CreateOneseoService;
+import team.themoment.hellogsmv3.global.common.handler.annotation.AuthRequest;
+import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 
 @RestController
 @RequestMapping("/oneseo/v3")
 @RequiredArgsConstructor
 public class OneseoController {
+
+    private final CreateOneseoService createOneseoService;
+
+    @PostMapping("/oneseo/me")
+    public CommonApiResponse create(
+            @RequestBody @Valid OneseoReqDto reqDto,
+            @AuthRequest Long memberId
+    ) {
+        createOneseoService.execute(reqDto, memberId);
+        return CommonApiResponse.created("생성되었습니다.");
+    }
+
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
@@ -53,7 +53,7 @@ public record OneseoReqDto(
 
         String schoolName,
 
-        String schoolLocation,
+        String schoolAddress,
 
         @NotNull
         Screening screening

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
@@ -49,7 +49,7 @@ public record OneseoReqDto(
         Major thirdDesiredMajor,
 
         @NotBlank
-        String middleSchoolGrade,
+        String transcript,
 
         String schoolName,
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
@@ -3,7 +3,7 @@ package team.themoment.hellogsmv3.domain.oneseo.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
-import team.themoment.hellogsmv3.domain.application.annotation.ValidDesiredMajors;
+import team.themoment.hellogsmv3.domain.oneseo.annotation.ValidDesiredMajors;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
@@ -14,14 +14,14 @@ public record OneseoReqDto(
         String guardianName,
 
         @NotBlank
-        @Pattern(regexp = "^0(?:\\d|\\d{2})(?:\\d{3}|\\d{4})\\d{4}$")
+        @Pattern(regexp = "^0(?:\\d|\\d{2})(?:\\d{3}|\\d{4})\\d{4}$", message = "유요한 전화번호가 아닙니다.")
         String guardianPhoneNumber,
 
         @NotBlank
         String relationWithApplicant,
 
         @NotBlank
-        @Pattern(regexp = "^https:\\/\\/[^\\s/$.?#].[^\\s]*$")
+        @Pattern(regexp = "^https:\\/\\/[^\\s/$.?#].[^\\s]*$", message = "유효한 이미지 URL이 아닙니다.")
         String profileImg,
 
         @NotBlank
@@ -36,7 +36,7 @@ public record OneseoReqDto(
         @Pattern(regexp = "^(?!\\s*$).+")
         String teacherName,
 
-        @Pattern(regexp = "^0(?:\\d|\\d{2})(?:\\d{3}|\\d{4})\\d{4}$")
+        @Pattern(regexp = "^0(?:\\d|\\d{2})(?:\\d{3}|\\d{4})\\d{4}$", message = "유요한 전화번호가 아닙니다.")
         String teacherPhoneNumber,
 
         @NotNull

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
@@ -18,7 +18,7 @@ public record OneseoReqDto(
         String guardianPhoneNumber,
 
         @NotBlank
-        String relationWithApplicant,
+        String relationshipWithGuardian,
 
         @NotBlank
         @Pattern(regexp = "^https:\\/\\/[^\\s/$.?#].[^\\s]*$", message = "유효한 이미지 URL이 아닙니다.")
@@ -34,10 +34,10 @@ public record OneseoReqDto(
         GraduationType graduationType,
 
         @Pattern(regexp = "^(?!\\s*$).+")
-        String teacherName,
+        String schoolTeacherName,
 
         @Pattern(regexp = "^0(?:\\d|\\d{2})(?:\\d{3}|\\d{4})\\d{4}$", message = "유요한 전화번호가 아닙니다.")
-        String teacherPhoneNumber,
+        String schoolTeacherPhoneNumber,
 
         @NotNull
         Major firstDesiredMajor,

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
@@ -1,0 +1,60 @@
+package team.themoment.hellogsmv3.domain.oneseo.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import team.themoment.hellogsmv3.domain.application.annotation.ValidDesiredMajors;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
+
+@ValidDesiredMajors
+public record OneseoReqDto(
+        @NotBlank
+        String guardianName,
+
+        @NotBlank
+        @Pattern(regexp = "^0(?:\\d|\\d{2})(?:\\d{3}|\\d{4})\\d{4}$")
+        String guardianPhoneNumber,
+
+        @NotBlank
+        String relationWithApplicant,
+
+        @NotBlank
+        @Pattern(regexp = "^https:\\/\\/[^\\s/$.?#].[^\\s]*$")
+        String profileImg,
+
+        @NotBlank
+        String address,
+
+        @NotBlank
+        String detailAddress,
+
+        @NotNull
+        GraduationType graduationType,
+
+        @Pattern(regexp = "^(?!\\s*$).+")
+        String teacherName,
+
+        @Pattern(regexp = "^0(?:\\d|\\d{2})(?:\\d{3}|\\d{4})\\d{4}$")
+        String teacherPhoneNumber,
+
+        @NotNull
+        Major firstDesiredMajor,
+
+        @NotNull
+        Major secondDesiredMajor,
+
+        @NotNull
+        Major thirdDesiredMajor,
+
+        @NotBlank
+        String middleSchoolGrade,
+
+        String schoolName,
+
+        String schoolLocation,
+
+        @NotNull
+        Screening screening
+) {}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
@@ -33,7 +33,7 @@ public record OneseoReqDto(
         @NotNull
         GraduationType graduationType,
 
-        @Pattern(regexp = "^(?!\\s*$).+")
+        @NotBlank
         String schoolTeacherName,
 
         @Pattern(regexp = "^0(?:\\d|\\d{2})(?:\\d{3}|\\d{4})\\d{4}$", message = "유요한 전화번호가 아닙니다.")

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
@@ -1,9 +1,7 @@
 package team.themoment.hellogsmv3.domain.oneseo.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.math.BigDecimal;
 
@@ -11,6 +9,8 @@ import java.math.BigDecimal;
 @Entity
 @Table(name = "tb_middle_school_achievement")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class MiddleSchoolAchievement {
 
     @Id

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
@@ -41,6 +41,10 @@ public class Oneseo {
     private YesNo finalSubmittedYn;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "wanted_screening", nullable = false)
+    private Screening wantedScreening;
+
+    @Enumerated(EnumType.STRING)
     @Column(name = "applied_screening", nullable = false)
     private Screening appliedScreening;
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
@@ -2,9 +2,7 @@ package team.themoment.hellogsmv3.domain.oneseo.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
@@ -14,6 +12,8 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 @Entity
 @Table(name = "tb_oneseo")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Oneseo {
 
     @Id

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
@@ -41,10 +41,6 @@ public class Oneseo {
     private YesNo finalSubmittedYn;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "wanted_screening", nullable = false)
-    private Screening wantedScreening;
-
-    @Enumerated(EnumType.STRING)
     @Column(name = "applied_screening", nullable = false)
     private Screening appliedScreening;
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/OneseoPrivacyDetail.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/OneseoPrivacyDetail.java
@@ -1,15 +1,15 @@
 package team.themoment.hellogsmv3.domain.oneseo.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 
 @Getter
 @Entity
 @Table(name = "tb_oneseo_privacy_detail")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class OneseoPrivacyDetail {
 
     @Id

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/type/DesiredMajors.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/type/DesiredMajors.java
@@ -9,8 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import team.themoment.hellogsmv3.domain.application.annotation.ValidDesiredMajors;
-import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
+import team.themoment.hellogsmv3.domain.oneseo.annotation.ValidDesiredMajors;
 
 @Embeddable
 @Getter

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/MiddleSchoolAchievementRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/MiddleSchoolAchievementRepository.java
@@ -1,0 +1,7 @@
+package team.themoment.hellogsmv3.domain.oneseo.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.themoment.hellogsmv3.domain.oneseo.entity.MiddleSchoolAchievement;
+
+public interface MiddleSchoolAchievementRepository extends JpaRepository<MiddleSchoolAchievement, Long> {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoPrivacyDetailRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoPrivacyDetailRepository.java
@@ -1,0 +1,6 @@
+package team.themoment.hellogsmv3.domain.oneseo.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OneseoPrivacyDetailRepository extends JpaRepository<OneseoPrivacyDetailRepository, Long> {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoPrivacyDetailRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoPrivacyDetailRepository.java
@@ -1,6 +1,7 @@
 package team.themoment.hellogsmv3.domain.oneseo.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import team.themoment.hellogsmv3.domain.oneseo.entity.OneseoPrivacyDetail;
 
-public interface OneseoPrivacyDetailRepository extends JpaRepository<OneseoPrivacyDetailRepository, Long> {
+public interface OneseoPrivacyDetailRepository extends JpaRepository<OneseoPrivacyDetail, Long> {
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoRepository.java
@@ -1,7 +1,9 @@
 package team.themoment.hellogsmv3.domain.oneseo.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 
 public interface OneseoRepository extends JpaRepository<Oneseo, Long> {
+    boolean existsByMember(Member member);
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoRepository.java
@@ -1,0 +1,7 @@
+package team.themoment.hellogsmv3.domain.oneseo.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+
+public interface OneseoRepository extends JpaRepository<Oneseo, Long> {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -40,9 +40,7 @@ public class CreateOneseoService {
         OneseoPrivacyDetail oneseoPrivacyDetail = buildOneseoPrivacyDetail(reqDto, oneseo);
         MiddleSchoolAchievement middleSchoolAchievement = buildMiddleSchoolAchievement(reqDto, oneseo);
 
-        oneseoRepository.save(oneseo);
-        oneseoPrivacyDetailRepository.save(oneseoPrivacyDetail);
-        middleSchoolAchievementRepository.save(middleSchoolAchievement);
+        saveOneseo(oneseo, oneseoPrivacyDetail, middleSchoolAchievement);
     }
 
     private static Oneseo buildOneseo(OneseoReqDto reqDto, Member currentMember) {
@@ -95,6 +93,12 @@ public class CreateOneseoService {
                 .grade2Semester1Score(BigDecimal.ONE)
                 .grade2Semester2Score(BigDecimal.ONE)
                 .grade3Semester1Score(BigDecimal.ONE).build();
+    }
+
+    private void saveOneseo(Oneseo oneseo, OneseoPrivacyDetail oneseoPrivacyDetail, MiddleSchoolAchievement middleSchoolAchievement) {
+        oneseoRepository.save(oneseo);
+        oneseoPrivacyDetailRepository.save(oneseoPrivacyDetail);
+        middleSchoolAchievementRepository.save(middleSchoolAchievement);
     }
 
     private void isExistOneseo(Member currentMember) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -59,6 +59,7 @@ public class CreateOneseoService {
                         .build())
                 .realOneseoArrivedYn(NO)
                 .finalSubmittedYn(NO)
+                .wantedScreening(reqDto.screening())
                 .appliedScreening(reqDto.screening())
                 .build();
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -1,0 +1,106 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.MiddleSchoolAchievement;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.entity.OneseoPrivacyDetail;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
+import team.themoment.hellogsmv3.domain.oneseo.repository.MiddleSchoolAchievementRepository;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRepository;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+import java.math.BigDecimal;
+
+import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.*;
+
+@Service
+@RequiredArgsConstructor
+public class CreateOneseoService {
+
+    private final MemberRepository memberRepository;
+    private final OneseoRepository oneseoRepository;
+    private final OneseoPrivacyDetailRepository oneseoPrivacyDetailRepository;
+    private final MiddleSchoolAchievementRepository middleSchoolAchievementRepository;
+
+    @Transactional
+    public void execute(OneseoReqDto reqDto, Long memberId) {
+        Member currentMember = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ExpectedException("존재하지 않는 지원자입니다. member ID: " + memberId, HttpStatus.NOT_FOUND));
+
+        isExistOneseo(currentMember);
+
+        Oneseo oneseo = buildOneseo(reqDto, currentMember);
+        OneseoPrivacyDetail oneseoPrivacyDetail = buildOneseoPrivacyDetail(reqDto, oneseo);
+        MiddleSchoolAchievement middleSchoolAchievement = buildMiddleSchoolAchievement(reqDto, oneseo);
+
+        oneseoRepository.save(oneseo);
+        oneseoPrivacyDetailRepository.save(oneseoPrivacyDetail);
+        middleSchoolAchievementRepository.save(middleSchoolAchievement);
+    }
+
+    private static Oneseo buildOneseo(OneseoReqDto reqDto, Member currentMember) {
+        return Oneseo.builder()
+                .member(currentMember)
+                .desiredMajors(DesiredMajors.builder()
+                        .firstDesiredMajor(reqDto.firstDesiredMajor())
+                        .secondDesiredMajor(reqDto.secondDesiredMajor())
+                        .thirdDesiredMajor(reqDto.thirdDesiredMajor())
+                        .build())
+                .realOneseoArrivedYn(NO)
+                .finalSubmittedYn(NO)
+                .appliedScreening(reqDto.screening()).build();
+    }
+
+    private static OneseoPrivacyDetail buildOneseoPrivacyDetail(OneseoReqDto reqDto, Oneseo oneseo) {
+        return OneseoPrivacyDetail.builder()
+                .oneseo(oneseo)
+                .graduationType(reqDto.graduationType())
+                .address(reqDto.address())
+                .detailAddress(reqDto.detailAddress())
+                .profileImg(reqDto.profileImg())
+                .guardianName(reqDto.guardianName())
+                .guardianPhoneNumber(reqDto.guardianPhoneNumber())
+                .relationshipWithGuardian(reqDto.relationWithApplicant())
+                .schoolAddress(reqDto.schoolAddress())
+                .schoolName(reqDto.schoolName())
+                .schoolTeacherName(reqDto.teacherName())
+                .schoolTeacherPhoneNumber(reqDto.teacherPhoneNumber()).build();
+    }
+
+    private static MiddleSchoolAchievement buildMiddleSchoolAchievement(OneseoReqDto reqDto, Oneseo oneseo) {
+
+        // TODO 추후에 성적 환산 로직 추가
+
+        return MiddleSchoolAchievement.builder()
+                .oneseo(oneseo)
+                .transcript(reqDto.middleSchoolGrade())
+                .percentileRank(BigDecimal.ONE)
+                .totalScore(BigDecimal.ONE)
+                .artisticScore(BigDecimal.ONE)
+                .attendanceScore(BigDecimal.ONE)
+                .volunteerScore(BigDecimal.ONE)
+                .curricularSubtotalScore(BigDecimal.ONE)
+                .extraCurricularSubtotalScore(BigDecimal.ONE)
+                .gedMaxScore(BigDecimal.ONE)
+                .gedTotalScore(BigDecimal.ONE)
+                .grade1Semester1Score(BigDecimal.ONE)
+                .grade1Semester2Score(BigDecimal.ONE)
+                .grade2Semester1Score(BigDecimal.ONE)
+                .grade2Semester2Score(BigDecimal.ONE)
+                .grade3Semester1Score(BigDecimal.ONE).build();
+    }
+
+    private void isExistOneseo(Member currentMember) {
+        if (oneseoRepository.existsByMember(currentMember)) {
+            throw new ExpectedException("이미 원서가 존재합니다.", HttpStatus.BAD_REQUEST);
+        }
+    }
+
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -43,7 +43,7 @@ public class CreateOneseoService {
         saveOneseo(oneseo, oneseoPrivacyDetail, middleSchoolAchievement);
     }
 
-    private static Oneseo buildOneseo(OneseoReqDto reqDto, Member currentMember) {
+    private Oneseo buildOneseo(OneseoReqDto reqDto, Member currentMember) {
         return Oneseo.builder()
                 .member(currentMember)
                 .desiredMajors(DesiredMajors.builder()
@@ -56,7 +56,7 @@ public class CreateOneseoService {
                 .appliedScreening(reqDto.screening()).build();
     }
 
-    private static OneseoPrivacyDetail buildOneseoPrivacyDetail(OneseoReqDto reqDto, Oneseo oneseo) {
+    private OneseoPrivacyDetail buildOneseoPrivacyDetail(OneseoReqDto reqDto, Oneseo oneseo) {
         return OneseoPrivacyDetail.builder()
                 .oneseo(oneseo)
                 .graduationType(reqDto.graduationType())
@@ -65,14 +65,14 @@ public class CreateOneseoService {
                 .profileImg(reqDto.profileImg())
                 .guardianName(reqDto.guardianName())
                 .guardianPhoneNumber(reqDto.guardianPhoneNumber())
-                .relationshipWithGuardian(reqDto.relationWithApplicant())
+                .relationshipWithGuardian(reqDto.relationshipWithGuardian())
                 .schoolAddress(reqDto.schoolAddress())
                 .schoolName(reqDto.schoolName())
-                .schoolTeacherName(reqDto.teacherName())
-                .schoolTeacherPhoneNumber(reqDto.teacherPhoneNumber()).build();
+                .schoolTeacherName(reqDto.schoolTeacherName())
+                .schoolTeacherPhoneNumber(reqDto.schoolTeacherPhoneNumber()).build();
     }
 
-    private static MiddleSchoolAchievement buildMiddleSchoolAchievement(OneseoReqDto reqDto, Oneseo oneseo) {
+    private MiddleSchoolAchievement buildMiddleSchoolAchievement(OneseoReqDto reqDto, Oneseo oneseo) {
 
         // TODO 추후에 성적 환산 로직 추가
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -40,7 +40,13 @@ public class CreateOneseoService {
         OneseoPrivacyDetail oneseoPrivacyDetail = buildOneseoPrivacyDetail(reqDto, oneseo);
         MiddleSchoolAchievement middleSchoolAchievement = buildMiddleSchoolAchievement(reqDto, oneseo);
 
-        saveOneseo(oneseo, oneseoPrivacyDetail, middleSchoolAchievement);
+        saveEntities(oneseo, oneseoPrivacyDetail, middleSchoolAchievement);
+    }
+
+    private void saveEntities(Oneseo oneseo, OneseoPrivacyDetail oneseoPrivacyDetail, MiddleSchoolAchievement middleSchoolAchievement) {
+        oneseoRepository.save(oneseo);
+        oneseoPrivacyDetailRepository.save(oneseoPrivacyDetail);
+        middleSchoolAchievementRepository.save(middleSchoolAchievement);
     }
 
     private Oneseo buildOneseo(OneseoReqDto reqDto, Member currentMember) {
@@ -93,12 +99,6 @@ public class CreateOneseoService {
                 .grade2Semester1Score(BigDecimal.ONE)
                 .grade2Semester2Score(BigDecimal.ONE)
                 .grade3Semester1Score(BigDecimal.ONE).build();
-    }
-
-    private void saveOneseo(Oneseo oneseo, OneseoPrivacyDetail oneseoPrivacyDetail, MiddleSchoolAchievement middleSchoolAchievement) {
-        oneseoRepository.save(oneseo);
-        oneseoPrivacyDetailRepository.save(oneseoPrivacyDetail);
-        middleSchoolAchievementRepository.save(middleSchoolAchievement);
     }
 
     private void isExistOneseo(Member currentMember) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -84,7 +84,7 @@ public class CreateOneseoService {
 
         return MiddleSchoolAchievement.builder()
                 .oneseo(oneseo)
-                .transcript(reqDto.middleSchoolGrade())
+                .transcript(reqDto.transcript())
                 .percentileRank(BigDecimal.ONE)
                 .totalScore(BigDecimal.ONE)
                 .artisticScore(BigDecimal.ONE)

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -59,7 +59,8 @@ public class CreateOneseoService {
                         .build())
                 .realOneseoArrivedYn(NO)
                 .finalSubmittedYn(NO)
-                .appliedScreening(reqDto.screening()).build();
+                .appliedScreening(reqDto.screening())
+                .build();
     }
 
     private OneseoPrivacyDetail buildOneseoPrivacyDetail(OneseoReqDto reqDto, Oneseo oneseo) {
@@ -75,7 +76,8 @@ public class CreateOneseoService {
                 .schoolAddress(reqDto.schoolAddress())
                 .schoolName(reqDto.schoolName())
                 .schoolTeacherName(reqDto.schoolTeacherName())
-                .schoolTeacherPhoneNumber(reqDto.schoolTeacherPhoneNumber()).build();
+                .schoolTeacherPhoneNumber(reqDto.schoolTeacherPhoneNumber())
+                .build();
     }
 
     private MiddleSchoolAchievement buildMiddleSchoolAchievement(OneseoReqDto reqDto, Oneseo oneseo) {
@@ -98,7 +100,8 @@ public class CreateOneseoService {
                 .grade1Semester2Score(BigDecimal.ONE)
                 .grade2Semester1Score(BigDecimal.ONE)
                 .grade2Semester2Score(BigDecimal.ONE)
-                .grade3Semester1Score(BigDecimal.ONE).build();
+                .grade3Semester1Score(BigDecimal.ONE)
+                .build();
     }
 
     private void isExistOneseo(Member currentMember) {

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -214,6 +214,12 @@ public class SecurityConfig {
                         Role.ADMIN.name()
                 )
 
+                // oneseo
+                .requestMatchers(HttpMethod.POST, "/oneseo/v3/oneseo/me").hasAnyAuthority(
+                        Role.APPLICANT.name(),
+                        Role.ROOT.name()
+                )
+
                 .anyRequest().permitAll()
         );
     }


### PR DESCRIPTION
## 개요

원서 추가 기능을 구현하였습니다.

## 본문

- 원서 추가 기능을 구현하였습니다. 
- `Oneseo` 엔티티의 식별 관계인 `OneseoPrivacyDetail`, `MiddleSchoolAchievement` 엔티티를 생성 후 저장합니다.

## 기타

- ~~`Oneseo` 엔티티의 `wantedScreening - 희망전형` 컬럼을 삭제하였습니다.~~ 
   - 논의 후 희망전형 컬럼을 두기로 결정하였습니다!