### PR TITLE
[oneseo] 원서 최종제출 기능 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/application/controller/ApplicationController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/controller/ApplicationController.java
@@ -21,7 +21,7 @@ import jakarta.validation.Valid;
 import team.themoment.hellogsmv3.domain.application.dto.request.ApplicationReqDto;
 import team.themoment.hellogsmv3.domain.application.service.CreateApplicationService;
 import team.themoment.hellogsmv3.domain.application.service.ModifyApplicationService;
-import team.themoment.hellogsmv3.domain.application.service.UpdateFinalSubmissionService;
+import team.themoment.hellogsmv3.domain.application.service.UpdateApplicationFinalSubmissionService;
 import team.themoment.hellogsmv3.domain.application.service.UpdateApplicationStatusService;
 
 
@@ -37,7 +37,7 @@ public class ApplicationController {
     private final QueryAllApplicationService queryAllApplicationService;
     private final CreateApplicationService createApplicationService;
     private final ModifyApplicationService modifyApplicationService;
-    private final UpdateFinalSubmissionService updateFinalSubmissionService;
+    private final UpdateApplicationFinalSubmissionService updateFinalSubmissionService;
     private final UpdateApplicationStatusService updateApplicationStatusService;
     private final QueryAdmissionTicketsService queryAdmissionTicketsService;
     private final DeleteApplicationByAuthIdService deleteApplicationByAuthIdService;

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/service/UpdateApplicationFinalSubmissionService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/service/UpdateApplicationFinalSubmissionService.java
@@ -12,7 +12,7 @@ import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
 @RequiredArgsConstructor
-public class UpdateFinalSubmissionService {
+public class UpdateApplicationFinalSubmissionService {
 
     private final ApplicantService applicantService;
     private final ApplicationRepository applicationRepository;

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -47,7 +47,7 @@ public class OneseoController {
     }
 
     @PatchMapping("/final-submit")
-    public CommonApiResponse finalSubmission(
+    public CommonApiResponse finalSubmit(
             @AuthRequest Long memberId
     ) {
         updateFinalSubmissionService.execute(memberId);

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.*;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.service.CreateOneseoService;
 import team.themoment.hellogsmv3.domain.oneseo.service.ModifyOneseoService;
+import team.themoment.hellogsmv3.domain.oneseo.service.UpdateFinalSubmissionService;
 import team.themoment.hellogsmv3.global.common.handler.annotation.AuthRequest;
 import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 
@@ -16,6 +17,7 @@ public class OneseoController {
 
     private final CreateOneseoService createOneseoService;
     private final ModifyOneseoService modifyOneseoService;
+    private final UpdateFinalSubmissionService updateFinalSubmissionService;
 
     @PostMapping("/oneseo/me")
     public CommonApiResponse create(
@@ -41,6 +43,14 @@ public class OneseoController {
             @PathVariable("memberId") Long memberId
     ) {
         modifyOneseoService.execute(reqDto, memberId, true);
+        return CommonApiResponse.success("수정되었습니다.");
+    }
+
+    @PatchMapping("/final-submit")
+    public CommonApiResponse finalSubmission(
+            @AuthRequest Long memberId
+    ) {
+        updateFinalSubmissionService.execute(memberId);
         return CommonApiResponse.success("수정되었습니다.");
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
@@ -9,6 +9,8 @@ import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 
+import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.*;
+
 @Getter
 @Entity
 @Table(name = "tb_oneseo")
@@ -49,4 +51,8 @@ public class Oneseo {
     @Enumerated(EnumType.STRING)
     @Column(name = "applied_screening", nullable = false)
     private Screening appliedScreening;
+
+    public void updateFinalSubmission() {
+        this.finalSubmittedYn = YES;
+    }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/UpdateFinalSubmissionService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/UpdateFinalSubmissionService.java
@@ -1,0 +1,37 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.*;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateFinalSubmissionService {
+
+    private final MemberRepository memberRepository;
+    private final OneseoRepository oneseoRepository;
+
+    @Transactional
+    public void execute(Long memberId) {
+        Member currentMember = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ExpectedException("존재하지 않는 지원자입니다. member ID: " + memberId, HttpStatus.NOT_FOUND));
+        Oneseo oneseo = oneseoRepository.findByMember(currentMember)
+                .orElseThrow(() -> new ExpectedException("원서 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        if (oneseo.getFinalSubmittedYn().equals(YES))
+            throw new ExpectedException("이미 최종제출 되었습니다.", HttpStatus.BAD_REQUEST);
+
+        oneseo.updateFinalSubmission();
+        oneseoRepository.save(oneseo);
+    }
+
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -222,6 +222,9 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.PUT, "/oneseo/v3/oneseo/{memberId}").hasAnyAuthority(
                         Role.ADMIN.name()
                 )
+                .requestMatchers(HttpMethod.PUT, "/oneseo/v3/final-submit").hasAnyAuthority(
+                        Role.APPLICANT.name()
+                )
 
                 .anyRequest().permitAll()
         );


### PR DESCRIPTION
## 개요

원서 최종제출 기능을 추가하였습니다.

## 본문

- `/oneseo/v3/final-submission` 원서 최종제출 기능을 추가하였습니다.
- 기존 명세서와 구현에서는 해당 API의 HTTP 메서드가 `PUT`으로 매핑되어 있었는데 하나의 컬럼만 수정하기 때문에 `PATCH` 메서드가 더 적절한것 같아 `PATCH` 메서드로 매핑하였습니다. 의견 부탁드립니다!
