### PR TITLE
[oneseo] 원서 추가, 수정시 중학교 성적 필드 네이밍 변경

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
@@ -48,7 +48,7 @@ public record OneseoReqDto(
         @NotNull
         Major thirdDesiredMajor,
 
-        MiddleSchoolAchievementReqDto transcript,
+        MiddleSchoolAchievementReqDto middleSchoolAchievement,
 
         String schoolName,
 


### PR DESCRIPTION
## 개요

원서 추가, 삭제시 중학교 성적 필드 네이밍을 `transcript` → `middleSchoolAchievement`로 변경하였습니다.