### PR TITLE
[oneseo] EntranceTestFactorsDetail 검정고시 관련 필드 삭제

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestFactorsDetail.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestFactorsDetail.java
@@ -51,12 +51,6 @@ public class EntranceTestFactorsDetail {
     @Column(name = "score_3_1")
     private BigDecimal score3_1;
 
-    @Column(name = "ged_total_score")
-    private BigDecimal gedTotalScore;
-
-    @Column(name = "ged_max_score")
-    private BigDecimal gedMaxScore;
-
     @Column(name = "percentile_rank")
     private BigDecimal percentileRank;
 }


### PR DESCRIPTION
## 개요

MiddleSchoolAchievement에 검정고시 관련 필드와 EntranceTestFactorsDetail의 필드가 중복되기도 하고 2025 입학 전형에서는 검정고시도 일반교과, 비교과 환산 점수 산출식이 있기 때문에 EntranceTestFactorsDetail에 검정고시 관련 필드를 삭제하였습니다.