### PR TITLE
[oneseo] 원서 수정 기능 구현

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -35,4 +35,13 @@ public class OneseoController {
         return CommonApiResponse.created("수정되었습니다.");
     }
 
+    @PutMapping("/oneseo/{memberId}")
+    public CommonApiResponse modifyOne(
+            @RequestBody @Valid OneseoReqDto reqDto,
+            @PathVariable("memberId") Long memberId
+    ) {
+        modifyOneseoService.execute(reqDto, memberId, true);
+        return CommonApiResponse.created("수정되었습니다.");
+    }
+
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -2,12 +2,10 @@ package team.themoment.hellogsmv3.domain.oneseo.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.service.CreateOneseoService;
+import team.themoment.hellogsmv3.domain.oneseo.service.ModifyOneseoService;
 import team.themoment.hellogsmv3.global.common.handler.annotation.AuthRequest;
 import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 
@@ -17,6 +15,7 @@ import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 public class OneseoController {
 
     private final CreateOneseoService createOneseoService;
+    private final ModifyOneseoService modifyOneseoService;
 
     @PostMapping("/oneseo/me")
     public CommonApiResponse create(
@@ -25,6 +24,15 @@ public class OneseoController {
     ) {
         createOneseoService.execute(reqDto, memberId);
         return CommonApiResponse.created("생성되었습니다.");
+    }
+
+    @PutMapping("/oneseo/me")
+    public CommonApiResponse modify(
+            @RequestBody @Valid OneseoReqDto reqDto,
+            @AuthRequest Long memberId
+    ) {
+        modifyOneseoService.execute(reqDto, memberId, false);
+        return CommonApiResponse.created("수정되었습니다.");
     }
 
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -36,7 +36,7 @@ public class OneseoController {
     }
 
     @PutMapping("/oneseo/{memberId}")
-    public CommonApiResponse modifyOne(
+    public CommonApiResponse modifyByAdmin(
             @RequestBody @Valid OneseoReqDto reqDto,
             @PathVariable("memberId") Long memberId
     ) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
@@ -2,6 +2,7 @@ package team.themoment.hellogsmv3.domain.oneseo.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicUpdate;
 
 import java.math.BigDecimal;
 
@@ -11,6 +12,7 @@ import java.math.BigDecimal;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@DynamicUpdate
 public class MiddleSchoolAchievement {
 
     @Id

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
@@ -49,7 +49,4 @@ public class Oneseo {
     @Enumerated(EnumType.STRING)
     @Column(name = "applied_screening", nullable = false)
     private Screening appliedScreening;
-
-
-
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
@@ -3,6 +3,7 @@ package team.themoment.hellogsmv3.domain.oneseo.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
+import org.hibernate.annotations.DynamicUpdate;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
@@ -14,6 +15,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@DynamicUpdate
 public class Oneseo {
 
     @Id

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
@@ -43,4 +43,7 @@ public class Oneseo {
     @Enumerated(EnumType.STRING)
     @Column(name = "applied_screening", nullable = false)
     private Screening appliedScreening;
+
+
+
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/OneseoPrivacyDetail.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/OneseoPrivacyDetail.java
@@ -2,6 +2,7 @@ package team.themoment.hellogsmv3.domain.oneseo.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicUpdate;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 
 @Getter
@@ -10,7 +11,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-// @DynamicUpdate <- 더티채킹시 변경된 컬럼만 UPDATE
+@DynamicUpdate
 public class OneseoPrivacyDetail {
 
     @Id

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/OneseoPrivacyDetail.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/OneseoPrivacyDetail.java
@@ -10,6 +10,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+// @DynamicUpdate <- 더티채킹시 변경된 컬럼만 UPDATE
 public class OneseoPrivacyDetail {
 
     @Id

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/ScreeningChangeHistory.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/ScreeningChangeHistory.java
@@ -1,9 +1,7 @@
 package team.themoment.hellogsmv3.domain.oneseo.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
@@ -15,6 +13,8 @@ import java.time.LocalDateTime;
 @Table(name = "tb_screening_change_history")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
+@AllArgsConstructor
+@Builder
 public class ScreeningChangeHistory {
 
     @Id

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/MiddleSchoolAchievementRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/MiddleSchoolAchievementRepository.java
@@ -2,6 +2,8 @@ package team.themoment.hellogsmv3.domain.oneseo.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.themoment.hellogsmv3.domain.oneseo.entity.MiddleSchoolAchievement;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 
 public interface MiddleSchoolAchievementRepository extends JpaRepository<MiddleSchoolAchievement, Long> {
+    MiddleSchoolAchievement findByOneseo(Oneseo oneseo);
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoPrivacyDetailRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoPrivacyDetailRepository.java
@@ -1,7 +1,9 @@
 package team.themoment.hellogsmv3.domain.oneseo.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.OneseoPrivacyDetail;
 
 public interface OneseoPrivacyDetailRepository extends JpaRepository<OneseoPrivacyDetail, Long> {
+    OneseoPrivacyDetail findByOneseo(Oneseo oneseo);
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoRepository.java
@@ -4,6 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 
+import java.util.Optional;
+
 public interface OneseoRepository extends JpaRepository<Oneseo, Long> {
     boolean existsByMember(Member member);
+    Optional<Oneseo> findByMember(Member member);
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/ScreeningChangeHistoryRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/ScreeningChangeHistoryRepository.java
@@ -1,0 +1,7 @@
+package team.themoment.hellogsmv3.domain.oneseo.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.themoment.hellogsmv3.domain.oneseo.entity.ScreeningChangeHistory;
+
+public interface ScreeningChangeHistoryRepository extends JpaRepository<ScreeningChangeHistory, Long> {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -45,7 +45,7 @@ public class ModifyOneseoService {
         OneseoPrivacyDetail oneseoPrivacyDetail = oneseoPrivacyDetailRepository.findByOneseo(oneseo);
         MiddleSchoolAchievement middleSchoolAchievement = middleSchoolAchievementRepository.findByOneseo(oneseo);
 
-        ifScreeningChangeSaveHistory(reqDto.screening(), oneseo);
+        saveHistoryIfScreeningChange(reqDto.screening(), oneseo);
 
         Oneseo modifiedOneseo = buildOneseo(reqDto, oneseo, currentMember);
         OneseoPrivacyDetail modifiedOneseoPrivacyDetail = buildOneseoPrivacyDetail(reqDto, oneseoPrivacyDetail, oneseo);
@@ -117,7 +117,7 @@ public class ModifyOneseoService {
             throw new ExpectedException("최종제출이 완료된 원서는 수정할 수 없습니다.", HttpStatus.BAD_REQUEST);
     }
 
-    private void ifScreeningChangeSaveHistory(Screening beforeScreening, Oneseo oneseo) {
+    private void saveHistoryIfScreeningChange(Screening beforeScreening, Oneseo oneseo) {
         if (oneseo.getAppliedScreening() != beforeScreening) {
             ScreeningChangeHistory screeningChangeHistory = ScreeningChangeHistory.builder()
                     .beforeScreening(oneseo.getAppliedScreening())

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -10,10 +10,12 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.MiddleSchoolAchievement;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.OneseoPrivacyDetail;
+import team.themoment.hellogsmv3.domain.oneseo.entity.ScreeningChangeHistory;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
 import team.themoment.hellogsmv3.domain.oneseo.repository.MiddleSchoolAchievementRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.hellogsmv3.domain.oneseo.repository.ScreeningChangeHistoryRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.math.BigDecimal;
@@ -28,6 +30,7 @@ public class ModifyOneseoService {
     private final OneseoRepository oneseoRepository;
     private final OneseoPrivacyDetailRepository oneseoPrivacyDetailRepository;
     private final MiddleSchoolAchievementRepository middleSchoolAchievementRepository;
+    private final ScreeningChangeHistoryRepository screeningChangeHistoryRepository;
 
     @Transactional
     public void execute(OneseoReqDto reqDto, Long memberId, boolean isAdmin) {
@@ -42,6 +45,15 @@ public class ModifyOneseoService {
 
         isNotFinalSubmitted(isAdmin, oneseo);
 
+        if (oneseo.getAppliedScreening() != reqDto.screening()) {
+            ScreeningChangeHistory screeningChangeHistory = ScreeningChangeHistory.builder()
+                    .beforeScreening(oneseo.getAppliedScreening())
+                    .afterScreening(reqDto.screening())
+                    .oneseo(oneseo).build();
+
+            screeningChangeHistoryRepository.save(screeningChangeHistory);
+        }
+
         Oneseo modifiedOneseo = Oneseo.builder()
                 .id(oneseo.getId())
                 .member(currentMember)
@@ -52,7 +64,7 @@ public class ModifyOneseoService {
                         .build())
                 .realOneseoArrivedYn(oneseo.getRealOneseoArrivedYn())
                 .finalSubmittedYn(oneseo.getFinalSubmittedYn())
-                .appliedScreening(oneseo.getAppliedScreening()).build(); // 적용되는 전형 로직 추가해야함
+                .appliedScreening(reqDto.screening()).build();
 
         OneseoPrivacyDetail modifiedOneseoPrivacyDetail = OneseoPrivacyDetail.builder()
                 .id(oneseoPrivacyDetail.getId())

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -1,0 +1,100 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.MiddleSchoolAchievement;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.entity.OneseoPrivacyDetail;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
+import team.themoment.hellogsmv3.domain.oneseo.repository.MiddleSchoolAchievementRepository;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRepository;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+import java.math.BigDecimal;
+
+import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.*;
+
+@Service
+@RequiredArgsConstructor
+public class ModifyOneseoService {
+
+    private final MemberRepository memberRepository;
+    private final OneseoRepository oneseoRepository;
+    private final OneseoPrivacyDetailRepository oneseoPrivacyDetailRepository;
+    private final MiddleSchoolAchievementRepository middleSchoolAchievementRepository;
+
+    @Transactional
+    public void execute(OneseoReqDto reqDto, Long memberId, boolean isAdmin) {
+        Member currentMember = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ExpectedException("존재하지 않는 지원자입니다. member ID: " + memberId, HttpStatus.NOT_FOUND));
+
+        Oneseo oneseo = oneseoRepository.findByMember(currentMember)
+                .orElseThrow(() -> new ExpectedException("원서 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+//        OneseoPrivacyDetail oneseoPrivacyDetail = oneseoPrivacyDetailRepository.findByOneseo(oneseo);
+//        MiddleSchoolAchievement middleSchoolAchievement = middleSchoolAchievementRepository.findByOneseo(oneseo);
+
+        isNotFinalSubmitted(isAdmin, oneseo);
+
+        Oneseo modifiedOneseo = Oneseo.builder()
+                .id(oneseo.getId())
+                .member(currentMember)
+                .desiredMajors(DesiredMajors.builder()
+                        .firstDesiredMajor(reqDto.firstDesiredMajor())
+                        .secondDesiredMajor(reqDto.secondDesiredMajor())
+                        .thirdDesiredMajor(reqDto.thirdDesiredMajor())
+                        .build())
+                .realOneseoArrivedYn(oneseo.getRealOneseoArrivedYn())
+                .finalSubmittedYn(oneseo.getFinalSubmittedYn())
+                .appliedScreening(oneseo.getAppliedScreening()).build(); // 적용되는 전형 로직 추가해야함
+
+        OneseoPrivacyDetail modifiedOneseoPrivacyDetail = OneseoPrivacyDetail.builder()
+                .oneseo(oneseo)
+                .graduationType(reqDto.graduationType())
+                .address(reqDto.address())
+                .detailAddress(reqDto.detailAddress())
+                .profileImg(reqDto.profileImg())
+                .guardianName(reqDto.guardianName())
+                .guardianPhoneNumber(reqDto.guardianPhoneNumber())
+                .relationshipWithGuardian(reqDto.relationWithApplicant())
+                .schoolAddress(reqDto.schoolAddress())
+                .schoolName(reqDto.schoolName())
+                .schoolTeacherName(reqDto.teacherName())
+                .schoolTeacherPhoneNumber(reqDto.teacherPhoneNumber()).build();
+
+        MiddleSchoolAchievement modifiedMiddleSchoolAchievement = MiddleSchoolAchievement.builder()
+                .oneseo(oneseo)
+                .transcript(reqDto.middleSchoolGrade())
+                .percentileRank(BigDecimal.ONE)
+                .totalScore(BigDecimal.ONE)
+                .artisticScore(BigDecimal.ONE)
+                .attendanceScore(BigDecimal.ONE)
+                .volunteerScore(BigDecimal.ONE)
+                .curricularSubtotalScore(BigDecimal.ONE)
+                .extraCurricularSubtotalScore(BigDecimal.ONE)
+                .gedMaxScore(BigDecimal.ONE)
+                .gedTotalScore(BigDecimal.ONE)
+                .grade1Semester1Score(BigDecimal.ONE)
+                .grade1Semester2Score(BigDecimal.ONE)
+                .grade2Semester1Score(BigDecimal.ONE)
+                .grade2Semester2Score(BigDecimal.ONE)
+                .grade3Semester1Score(BigDecimal.ONE).build();
+
+        oneseoRepository.save(modifiedOneseo);
+        oneseoPrivacyDetailRepository.save(modifiedOneseoPrivacyDetail);
+        middleSchoolAchievementRepository.save(modifiedMiddleSchoolAchievement);
+
+    }
+
+    private static void isNotFinalSubmitted(boolean isAdmin, Oneseo oneseo) {
+        if (!isAdmin && oneseo.getFinalSubmittedYn().equals(YES))
+            throw new ExpectedException("최종제출이 완료된 원서는 수정할 수 없습니다.", HttpStatus.BAD_REQUEST);
+    }
+
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -117,11 +117,11 @@ public class ModifyOneseoService {
             throw new ExpectedException("최종제출이 완료된 원서는 수정할 수 없습니다.", HttpStatus.BAD_REQUEST);
     }
 
-    private void saveHistoryIfScreeningChange(Screening beforeScreening, Oneseo oneseo) {
-        if (oneseo.getAppliedScreening() != beforeScreening) {
+    private void saveHistoryIfScreeningChange(Screening afterScreening, Oneseo oneseo) {
+        if (oneseo.getAppliedScreening() != afterScreening) {
             ScreeningChangeHistory screeningChangeHistory = ScreeningChangeHistory.builder()
                     .beforeScreening(oneseo.getAppliedScreening())
-                    .afterScreening(beforeScreening)
+                    .afterScreening(afterScreening)
                     .oneseo(oneseo).build();
 
             screeningChangeHistoryRepository.save(screeningChangeHistory);

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -40,10 +40,10 @@ public class ModifyOneseoService {
         Oneseo oneseo = oneseoRepository.findByMember(currentMember)
                 .orElseThrow(() -> new ExpectedException("원서 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
+        isNotFinalSubmitted(isAdmin, oneseo);
+
         OneseoPrivacyDetail oneseoPrivacyDetail = oneseoPrivacyDetailRepository.findByOneseo(oneseo);
         MiddleSchoolAchievement middleSchoolAchievement = middleSchoolAchievementRepository.findByOneseo(oneseo);
-
-        isNotFinalSubmitted(isAdmin, oneseo);
 
         ifScreeningChangeSaveHistory(reqDto.screening(), oneseo);
 
@@ -78,18 +78,18 @@ public class ModifyOneseoService {
                 .profileImg(reqDto.profileImg())
                 .guardianName(reqDto.guardianName())
                 .guardianPhoneNumber(reqDto.guardianPhoneNumber())
-                .relationshipWithGuardian(reqDto.relationWithApplicant())
+                .relationshipWithGuardian(reqDto.relationshipWithGuardian())
                 .schoolAddress(reqDto.schoolAddress())
                 .schoolName(reqDto.schoolName())
-                .schoolTeacherName(reqDto.teacherName())
-                .schoolTeacherPhoneNumber(reqDto.teacherPhoneNumber()).build();
+                .schoolTeacherName(reqDto.schoolTeacherName())
+                .schoolTeacherPhoneNumber(reqDto.schoolTeacherPhoneNumber()).build();
     }
 
     private MiddleSchoolAchievement buildMiddleSchoolAchievement(OneseoReqDto reqDto, MiddleSchoolAchievement middleSchoolAchievement, Oneseo oneseo) {
         return MiddleSchoolAchievement.builder()
                 .id(middleSchoolAchievement.getId())
                 .oneseo(oneseo)
-                .transcript(reqDto.middleSchoolGrade())
+                .transcript(reqDto.transcript())
                 .percentileRank(BigDecimal.ONE)
                 .totalScore(BigDecimal.ONE)
                 .artisticScore(BigDecimal.ONE)

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -51,7 +51,7 @@ public class ModifyOneseoService {
         OneseoPrivacyDetail modifiedOneseoPrivacyDetail = buildOneseoPrivacyDetail(reqDto, oneseoPrivacyDetail, oneseo);
         MiddleSchoolAchievement modifiedMiddleSchoolAchievement = buildMiddleSchoolAchievement(reqDto, middleSchoolAchievement, oneseo);
 
-        saveModifiedOneseo(modifiedOneseo, modifiedOneseoPrivacyDetail, modifiedMiddleSchoolAchievement);
+        saveModifiedEntities(modifiedOneseo, modifiedOneseoPrivacyDetail, modifiedMiddleSchoolAchievement);
     }
 
     private Oneseo buildOneseo(OneseoReqDto reqDto, Oneseo oneseo, Member currentMember) {
@@ -106,7 +106,7 @@ public class ModifyOneseoService {
                 .grade3Semester1Score(BigDecimal.ONE).build();
     }
 
-    private void saveModifiedOneseo(Oneseo modifiedOneseo, OneseoPrivacyDetail modifiedOneseoPrivacyDetail, MiddleSchoolAchievement modifiedMiddleSchoolAchievement) {
+    private void saveModifiedEntities(Oneseo modifiedOneseo, OneseoPrivacyDetail modifiedOneseoPrivacyDetail, MiddleSchoolAchievement modifiedMiddleSchoolAchievement) {
         oneseoRepository.save(modifiedOneseo);
         oneseoPrivacyDetailRepository.save(modifiedOneseoPrivacyDetail);
         middleSchoolAchievementRepository.save(modifiedMiddleSchoolAchievement);

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -65,6 +65,7 @@ public class ModifyOneseoService {
                         .build())
                 .realOneseoArrivedYn(oneseo.getRealOneseoArrivedYn())
                 .finalSubmittedYn(oneseo.getFinalSubmittedYn())
+                .wantedScreening(reqDto.screening())
                 .appliedScreening(reqDto.screening())
                 .build();
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -37,8 +37,8 @@ public class ModifyOneseoService {
         Oneseo oneseo = oneseoRepository.findByMember(currentMember)
                 .orElseThrow(() -> new ExpectedException("원서 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
-//        OneseoPrivacyDetail oneseoPrivacyDetail = oneseoPrivacyDetailRepository.findByOneseo(oneseo);
-//        MiddleSchoolAchievement middleSchoolAchievement = middleSchoolAchievementRepository.findByOneseo(oneseo);
+        OneseoPrivacyDetail oneseoPrivacyDetail = oneseoPrivacyDetailRepository.findByOneseo(oneseo);
+        MiddleSchoolAchievement middleSchoolAchievement = middleSchoolAchievementRepository.findByOneseo(oneseo);
 
         isNotFinalSubmitted(isAdmin, oneseo);
 
@@ -55,6 +55,7 @@ public class ModifyOneseoService {
                 .appliedScreening(oneseo.getAppliedScreening()).build(); // 적용되는 전형 로직 추가해야함
 
         OneseoPrivacyDetail modifiedOneseoPrivacyDetail = OneseoPrivacyDetail.builder()
+                .id(oneseoPrivacyDetail.getId())
                 .oneseo(oneseo)
                 .graduationType(reqDto.graduationType())
                 .address(reqDto.address())
@@ -69,6 +70,7 @@ public class ModifyOneseoService {
                 .schoolTeacherPhoneNumber(reqDto.teacherPhoneNumber()).build();
 
         MiddleSchoolAchievement modifiedMiddleSchoolAchievement = MiddleSchoolAchievement.builder()
+                .id(middleSchoolAchievement.getId())
                 .oneseo(oneseo)
                 .transcript(reqDto.middleSchoolGrade())
                 .percentileRank(BigDecimal.ONE)

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -65,7 +65,8 @@ public class ModifyOneseoService {
                         .build())
                 .realOneseoArrivedYn(oneseo.getRealOneseoArrivedYn())
                 .finalSubmittedYn(oneseo.getFinalSubmittedYn())
-                .appliedScreening(reqDto.screening()).build();
+                .appliedScreening(reqDto.screening())
+                .build();
     }
 
     private OneseoPrivacyDetail buildOneseoPrivacyDetail(OneseoReqDto reqDto, OneseoPrivacyDetail oneseoPrivacyDetail, Oneseo oneseo) {
@@ -82,7 +83,8 @@ public class ModifyOneseoService {
                 .schoolAddress(reqDto.schoolAddress())
                 .schoolName(reqDto.schoolName())
                 .schoolTeacherName(reqDto.schoolTeacherName())
-                .schoolTeacherPhoneNumber(reqDto.schoolTeacherPhoneNumber()).build();
+                .schoolTeacherPhoneNumber(reqDto.schoolTeacherPhoneNumber())
+                .build();
     }
 
     private MiddleSchoolAchievement buildMiddleSchoolAchievement(OneseoReqDto reqDto, MiddleSchoolAchievement middleSchoolAchievement, Oneseo oneseo) {
@@ -103,7 +105,8 @@ public class ModifyOneseoService {
                 .grade1Semester2Score(BigDecimal.ONE)
                 .grade2Semester1Score(BigDecimal.ONE)
                 .grade2Semester2Score(BigDecimal.ONE)
-                .grade3Semester1Score(BigDecimal.ONE).build();
+                .grade3Semester1Score(BigDecimal.ONE)
+                .build();
     }
 
     private void saveModifiedEntities(Oneseo modifiedOneseo, OneseoPrivacyDetail modifiedOneseoPrivacyDetail, MiddleSchoolAchievement modifiedMiddleSchoolAchievement) {

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -215,9 +215,12 @@ public class SecurityConfig {
                 )
 
                 // oneseo
-                .requestMatchers(HttpMethod.POST, "/oneseo/v3/oneseo/me").hasAnyAuthority(
+                .requestMatchers("/oneseo/v3/oneseo/me").hasAnyAuthority(
                         Role.APPLICANT.name(),
                         Role.ROOT.name()
+                )
+                .requestMatchers(HttpMethod.PUT, "/oneseo/v3/oneseo/{memberId}").hasAnyAuthority(
+                        Role.ADMIN.name()
                 )
 
                 .anyRequest().permitAll()


### PR DESCRIPTION
## 개요

내 원서 수정, 원서 수정 기능을 구현하였습니다.

## 본문

- `/oneseo/me`,`/oneseo/{memberId}` 원서 수정 기능을 구현하였습니다.
- 수정 비즈니스 로직 메서드 파라미터에 `isAdmin` 값으로 어드민 수정 요청을 판별합니다. 어드민은 최종제출한 원서도 수정이 가능합니다.
- `Oneseo` 엔티티와 식별 관계인 `OneseoPrivacyDetail`, `MiddleSchoolAchievement` 엔티티를 조회시 해당 엔티티들은 원서 생성시 필수로 save되는 엔티티이므로 JPARepository에서 Optional로 받아오지 않았습니다.

* `@DynamicUpdate` 어노테이션으로 더티채킹시 변경이 발생하는 컬럼에만 update 쿼리가 나가도록 구현하였습니다.
* 기존 더티채킹은 변경이 발생한 컬럼이 있다면 해당 엔티티의 모든 컬럼에 대해서 update 쿼리를 발생시켰습니다. 위의 어노테이션을 엔티티에 붙혀 변경된 컬럼에 대해서만 update 쿼리하도록 구현하였습니다.