### PR TITLE
[entity] 입학시험 평가요소, 중학교 성취도 엔티티 구성

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -32,7 +32,7 @@ public class OneseoController {
             @AuthRequest Long memberId
     ) {
         modifyOneseoService.execute(reqDto, memberId, false);
-        return CommonApiResponse.created("수정되었습니다.");
+        return CommonApiResponse.success("수정되었습니다.");
     }
 
     @PutMapping("/oneseo/{memberId}")
@@ -41,7 +41,7 @@ public class OneseoController {
             @PathVariable("memberId") Long memberId
     ) {
         modifyOneseoService.execute(reqDto, memberId, true);
-        return CommonApiResponse.created("수정되었습니다.");
+        return CommonApiResponse.success("수정되었습니다.");
     }
 
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/MiddleSchoolAchievementReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/MiddleSchoolAchievementReqDto.java
@@ -1,0 +1,25 @@
+package team.themoment.hellogsmv3.domain.oneseo.dto.request;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record MiddleSchoolAchievementReqDto(
+
+        List<Integer> achievement1_1,
+        List<Integer> achievement1_2,
+        List<Integer> achievement2_1,
+        List<Integer> achievement2_2,
+        List<Integer> achievement3_1,
+        List<String> generalSubjects,
+        List<String> newSubjects,
+        List<Integer> artsPhysicalAchievement,
+        List<String> artsPhysicalSubjects,
+        List<Integer> absentDays,
+        List<Integer> attendanceDays,
+        List<Integer> volunteerTime,
+        String liberalSystem,
+        String freeSemester,
+        BigDecimal gedTotalScore,
+        BigDecimal gedMaxScore
+) {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
@@ -48,8 +48,7 @@ public record OneseoReqDto(
         @NotNull
         Major thirdDesiredMajor,
 
-        @NotBlank
-        String transcript,
+        MiddleSchoolAchievementReqDto transcript,
 
         String schoolName,
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestFactorsDetail.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestFactorsDetail.java
@@ -37,7 +37,7 @@ public class EntranceTestFactorsDetail {
     private BigDecimal documentEvaluationScore;
 
     @Column(name = "aptitude_evaluation_score")
-    private BigDecimal AptitudeEvaluationScore;
+    private BigDecimal aptitudeEvaluationScore;
 
     @Column(name = "interview_score")
     private BigDecimal interviewScore;

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestFactorsDetail.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestFactorsDetail.java
@@ -18,14 +18,14 @@ public class EntranceTestFactorsDetail {
     @Column(name = "entrance_test_factors_detail_id")
     private Long id;
 
-    @Column(name = "curricular_subtotal_score")
-    private BigDecimal curricularSubtotalScore;
+    @Column(name = "general_subjects_score")
+    private BigDecimal generalSubjectsScore;
 
-    @Column(name = "extra_curricular_subtotal_score")
-    private BigDecimal extraCurricularSubtotalScore;
+    @Column(name = "arts_physical_subjects_score")
+    private BigDecimal artsPhysicalSubjectsScore;
 
-    @Column(name = "artistic_score")
-    private BigDecimal artisticScore;
+    @Column(name = "total_subjects_score")
+    private BigDecimal totalSubjectsScore;
 
     @Column(name = "attendance_score")
     private BigDecimal attendanceScore;
@@ -33,12 +33,30 @@ public class EntranceTestFactorsDetail {
     @Column(name = "volunteer_score")
     private BigDecimal volunteerScore;
 
-    @Column(name = "document_evaluation_score")
-    private BigDecimal documentEvaluationScore;
+    @Column(name = "total_non_subjects_score")
+    private BigDecimal totalNonSubjectsScore;
 
-    @Column(name = "aptitude_evaluation_score")
-    private BigDecimal aptitudeEvaluationScore;
+    @Column(name = "score_1_1")
+    private BigDecimal score11;
 
-    @Column(name = "interview_score")
-    private BigDecimal interviewScore;
+    @Column(name = "score_1_2")
+    private BigDecimal score12;
+
+    @Column(name = "score_2_1")
+    private BigDecimal score21;
+
+    @Column(name = "score_2_2")
+    private BigDecimal score22;
+
+    @Column(name = "score_3_1")
+    private BigDecimal score31;
+
+    @Column(name = "ged_total_score")
+    private BigDecimal gedTotalScore;
+
+    @Column(name = "ged_max_score")
+    private BigDecimal gedMaxScore;
+
+    @Column(name = "percentile_rank")
+    private BigDecimal percentileRank;
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestFactorsDetail.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestFactorsDetail.java
@@ -37,19 +37,19 @@ public class EntranceTestFactorsDetail {
     private BigDecimal totalNonSubjectsScore;
 
     @Column(name = "score_1_1")
-    private BigDecimal score11;
+    private BigDecimal score1_1;
 
     @Column(name = "score_1_2")
-    private BigDecimal score12;
+    private BigDecimal score1_2;
 
     @Column(name = "score_2_1")
-    private BigDecimal score21;
+    private BigDecimal score2_1;
 
     @Column(name = "score_2_2")
-    private BigDecimal score22;
+    private BigDecimal score2_2;
 
     @Column(name = "score_3_1")
-    private BigDecimal score31;
+    private BigDecimal score3_1;
 
     @Column(name = "ged_total_score")
     private BigDecimal gedTotalScore;

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestFactorsDetail.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestFactorsDetail.java
@@ -1,0 +1,44 @@
+package team.themoment.hellogsmv3.domain.oneseo.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@Entity
+@Table(name = "tb_entrance_test_factors_detail")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EntranceTestFactorsDetail {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "entrance _test_factors_detail_id")
+    private Long id;
+
+    @Column(name = "curricular_subtotal_score")
+    private BigDecimal curricularSubtotalScore;
+
+    @Column(name = "extra_curricular_subtotal_score")
+    private BigDecimal extraCurricularSubtotalScore;
+
+    @Column(name = "artistic_score")
+    private BigDecimal artisticScore;
+
+    @Column(name = "attendance_score")
+    private BigDecimal attendanceScore;
+
+    @Column(name = "volunteer_score")
+    private BigDecimal volunteerScore;
+
+    @Column(name = "document_evaluation_score")
+    private BigDecimal documentEvaluationScore;
+
+    @Column(name = "aptitude_evaluation_score")
+    private BigDecimal AptitudeEvaluationScore;
+
+    @Column(name = "interview_score")
+    private BigDecimal interviewScore;
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestFactorsDetail.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestFactorsDetail.java
@@ -15,7 +15,7 @@ public class EntranceTestFactorsDetail {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "entrance _test_factors_detail_id")
+    @Column(name = "entrance_test_factors_detail_id")
     private Long id;
 
     @Column(name = "curricular_subtotal_score")

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestResult.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestResult.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 
+import java.math.BigDecimal;
+
 @Getter
 @Entity
 @Table(name = "tb_entrance_test_result")
@@ -26,9 +28,18 @@ public class EntranceTestResult {
     @JoinColumn(name = "entrance_test_factors_detail_id")
     private EntranceTestFactorsDetail entranceTestFactorsDetail;
 
+    @Column(name = "document_evaluation_score")
+    private BigDecimal documentEvaluationScore;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "first_test_pass_yn")
     private YesNo firstTestPassYn;
+
+    @Column(name = "aptitude_evaluation_score")
+    private BigDecimal aptitudeEvaluationScore;
+
+    @Column(name = "interview_score")
+    private BigDecimal interviewScore;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "second_test_pass_yn")

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestResult.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestResult.java
@@ -7,8 +7,6 @@ import lombok.NoArgsConstructor;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 
-import java.math.BigDecimal;
-
 @Getter
 @Entity
 @Table(name = "tb_entrance_test_result")
@@ -24,22 +22,17 @@ public class EntranceTestResult {
     @JoinColumn(name = "oneseo_id")
     private Oneseo oneseo;
 
-    @Column(name = "first_test_result_score")
-    private BigDecimal firstTestResultScore;
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "entrance_test_factors_detail_id")
+    private EntranceTestFactorsDetail entranceTestFactorsDetail;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "first_test_pass_yn")
     private YesNo firstTestPassYn;
 
-    @Column(name = "second_test_result_score")
-    private BigDecimal secondTestResultScore;
-
     @Enumerated(EnumType.STRING)
     @Column(name = "second_test_pass_yn")
     private YesNo secondTestPassYn;
-
-    @Column(name = "interview_score")
-    private BigDecimal interviewScore;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "decided_major")

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
@@ -16,7 +16,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @DynamicUpdate
-public class MiddleSchoolAchievement {  // TODO converter 구현
+public class MiddleSchoolAchievement {
 
     @Id
     private Long id;

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
@@ -53,12 +53,12 @@ public class MiddleSchoolAchievement {
     private List<String> new_subjects;
 
     @Convert
-    @Column(name = "arts_sports_achievement")
-    private List<Integer> arts_sports_achievement;
+    @Column(name = "arts_physical_achievement")
+    private List<Integer> arts_physical_achievement;
 
     @Convert
-    @Column(name = "arts_sports_subjects")
-    private List<String> arts_sports_subjects;
+    @Column(name = "arts_physical_subjects")
+    private List<String> arts_physical_subjects;
 
     @Convert
     @Column(name = "absent_days")

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
@@ -3,6 +3,7 @@ package team.themoment.hellogsmv3.domain.oneseo.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
+import team.themoment.hellogsmv3.global.common.converter.IntegerListConverter;
 import team.themoment.hellogsmv3.global.common.converter.StringListConverter;
 
 import java.math.BigDecimal;
@@ -25,23 +26,23 @@ public class MiddleSchoolAchievement {  // TODO converter 구현
     @JoinColumn(name = "oneseo_id")
     private Oneseo oneseo;
 
-    @Convert
+    @Convert(converter = IntegerListConverter.class)
     @Column(name = "achievement_1_1")
     private List<Integer> achievement1_1;
 
-    @Convert
+    @Convert(converter = IntegerListConverter.class)
     @Column(name = "achievement_1_2")
     private List<Integer> achievement1_2;
 
-    @Convert
+    @Convert(converter = IntegerListConverter.class)
     @Column(name = "achievement_2_1")
     private List<Integer> achievement2_1;
 
-    @Convert
+    @Convert(converter = IntegerListConverter.class)
     @Column(name = "achievement_2_2")
     private List<Integer> achievement2_2;
 
-    @Convert
+    @Convert(converter = IntegerListConverter.class)
     @Column(name = "achievement_3_1")
     private List<Integer> achievement3_1;
 
@@ -53,7 +54,7 @@ public class MiddleSchoolAchievement {  // TODO converter 구현
     @Column(name = "new_subjects")
     private List<String> newSubjects;
 
-    @Convert
+    @Convert(converter = IntegerListConverter.class)
     @Column(name = "arts_physical_achievement")
     private List<Integer> artsPhysicalAchievement;
 
@@ -61,15 +62,15 @@ public class MiddleSchoolAchievement {  // TODO converter 구현
     @Column(name = "arts_physical_subjects")
     private List<String> artsPhysicalSubjects;
 
-    @Convert
+    @Convert(converter = IntegerListConverter.class)
     @Column(name = "absent_days")
     private List<Integer> absentDays;
 
-    @Convert
+    @Convert(converter = IntegerListConverter.class)
     @Column(name = "attendance_days")
     private List<Integer> attendanceDays;
 
-    @Convert
+    @Convert(converter = IntegerListConverter.class)
     @Column(name = "volunteer_time")
     private List<Integer> volunteerTime;
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
@@ -26,61 +26,61 @@ public class MiddleSchoolAchievement {
 
     @Convert
     @Column(name = "achievement_1_1")
-    private List<Integer> achievement_1_1;
+    private List<Integer> achievement1_1;
 
     @Convert
     @Column(name = "achievement_1_2")
-    private List<Integer> achievement_1_2;
+    private List<Integer> achievement1_2;
 
     @Convert
     @Column(name = "achievement_2_1")
-    private List<Integer> achievement_2_1;
+    private List<Integer> achievement2_1;
 
     @Convert
     @Column(name = "achievement_2_2")
-    private List<Integer> achievement_2_2;
+    private List<Integer> achievement2_2;
 
     @Convert
     @Column(name = "achievement_3_1")
-    private List<Integer> achievement_3_1;
+    private List<Integer> achievement3_1;
 
     @Convert
     @Column(name = "general_subjects")
-    private List<String> general_subjects;
+    private List<String> generalSubjects;
 
     @Convert
     @Column(name = "new_subjects")
-    private List<String> new_subjects;
+    private List<String> newSubjects;
 
     @Convert
     @Column(name = "arts_physical_achievement")
-    private List<Integer> arts_physical_achievement;
+    private List<Integer> artsPhysicalAchievement;
 
     @Convert
     @Column(name = "arts_physical_subjects")
-    private List<String> arts_physical_subjects;
+    private List<String> artsPhysicalSubjects;
 
     @Convert
     @Column(name = "absent_days")
-    private List<Integer> absent_days;
+    private List<Integer> absentDays;
 
     @Convert
     @Column(name = "attendance_days")
-    private List<Integer> attendance_days;
+    private List<Integer> attendanceDays;
 
     @Convert
     @Column(name = "volunteer_time")
-    private List<Integer> volunteer_time;
+    private List<Integer> volunteerTime;
 
     @Column(name = "liberal_system")
-    private String liberal_system;
+    private String liberalSystem;
 
     @Column(name = "free_semester")
-    private String free_semester;
+    private String freeSemester;
 
     @Column(name = "ged_total_score")
-    private BigDecimal ged_total_score;
+    private BigDecimal gedTotalScore;
 
     @Column(name = "ged_max_score")
-    private BigDecimal ged_max_score;
+    private BigDecimal gedMaxScore;
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 @Getter
 @Entity
@@ -23,48 +24,63 @@ public class MiddleSchoolAchievement {
     @JoinColumn(name = "oneseo_id")
     private Oneseo oneseo;
 
-    @Column(name = "transcript", columnDefinition = "TEXT", nullable = false)
-    private String transcript;
+    @Convert
+    @Column(name = "achievement_1_1")
+    private List<Integer> achievement_1_1;
 
-    @Column(name = "percentile_rank", nullable = false)
-    private BigDecimal percentileRank;
+    @Convert
+    @Column(name = "achievement_1_2")
+    private List<Integer> achievement_1_2;
 
-    @Column(name = "total_score", nullable = false)
-    private BigDecimal totalScore;
+    @Convert
+    @Column(name = "achievement_2_1")
+    private List<Integer> achievement_2_1;
 
-    @Column(name = "artistic_score")
-    private BigDecimal artisticScore;
+    @Convert
+    @Column(name = "achievement_2_2")
+    private List<Integer> achievement_2_2;
 
-    @Column(name = "attendance_score")
-    private BigDecimal attendanceScore;
+    @Convert
+    @Column(name = "achievement_3_1")
+    private List<Integer> achievement_3_1;
 
-    @Column(name = "volunteer_score")
-    private BigDecimal volunteerScore;
+    @Convert
+    @Column(name = "general_subjects")
+    private List<String> general_subjects;
 
-    @Column(name = "curricular_subtotal_score")
-    private BigDecimal curricularSubtotalScore;
+    @Convert
+    @Column(name = "new_subjects")
+    private List<String> new_subjects;
 
-    @Column(name = "extra_curricular_subtotal_score")
-    private BigDecimal extraCurricularSubtotalScore;
+    @Convert
+    @Column(name = "arts_sports_achievement")
+    private List<Integer> arts_sports_achievement;
 
-    @Column(name = "ged_max_score")
-    private BigDecimal gedMaxScore;
+    @Convert
+    @Column(name = "arts_sports_subjects")
+    private List<String> arts_sports_subjects;
+
+    @Convert
+    @Column(name = "absent_days")
+    private List<Integer> absent_days;
+
+    @Convert
+    @Column(name = "attendance_days")
+    private List<Integer> attendance_days;
+
+    @Convert
+    @Column(name = "volunteer_time")
+    private List<Integer> volunteer_time;
+
+    @Column(name = "liberal_system")
+    private String liberal_system;
+
+    @Column(name = "free_semester")
+    private String free_semester;
 
     @Column(name = "ged_total_score")
-    private BigDecimal gedTotalScore;
+    private BigDecimal ged_total_score;
 
-    @Column(name = "grade1_semester1_score")
-    private BigDecimal grade1Semester1Score;
-
-    @Column(name = "grade1_semester2_score")
-    private BigDecimal grade1Semester2Score;
-
-    @Column(name = "grade2_semester1_score")
-    private BigDecimal grade2Semester1Score;
-
-    @Column(name = "grade2_semester2_score")
-    private BigDecimal grade2Semester2Score;
-
-    @Column(name = "grade3_semester1_score")
-    private BigDecimal grade3Semester1Score;
+    @Column(name = "ged_max_score")
+    private BigDecimal ged_max_score;
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
@@ -14,7 +14,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @DynamicUpdate
-public class MiddleSchoolAchievement {
+public class MiddleSchoolAchievement {  // TODO converter 구현
 
     @Id
     private Long id;

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
@@ -3,6 +3,7 @@ package team.themoment.hellogsmv3.domain.oneseo.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
+import team.themoment.hellogsmv3.global.common.converter.StringListConverter;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -44,11 +45,11 @@ public class MiddleSchoolAchievement {  // TODO converter 구현
     @Column(name = "achievement_3_1")
     private List<Integer> achievement3_1;
 
-    @Convert
+    @Convert(converter = StringListConverter.class)
     @Column(name = "general_subjects")
     private List<String> generalSubjects;
 
-    @Convert
+    @Convert(converter = StringListConverter.class)
     @Column(name = "new_subjects")
     private List<String> newSubjects;
 
@@ -56,7 +57,7 @@ public class MiddleSchoolAchievement {  // TODO converter 구현
     @Column(name = "arts_physical_achievement")
     private List<Integer> artsPhysicalAchievement;
 
-    @Convert
+    @Convert(converter = StringListConverter.class)
     @Column(name = "arts_physical_subjects")
     private List<String> artsPhysicalSubjects;
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.MiddleSchoolAchievement;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
@@ -15,8 +16,6 @@ import team.themoment.hellogsmv3.domain.oneseo.repository.MiddleSchoolAchievemen
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
-
-import java.math.BigDecimal;
 
 import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.*;
 
@@ -82,26 +81,26 @@ public class CreateOneseoService {
     }
 
     private MiddleSchoolAchievement buildMiddleSchoolAchievement(OneseoReqDto reqDto, Oneseo oneseo) {
-
-        // TODO 추후에 성적 환산 로직 추가
+        MiddleSchoolAchievementReqDto transcript = reqDto.transcript();
 
         return MiddleSchoolAchievement.builder()
                 .oneseo(oneseo)
-                .transcript(reqDto.transcript())
-                .percentileRank(BigDecimal.ONE)
-                .totalScore(BigDecimal.ONE)
-                .artisticScore(BigDecimal.ONE)
-                .attendanceScore(BigDecimal.ONE)
-                .volunteerScore(BigDecimal.ONE)
-                .curricularSubtotalScore(BigDecimal.ONE)
-                .extraCurricularSubtotalScore(BigDecimal.ONE)
-                .gedMaxScore(BigDecimal.ONE)
-                .gedTotalScore(BigDecimal.ONE)
-                .grade1Semester1Score(BigDecimal.ONE)
-                .grade1Semester2Score(BigDecimal.ONE)
-                .grade2Semester1Score(BigDecimal.ONE)
-                .grade2Semester2Score(BigDecimal.ONE)
-                .grade3Semester1Score(BigDecimal.ONE)
+                .achievement1_1(transcript.achievement1_1())
+                .achievement1_2(transcript.achievement1_2())
+                .achievement2_1(transcript.achievement2_1())
+                .achievement2_2(transcript.achievement2_2())
+                .achievement3_1(transcript.achievement3_1())
+                .generalSubjects(transcript.generalSubjects())
+                .newSubjects(transcript.newSubjects())
+                .artsPhysicalAchievement(transcript.artsPhysicalAchievement())
+                .artsPhysicalSubjects(transcript.artsPhysicalSubjects())
+                .absentDays(transcript.absentDays())
+                .attendanceDays(transcript.attendanceDays())
+                .volunteerTime(transcript.volunteerTime())
+                .liberalSystem(transcript.liberalSystem())
+                .freeSemester(transcript.freeSemester())
+                .gedTotalScore(transcript.gedTotalScore())
+                .gedMaxScore(transcript.gedMaxScore())
                 .build();
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.MiddleSchoolAchievement;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
@@ -89,24 +90,27 @@ public class ModifyOneseoService {
     }
 
     private MiddleSchoolAchievement buildMiddleSchoolAchievement(OneseoReqDto reqDto, MiddleSchoolAchievement middleSchoolAchievement, Oneseo oneseo) {
+        MiddleSchoolAchievementReqDto transcript = reqDto.transcript();
+
         return MiddleSchoolAchievement.builder()
                 .id(middleSchoolAchievement.getId())
                 .oneseo(oneseo)
-                .transcript(reqDto.transcript())
-                .percentileRank(BigDecimal.ONE)
-                .totalScore(BigDecimal.ONE)
-                .artisticScore(BigDecimal.ONE)
-                .attendanceScore(BigDecimal.ONE)
-                .volunteerScore(BigDecimal.ONE)
-                .curricularSubtotalScore(BigDecimal.ONE)
-                .extraCurricularSubtotalScore(BigDecimal.ONE)
-                .gedMaxScore(BigDecimal.ONE)
-                .gedTotalScore(BigDecimal.ONE)
-                .grade1Semester1Score(BigDecimal.ONE)
-                .grade1Semester2Score(BigDecimal.ONE)
-                .grade2Semester1Score(BigDecimal.ONE)
-                .grade2Semester2Score(BigDecimal.ONE)
-                .grade3Semester1Score(BigDecimal.ONE)
+                .achievement1_1(transcript.achievement1_1())
+                .achievement1_2(transcript.achievement1_2())
+                .achievement2_1(transcript.achievement2_1())
+                .achievement2_2(transcript.achievement2_2())
+                .achievement3_1(transcript.achievement3_1())
+                .generalSubjects(transcript.generalSubjects())
+                .newSubjects(transcript.newSubjects())
+                .artsPhysicalAchievement(transcript.artsPhysicalAchievement())
+                .artsPhysicalSubjects(transcript.artsPhysicalSubjects())
+                .absentDays(transcript.absentDays())
+                .attendanceDays(transcript.attendanceDays())
+                .volunteerTime(transcript.volunteerTime())
+                .liberalSystem(transcript.liberalSystem())
+                .freeSemester(transcript.freeSemester())
+                .gedTotalScore(transcript.gedTotalScore())
+                .gedMaxScore(transcript.gedMaxScore())
                 .build();
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/global/common/converter/IntegerListConverter.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/common/converter/IntegerListConverter.java
@@ -1,0 +1,32 @@
+package team.themoment.hellogsmv3.global.common.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.List;
+
+@Converter
+public class IntegerListConverter implements AttributeConverter<List<Integer>, String> {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<Integer> dataList) {
+        try {
+            return mapper.writeValueAsString(dataList);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public List<Integer> convertToEntityAttribute(String data) {
+        try {
+            return mapper.readValue(data, List.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/common/converter/StringListConverter.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/common/converter/StringListConverter.java
@@ -1,0 +1,32 @@
+package team.themoment.hellogsmv3.global.common.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.List;
+
+@Converter
+public class StringListConverter implements AttributeConverter<List<String>, String> {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<String> dataList) {
+        try {
+            return mapper.writeValueAsString(dataList);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String data) {
+        try {
+            return mapper.readValue(data, List.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## 개요

- `EntranceTestFactorsDetail(입학시험 평가요소)` 엔티티 추가 작업을 하였습니다.  
- `MiddleSchoolAchievement(중학교 성취도)` 엔티티 구조 변경을 하였습니다.

<br>

## 본문

```
엔티티 구조

EntranceTestFactorsDetail
- id
- generalSubjectsScore (일반교과 점수)
- artsPhysicalSubjectsScore (비교과 점수)
- totalSubjectsScore (예체능점수)
- attendanceScore (출석 점수)
- volunteerScore (봉사 점수)
- totalNonSubjectsScore (서류평가 점수)
- score1_1 (직무적성 소양평가 점수)
- score1_2 (심층면접 점수)
- score2_1
- score2_2
- score3_1
- gedTotalScore
- gedMaxScore
- percentileRank


MiddleSchoolAchievement
- oneseo
- achievement1_1
- achievement1_2
- achievement1_2
- achievement1_2
- achievement1_2
- generalSubjects
- newSubjects
- artsPhysicalAchievement
- artsPhysicalSubjects
- absentDays
- attendanceDays
- volunteerTime
- liberalSystem
- freeSemester
- gedTotalScore
- gedMaxScore
```

--- 

`EntranceTestResult`와 `EntranceTestFactorsDetail`를 1:1 매핑하엿습니다.
fk 위치는 `EntranceTestResult` 입니다.

`MiddleSchoolAchievement`는 오직 전체 조회만 발생하는 데이터이기 때문에 역 정규화를 하였습니다.
`@Converter`를 사용하여 List형태의 데이터를 String으로 저장합니다.

