### PR TITLE
[member] 인증코드 관련 서비스 테스트코드 작성

### DIFF
--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
@@ -43,6 +43,7 @@ class CommonCodeServiceTest {
         private final String validCode = "validCode";
         private final String validPhoneNumber = "010-1234-5678";
         private final String invalidCode = "invalidCode";
+        private final String invalidPhoneNumber = "010-8765-4321";
         private AuthenticationCode authenticationCode;
 
         @BeforeEach
@@ -134,6 +135,28 @@ class CommonCodeServiceTest {
                 });
 
                 assertEquals("유효하지 않은 요청입니다. 이전 혹은 잘못된 형식의 code입니다.", exception.getMessage());
+                assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+            }
+        }
+
+        @Nested
+        @DisplayName("잘못된 전화번호가 주어지면")
+        class Context_with_invalid_phone_number {
+
+            @BeforeEach
+            void setUp() {
+                authenticationCode.authenticatedAuthenticationCode();
+                given(codeRepository.findByMemberId(memberId)).willReturn(Optional.of(authenticationCode));
+            }
+
+            @Test
+            @DisplayName("ExpectedException을 던진다")
+            void it_throws_expected_exception() {
+                ExpectedException exception = assertThrows(ExpectedException.class, () -> {
+                    commonCodeService.validateAndDelete(memberId, validCode, invalidPhoneNumber);
+                });
+
+                assertEquals("유효하지 않은 요청입니다. code인증에 사용되었던 전화번호와 요청에 사용한 전화번호가 일치하지 않습니다.", exception.getMessage());
                 assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
             }
         }

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
@@ -42,6 +42,7 @@ class CommonCodeServiceTest {
         private final Long memberId = 1L;
         private final String validCode = "validCode";
         private final String validPhoneNumber = "010-1234-5678";
+        private final String invalidCode = "invalidCode";
         private AuthenticationCode authenticationCode;
 
         @BeforeEach
@@ -111,6 +112,28 @@ class CommonCodeServiceTest {
                 });
 
                 assertEquals("유효하지 않은 요청입니다. 인증받지 않은 code입니다.", exception.getMessage());
+                assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+            }
+        }
+
+        @Nested
+        @DisplayName("잘못된 코드가 주어지면")
+        class Context_with_invalid_code {
+
+            @BeforeEach
+            void setUp() {
+                authenticationCode.authenticatedAuthenticationCode();
+                given(codeRepository.findByMemberId(memberId)).willReturn(Optional.of(authenticationCode));
+            }
+
+            @Test
+            @DisplayName("ExpectedException을 던진다")
+            void it_throws_expected_exception_when_code_is_invalid() {
+                ExpectedException exception = assertThrows(ExpectedException.class, () -> {
+                    commonCodeService.validateAndDelete(memberId, invalidCode, validPhoneNumber);
+                });
+
+                assertEquals("유효하지 않은 요청입니다. 이전 혹은 잘못된 형식의 code입니다.", exception.getMessage());
                 assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
             }
         }

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
@@ -93,5 +93,26 @@ class CommonCodeServiceTest {
                 assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
             }
         }
+
+        @Nested
+        @DisplayName("인증코드가 인증받지 않았다면")
+        class Context_with_unauthenticated_code {
+
+            @BeforeEach
+            void setUp() {
+                given(codeRepository.findByMemberId(memberId)).willReturn(Optional.of(authenticationCode));
+            }
+
+            @Test
+            @DisplayName("ExpectedException을 던진다")
+            void it_throws_expected_exception_when_code_is_not_authenticated() {
+                ExpectedException exception = assertThrows(ExpectedException.class, () -> {
+                    commonCodeService.validateAndDelete(memberId, validCode, validPhoneNumber);
+                });
+
+                assertEquals("유효하지 않은 요청입니다. 인증받지 않은 code입니다.", exception.getMessage());
+                assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+            }
+        }
     }
 }

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
@@ -7,12 +7,17 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -65,6 +70,27 @@ class CommonCodeServiceTest {
                 commonCodeService.validateAndDelete(memberId, validCode, validPhoneNumber);
 
                 verify(codeRepository).delete(authenticationCode);
+            }
+        }
+
+        @Nested
+        @DisplayName("인증 코드가 존재하지 않으면")
+        class Context_with_non_existing_code {
+
+            @BeforeEach
+            void setUp() {
+                given(codeRepository.findByMemberId(anyLong())).willReturn(Optional.empty());
+            }
+
+            @Test
+            @DisplayName("ExpectedException을 던진다")
+            void it_throws_expected_exception() {
+                ExpectedException exception = assertThrows(ExpectedException.class, () -> {
+                    commonCodeService.validateAndDelete(memberId, validCode, validPhoneNumber);
+                });
+
+                assertEquals("사용자의 code가 존재하지 않습니다. 사용자의 ID : " + memberId, exception.getMessage());
+                assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
             }
         }
     }

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
@@ -1,0 +1,71 @@
+package team.themoment.hellogsmv3.domain.member.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("CommonCodeService 클래스의")
+class CommonCodeServiceTest {
+
+    @Mock
+    private CodeRepository codeRepository;
+
+    @InjectMocks
+    private CommonCodeService commonCodeService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Nested
+    @DisplayName("validateAndDelete 메소드는")
+    class Describe_validateAndDelete {
+
+        private final Long memberId = 1L;
+        private final String validCode = "validCode";
+        private final String validPhoneNumber = "010-1234-5678";
+        private AuthenticationCode authenticationCode;
+
+        @BeforeEach
+        void setUp() {
+            authenticationCode = new AuthenticationCode(
+                    memberId,
+                    validCode,
+                    validPhoneNumber,
+                    LocalDateTime.now()
+            );
+        }
+
+        @Nested
+        @DisplayName("유효한 회원 ID와 코드와 전화번호가 주어지면")
+        class Context_with_valid_code_and_phone_number {
+
+            @BeforeEach
+            void setUp() {
+                authenticationCode.authenticatedAuthenticationCode();
+                given(codeRepository.findByMemberId(memberId)).willReturn(Optional.of(authenticationCode));
+            }
+
+            @Test
+            @DisplayName("코드를 삭제한다")
+            void it_deletes_the_code() {
+                commonCodeService.validateAndDelete(memberId, validCode, validPhoneNumber);
+
+                verify(codeRepository).delete(authenticationCode);
+            }
+        }
+    }
+}

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
@@ -41,9 +41,9 @@ class CommonCodeServiceTest {
 
         private final Long memberId = 1L;
         private final String validCode = "validCode";
-        private final String validPhoneNumber = "010-1234-5678";
+        private final String validPhoneNumber = "01012345678";
         private final String invalidCode = "invalidCode";
-        private final String invalidPhoneNumber = "010-8765-4321";
+        private final String invalidPhoneNumber = "01087654321";
         private AuthenticationCode authenticationCode;
 
         @BeforeEach


### PR DESCRIPTION
## 개요

인증코드 관련 서비스인 `CommonCodeService`의 단위테스트를 작성하였습니다. 

## 본문

test case
- CommonCodeService 클래스의 validateAndDelete 메소드는 유효한 회원 ID와 코드와 전화번호가 주어지면 코드를 삭제한다
- CommonCodeService 클래스의 validateAndDelete 메소드는 인증 코드가 존재하지 않으면 ExpectedException을 던진다
- CommonCodeService 클래스의 validateAndDelete 메소드는 인증코드가 인증받지 않았다면 ExpectedException을 던진다
- CommonCodeService 클래스의 validateAndDelete 메소드는 잘못된 코드가 주어지면 ExpectedException을 던진다
- CommonCodeService 클래스의 validateAndDelete 메소드는 잘못된 전화번호가 주어지면 ExpectedException을 던진다

<br>

<img width="320" alt="image" src="https://github.com/user-attachments/assets/cb4ac971-b31c-4f1e-9d38-fab237cdccf9">
