### PR TITLE
[member] 지원자 정보 조회 서비스 테스트코드 작성

### DIFF
--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdServiceTest.java
@@ -2,10 +2,21 @@ package team.themoment.hellogsmv3.domain.member.service;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberResDto;
+import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
 import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
 
 @DisplayName("QueryMemberByIdService 클래스의")
 class QueryMemberByIdServiceTest {
@@ -19,5 +30,43 @@ class QueryMemberByIdServiceTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
+    }
+
+    @Nested
+    @DisplayName("execute 메소드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("존재하는 회원 ID가 주어지면")
+        class Context_with_existing_member_id {
+
+            private final Long memberId = 1L;
+            private Member member;
+
+            @BeforeEach
+            void setUp() {
+                member = Member.builder()
+                        .id(memberId)
+                        .name("최장우")
+                        .birth(LocalDate.of(2006, 3, 6))
+                        .phoneNumber("01012345678")
+                        .sex(Sex.MALE)
+                        .build();
+
+                given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+            }
+
+            @Test
+            @DisplayName("회원 정보를 반환한다")
+            void it_returns_member_info() {
+                FoundMemberResDto result = queryMemberByIdService.execute(memberId);
+
+                assertEquals(memberId, result.memberId());
+                assertEquals("최장우", result.name());
+                assertEquals(LocalDate.of(2006, 3, 6), result.birth());
+                assertEquals("01012345678", result.phoneNumber());
+                assertEquals(Sex.MALE, result.sex());
+            }
+        }
     }
 }

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdServiceTest.java
@@ -43,11 +43,10 @@ class QueryMemberByIdServiceTest {
         class Context_with_existing_member_id {
 
             private final Long memberId = 1L;
-            private Member member;
 
             @BeforeEach
             void setUp() {
-                member = Member.builder()
+                Member member = Member.builder()
                         .id(memberId)
                         .name("최장우")
                         .birth(LocalDate.of(2006, 3, 6))

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdServiceTest.java
@@ -38,11 +38,11 @@ class QueryMemberByIdServiceTest {
     @DisplayName("execute 메소드는")
     class Describe_execute {
 
+        private final Long memberId = 1L;
+
         @Nested
         @DisplayName("존재하는 회원 ID가 주어지면")
         class Context_with_existing_member_id {
-
-            private final Long memberId = 1L;
 
             @BeforeEach
             void setUp() {
@@ -73,8 +73,6 @@ class QueryMemberByIdServiceTest {
         @Nested
         @DisplayName("존재하지 않는 회원 ID가 주어지면")
         class Context_with_non_existing_member_id {
-
-            private final Long memberId = 2L;
 
             @BeforeEach
             void setUp() {

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdServiceTest.java
@@ -1,0 +1,23 @@
+package team.themoment.hellogsmv3.domain.member.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
+
+@DisplayName("QueryMemberByIdService 클래스의")
+class QueryMemberByIdServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private QueryMemberByIdService queryMemberByIdService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+}

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdServiceTest.java
@@ -44,9 +44,11 @@ class QueryMemberByIdServiceTest {
         @DisplayName("존재하는 회원 ID가 주어지면")
         class Context_with_existing_member_id {
 
+            private Member member;
+
             @BeforeEach
             void setUp() {
-                Member member = Member.builder()
+                member = Member.builder()
                         .id(memberId)
                         .name("최장우")
                         .birth(LocalDate.of(2006, 3, 6))
@@ -62,11 +64,11 @@ class QueryMemberByIdServiceTest {
             void it_returns_member_info() {
                 FoundMemberResDto result = queryMemberByIdService.execute(memberId);
 
-                assertEquals(memberId, result.memberId());
-                assertEquals("최장우", result.name());
-                assertEquals(LocalDate.of(2006, 3, 6), result.birth());
-                assertEquals("01012345678", result.phoneNumber());
-                assertEquals(Sex.MALE, result.sex());
+                assertEquals(member.getId(), result.memberId());
+                assertEquals(member.getName(), result.name());
+                assertEquals(member.getBirth(), result.birth());
+                assertEquals(member.getPhoneNumber(), result.phoneNumber());
+                assertEquals(member.getSex(), result.sex());
             }
         }
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMemberByIdServiceTest.java
@@ -7,10 +7,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberResDto;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
 import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.time.LocalDate;
 import java.util.Optional;
@@ -66,6 +68,29 @@ class QueryMemberByIdServiceTest {
                 assertEquals(LocalDate.of(2006, 3, 6), result.birth());
                 assertEquals("01012345678", result.phoneNumber());
                 assertEquals(Sex.MALE, result.sex());
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 회원 ID가 주어지면")
+        class Context_with_non_existing_member_id {
+
+            private final Long memberId = 2L;
+
+            @BeforeEach
+            void setUp() {
+                given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+            }
+
+            @Test
+            @DisplayName("ExpectedException을 던진다")
+            void it_throws_expected_exception() {
+                ExpectedException exception = assertThrows(ExpectedException.class, () -> {
+                    queryMemberByIdService.execute(memberId);
+                });
+
+                assertEquals("존재하지 않는 지원자입니다. member ID: " + memberId, exception.getMessage());
+                assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
             }
         }
     }


### PR DESCRIPTION
## 개요

지원자 정보 조회 서비스인 `QueryMemberByIdServic`의 단위테스트를 작성하였습니다.

## 본문

test case
- QueryMemberByIdService 클래스의 execute 메소드는 존재하는 회원 ID가 주어지면 회원 정보를 반환한다.
- QueryMemberByIdService 클래스의 execute 메소드는존재하지 않는 회원 ID가 주어지면 ExpectedException을 던진다. 

<br>

<img width="282" alt="image" src="https://github.com/user-attachments/assets/09eb92e7-55e7-4396-9108-008f2c82a99d">
