### PR TITLE
[member] 회원가입 서비스 테스트코드 작성

### DIFF
--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberServiceTest.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
 
 @DisplayName("CreateMemberService 클래스의")
@@ -69,7 +69,7 @@ class CreateMemberServiceTest {
                         .authReferrerType(AuthReferrerType.GOOGLE)
                         .build();
                 given(memberRepository.findById(memberId)).willReturn(Optional.of(existingMember));
-                doNothing().when(commonCodeService).validateAndDelete(memberId, reqDto.code(), reqDto.phoneNumber());
+                willDoNothing().given(commonCodeService).validateAndDelete(memberId, reqDto.code(), reqDto.phoneNumber());
             }
 
             @Test
@@ -98,7 +98,7 @@ class CreateMemberServiceTest {
             @BeforeEach
             void setUp() {
                 given(memberRepository.findById(memberId)).willReturn(Optional.empty());
-                doNothing().when(commonCodeService).validateAndDelete(memberId, reqDto.code(), reqDto.phoneNumber());
+                willDoNothing().given(commonCodeService).validateAndDelete(memberId, reqDto.code(), reqDto.phoneNumber());
             }
 
             @Test


### PR DESCRIPTION
## 개요

회원가입 서비스인 `CreateMemberService`의 단위테스트를 작성하였습니다.

## 본문

test case
- CreateMemberService 클래스의 execute 메소드는 유효한 회원 ID와 요청 데이터가 주어지면 새로운 회원을 생성하고 저장 후 Role을 반환한다
- CreateMemberService 클래스의 execute 메소드는 회원 ID가 유효하지 않으면 ExpectedException을 던진다

<br>

<img width="350" alt="image" src="https://github.com/user-attachments/assets/2784abd7-2c88-4f92-9dfe-971fe3b13a69">
