### PR TITLE
[oneseo] 원서접수번호 할당 구현

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
@@ -43,6 +43,10 @@ public class Oneseo {
     private YesNo finalSubmittedYn;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "wanted_screening", nullable = false)
+    private Screening wantedScreening;
+
+    @Enumerated(EnumType.STRING)
     @Column(name = "applied_screening", nullable = false)
     private Screening appliedScreening;
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
@@ -28,7 +28,7 @@ public class Oneseo {
     private Member member;
 
     @Column(name = "oneseo_submit_code")
-    private Long oneseoSubmitCode;
+    private String oneseoSubmitCode;
 
     @NotNull
     @Embedded
@@ -49,4 +49,11 @@ public class Oneseo {
     @Enumerated(EnumType.STRING)
     @Column(name = "applied_screening", nullable = false)
     private Screening appliedScreening;
+
+
+    public Oneseo setOneseoSubmitCode(String submitCode) {
+        this.oneseoSubmitCode = submitCode;
+
+        return this;
+    }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoRepository.java
@@ -3,10 +3,11 @@ package team.themoment.hellogsmv3.domain.oneseo.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.repository.custom.CustomOneseoRepository;
 
 import java.util.Optional;
 
-public interface OneseoRepository extends JpaRepository<Oneseo, Long> {
+public interface OneseoRepository extends JpaRepository<Oneseo, Long>, CustomOneseoRepository {
     boolean existsByMember(Member member);
     Optional<Oneseo> findByMember(Member member);
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
@@ -1,0 +1,8 @@
+package team.themoment.hellogsmv3.domain.oneseo.repository.custom;
+
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
+
+public interface CustomOneseoRepository {
+
+    Integer findMaxSubmitCodeByScreening(Screening screening);
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepositoryImpl.java
@@ -1,0 +1,26 @@
+package team.themoment.hellogsmv3.domain.oneseo.repository.custom;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
+
+import static team.themoment.hellogsmv3.domain.oneseo.entity.QOneseo.oneseo;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomOneseoRepositoryImpl implements CustomOneseoRepository{
+
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public Integer findMaxSubmitCodeByScreening(Screening screening) {
+        return queryFactory
+                .select(oneseo.oneseoSubmitCode.substring(2).castToNum(Integer.class))
+                .from(oneseo)
+                .where(oneseo.appliedScreening.eq(screening))
+                .orderBy(oneseo.oneseoSubmitCode.substring(2).castToNum(Integer.class).desc())
+                .fetchFirst();
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnService.java
@@ -46,6 +46,11 @@ public class ModifyRealOneseoArrivedYnService {
     }
 
     private void assignSubmitCode(Oneseo oneseo) {
+        if (oneseo.getRealOneseoArrivedYn().equals(YesNo.NO)) {
+            oneseo.setOneseoSubmitCode(null);
+            return;
+        }
+
         Integer maxSubmitCodeNumber = oneseoRepository.findMaxSubmitCodeByScreening(oneseo.getAppliedScreening());
         int newSubmitCodeNumber = (maxSubmitCodeNumber != null ? maxSubmitCodeNumber : 0) + 1;
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnService.java
@@ -52,18 +52,10 @@ public class ModifyRealOneseoArrivedYnService {
         String submitCode;
         ScreeningCategory screeningCategory = oneseo.getAppliedScreening().getScreeningCategory();
         switch (screeningCategory) {
-            case GENERAL -> {
-                submitCode = "A-" + newSubmitCodeNumber;
-            }
-            case SPECIAL -> {
-                submitCode = "B-" + newSubmitCodeNumber;
-            }
-            case EXTRA -> {
-                submitCode = "C-" + newSubmitCodeNumber;
-            }
-            default -> {
-                throw new IllegalArgumentException("Unexpected value: " + screeningCategory);
-            }
+            case GENERAL -> submitCode = "A-" + newSubmitCodeNumber;
+            case SPECIAL -> submitCode = "B-" + newSubmitCodeNumber;
+            case EXTRA -> submitCode = "C-" + newSubmitCodeNumber;
+            default -> throw new IllegalArgumentException("Unexpected value: " + screeningCategory);
         }
 
         oneseo.setOneseoSubmitCode(submitCode);


### PR DESCRIPTION
## 개요

실물서류 접수가 완료되면 원서접수번호를 할당하는 로직을 구현하였습니다.

<br>

## 본문

- 실물서류접수 상태 컬럼인 realOneseoArrivedYn가 YES로 전환 후 접수번호 할당을 합니다.  
- 변경된 접수번호 포맷에 맞게 oneseoSubmitCode 타입을 Long에서 String으로 변경하였습니다.

<br>

**접수번호 매커니즘**

전형별로 prefix를 가집니다.  (ex. A-12)
일반전형 = A- , 특별전형 = B- , 정원외전형 = C- 

번호는 db에서 전형별로 max값을 가져와 1을 더한값을 사용합니다. (해당 쿼리는 queryDsl로 구현)