### PR TITLE
[oneseo] 원서 상태 변경 기능 구현

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/MemberService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/MemberService.java
@@ -1,0 +1,20 @@
+package team.themoment.hellogsmv3.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Member findById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new ExpectedException("존재하지 않는 지원자입니다. member ID: " + memberId, HttpStatus.NOT_FOUND));
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberAuthInfoByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberAuthInfoByIdService.java
@@ -12,11 +12,10 @@ import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 @RequiredArgsConstructor
 public class QueryMemberAuthInfoByIdService {
 
-    private final MemberRepository memberRepository;
+    private final MemberService memberService;
 
     public FoundMemberAuthInfoResDto execute(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new ExpectedException("존재하지 않는 지원자입니다. member ID: " + memberId, HttpStatus.NOT_FOUND));
+        Member member = memberService.findById(memberId);
 
         return FoundMemberAuthInfoResDto.builder()
                 .memberId(member.getId())

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdService.java
@@ -13,12 +13,11 @@ import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 @RequiredArgsConstructor
 public class QueryMemberByIdService {
 
-    private final MemberRepository memberRepository;
+    private final MemberService memberService;
 
     @Transactional(readOnly = true)
     public FoundMemberResDto execute(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new ExpectedException("존재하지 않는 지원자입니다. member ID: " + memberId, HttpStatus.NOT_FOUND));
+        Member member = memberService.findById(memberId);
 
         return FoundMemberResDto.builder()
                 .memberId(member.getId())

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsmv3.domain.oneseo.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import team.themoment.hellogsmv3.domain.oneseo.dto.OneseoStatusReqDto;
@@ -16,7 +17,7 @@ public class OneseoController {
     @PutMapping("/status/{memberId}")
     public CommonApiResponse modifyOneseoStatus(
             @PathVariable Long memberId,
-            @RequestBody OneseoStatusReqDto oneseoStatusReqDto
+            @RequestBody @Valid OneseoStatusReqDto oneseoStatusReqDto
     ) {
         modifyOneseoStatusService.execute(memberId, oneseoStatusReqDto);
         return CommonApiResponse.success("수정되었습니다.");

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -1,0 +1,24 @@
+package team.themoment.hellogsmv3.domain.oneseo.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import team.themoment.hellogsmv3.domain.oneseo.dto.OneseoStatusReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.service.ModifyOneseoStatusService;
+import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/oneseo/v3")
+public class OneseoController {
+
+    private final ModifyOneseoStatusService modifyOneseoStatusService;
+
+    @PutMapping("/status/{memberId}")
+    public CommonApiResponse modifyOneseoStatus(
+            @PathVariable Long memberId,
+            @RequestBody OneseoStatusReqDto oneseoStatusReqDto
+    ) {
+        modifyOneseoStatusService.execute(memberId, oneseoStatusReqDto);
+        return CommonApiResponse.success("수정되었습니다.");
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/OneseoStatusReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/OneseoStatusReqDto.java
@@ -1,0 +1,27 @@
+package team.themoment.hellogsmv3.domain.oneseo.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import team.themoment.hellogsmv3.domain.application.type.EvaluationStatus;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
+
+import java.math.BigDecimal;
+
+public record OneseoStatusReqDto(
+        @NotNull
+        YesNo finalSubmittedYn,
+        @NotNull
+        YesNo realOneseoArrivedYn,
+        @NotBlank
+        YesNo firstTestPassYn,
+        @NotBlank
+        YesNo secondTestPassYn,
+        Screening appliedScreening,
+        Long oneseoSubmitCode,
+        BigDecimal secondTestResultScore,
+        BigDecimal interviewScore,
+        Major decidedMajor
+) {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestResult.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestResult.java
@@ -1,9 +1,7 @@
 package team.themoment.hellogsmv3.domain.oneseo.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 
@@ -11,6 +9,8 @@ import java.math.BigDecimal;
 
 @Getter
 @Entity
+@Builder
+@AllArgsConstructor
 @Table(name = "tb_entrance_test_result")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EntranceTestResult {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
@@ -2,9 +2,7 @@ package team.themoment.hellogsmv3.domain.oneseo.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
@@ -12,6 +10,8 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 
 @Getter
 @Entity
+@Builder
+@AllArgsConstructor
 @Table(name = "tb_oneseo")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Oneseo {
@@ -39,10 +39,6 @@ public class Oneseo {
     @Enumerated(EnumType.STRING)
     @Column(name = "final_submitted_yn", nullable = false)
     private YesNo finalSubmittedYn;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "wanted_screening", nullable = false)
-    private Screening wantedScreening;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "applied_screening", nullable = false)

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/EntranceTestResultRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/EntranceTestResultRepository.java
@@ -1,0 +1,12 @@
+package team.themoment.hellogsmv3.domain.oneseo.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+
+import java.util.Optional;
+
+public interface EntranceTestResultRepository extends JpaRepository<EntranceTestResult, Long> {
+
+    Optional<EntranceTestResult> findByOneseo(Oneseo oneseo);
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoRepository.java
@@ -1,0 +1,12 @@
+package team.themoment.hellogsmv3.domain.oneseo.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+
+import java.util.Optional;
+
+public interface OneseoRepository extends JpaRepository<Oneseo, Long> {
+
+    Optional<Oneseo> findByMember(Member member);
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoStatusService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoStatusService.java
@@ -1,0 +1,62 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.member.service.MemberService;
+import team.themoment.hellogsmv3.domain.oneseo.dto.OneseoStatusReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+@Service
+@RequiredArgsConstructor
+public class ModifyOneseoStatusService {
+
+    private final OneseoRepository oneseoRepository;
+    private final EntranceTestResultRepository entranceTestResultRepository;
+    private final MemberService memberService;
+
+    public void execute(Long memberId, OneseoStatusReqDto oneseoStatusReqDto) {
+        Member member = memberService.findById(memberId);
+        Oneseo oneseo = oneseoRepository.findByMember(member)
+                .orElseThrow(() -> new ExpectedException("해당 지원자의 원서를 찾을 수 없습니다. member ID : " + memberId, HttpStatus.NOT_FOUND));
+        EntranceTestResult entranceTestResult = entranceTestResultRepository.findByOneseo(oneseo)
+                .orElseThrow(() -> new ExpectedException("해당 지원자의 원서로 입학 시험 결과를 찾을 수 없습니다. member ID : " + oneseo.getMember().getId(), HttpStatus.NOT_FOUND));
+
+        saveModifiedOneseo(oneseo, oneseoStatusReqDto);
+        saveModifiedEntranceTestResult(entranceTestResult, oneseoStatusReqDto);
+    }
+
+    private void saveModifiedOneseo(Oneseo oneseo, OneseoStatusReqDto oneseoStatusReqDto) {
+        Oneseo modifiedOneseo = Oneseo.builder()
+                .id(oneseo.getId())
+                .member(oneseo.getMember())
+                .oneseoSubmitCode(oneseo.getOneseoSubmitCode())
+                .desiredMajors(oneseo.getDesiredMajors())
+                .realOneseoArrivedYn(oneseoStatusReqDto.realOneseoArrivedYn())
+                .finalSubmittedYn(oneseoStatusReqDto.finalSubmittedYn())
+                .appliedScreening(oneseoStatusReqDto.appliedScreening())
+                .build();
+
+        oneseoRepository.save(modifiedOneseo);
+    }
+
+    private void saveModifiedEntranceTestResult(EntranceTestResult entranceTestResult, OneseoStatusReqDto oneseoStatusReqDto) {
+        EntranceTestResult modifiedEntranceTestResult = EntranceTestResult.builder()
+                .id(entranceTestResult.getId())
+                .oneseo(entranceTestResult.getOneseo())
+                .firstTestResultScore(entranceTestResult.getFirstTestResultScore())
+                .firstTestPassYn(oneseoStatusReqDto.firstTestPassYn())
+                .secondTestPassYn(oneseoStatusReqDto.secondTestPassYn())
+                .secondTestResultScore(oneseoStatusReqDto.secondTestResultScore())
+                .interviewScore(oneseoStatusReqDto.interviewScore())
+                .decidedMajor(oneseoStatusReqDto.decidedMajor())
+                .build();
+
+        entranceTestResultRepository.save(modifiedEntranceTestResult);
+    }
+}


### PR DESCRIPTION
## 개요

원서의 상태를 변경하는 기능을 구현

## 본문

 `PUT /oneseo/v3/status/{memberId}` 원서의 상태를 변경하는 기능을 구현하였습니다.