### PR TITLE
[oneseo] 원서 정보 검색 서비스 테스트코드 작성

### DIFF
--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
@@ -33,7 +33,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 @DisplayName("SearchOneseoService 클래스의")
-class SearchOneseoServiceAdditionalTests {
+class SearchOneseoServiceTest {
 
     @Mock
     private OneseoRepository oneseoRepository;

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
@@ -1,0 +1,84 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import team.themoment.hellogsmv3.domain.application.type.ScreeningCategory;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.TestResultTag;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.SearchOneseosResDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
+import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRepository;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+
+@DisplayName("SearchOneseoService 클래스의")
+class SearchOneseoServiceAdditionalTests {
+
+    @Mock
+    private OneseoRepository oneseoRepository;
+
+    @Mock
+    private OneseoPrivacyDetailRepository oneseoPrivacyDetailRepository;
+
+    @Mock
+    private EntranceTestResultRepository entranceTestResultRepository;
+
+    @InjectMocks
+    private SearchOneseoService searchOneseoService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Nested
+    @DisplayName("execute 메소드는")
+    class Describe_execute {
+
+        private final int page = 0;
+        private final int size = 10;
+        private final TestResultTag testResultTag = TestResultTag.ALL;
+        private final ScreeningCategory screeningTag = ScreeningCategory.GENERAL;
+        private final YesNo isSubmitted = YesNo.YES;
+        private final String keyword = "홍길동";
+
+        @Nested
+        @DisplayName("검색 결과가 없을 때")
+        class Context_with_no_search_results {
+
+            @BeforeEach
+            void setUp() {
+                Pageable pageable = PageRequest.of(page, size);
+                Page<Oneseo> emptyPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
+
+                given(oneseoRepository.findAllByKeywordAndScreeningAndSubmissionStatusAndTestResult(
+                        keyword, screeningTag, isSubmitted, testResultTag, pageable
+                )).willReturn(emptyPage);
+            }
+
+            @Test
+            @DisplayName("빈 결과를 반환한다")
+            void it_returns_empty_result() {
+                SearchOneseosResDto result = searchOneseoService.execute(page, size, testResultTag, screeningTag, isSubmitted, keyword);
+
+                assertEquals(0, result.info().totalElements());
+                assertEquals(0, result.info().totalPages());
+                assertEquals(0, result.oneseos().size());
+            }
+        }
+    }
+}

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Pageable;
 import team.themoment.hellogsmv3.domain.application.type.ScreeningCategory;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.TestResultTag;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.SearchOneseoPageInfoDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.SearchOneseoResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.SearchOneseosResDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
@@ -95,6 +97,7 @@ class SearchOneseoServiceTest {
             private Member member;
             private Oneseo oneseo;
             private OneseoPrivacyDetail oneseoPrivacyDetail;
+            private EntranceTestResult entranceTestResult;
 
             @BeforeEach
             void setUp() {
@@ -104,7 +107,7 @@ class SearchOneseoServiceTest {
                 Page<Oneseo> oneseoPage = new PageImpl<>(List.of(oneseo), pageable, 1);
 
                 oneseoPrivacyDetail = buildOneseoPrivacyDetail();
-                EntranceTestResult entranceTestResult = mock(EntranceTestResult.class);
+                entranceTestResult = mock(EntranceTestResult.class);
 
                 given(oneseoRepository.findAllByKeywordAndScreeningAndSubmissionStatusAndTestResult(
                         keyword, screeningTag, isSubmitted, testResultTag, pageable
@@ -119,16 +122,24 @@ class SearchOneseoServiceTest {
             void it_returns_filtered_results() {
                 SearchOneseosResDto result = searchOneseoService.execute(page, size, testResultTag, screeningTag, isSubmitted, keyword);
 
-                assertEquals(1, result.info().totalElements());
-                assertEquals(1, result.info().totalPages());
-                assertEquals(1, result.oneseos().size());
+                SearchOneseoPageInfoDto searchOneseoPageInfoDto = result.info();
+                assertEquals(1, searchOneseoPageInfoDto.totalElements());
+                assertEquals(1, searchOneseoPageInfoDto.totalPages());
 
-                assertEquals(member.getName(), result.oneseos().get(0).name());
-                assertEquals(member.getPhoneNumber(), result.oneseos().get(0).phoneNumber());
-                assertEquals(oneseo.getOneseoSubmitCode(), result.oneseos().get(0).submitCode());
-                assertEquals(oneseo.getAppliedScreening(), result.oneseos().get(0).screening());
-                assertEquals(oneseoPrivacyDetail.getSchoolName(), result.oneseos().get(0).schoolName());
-                assertEquals(oneseoPrivacyDetail.getGuardianPhoneNumber(), result.oneseos().get(0).guardianPhoneNumber());
+                SearchOneseoResDto searchOneseoResDto = result.oneseos().get(0);
+                assertEquals(member.getId(), searchOneseoResDto.memberId());
+                assertEquals(oneseo.getOneseoSubmitCode(), searchOneseoResDto.submitCode());
+                assertEquals(oneseo.getRealOneseoArrivedYn(), searchOneseoResDto.realOneseoArrivedYn());
+                assertEquals(member.getName(), searchOneseoResDto.name());
+                assertEquals(oneseo.getAppliedScreening(), searchOneseoResDto.screening());
+                assertEquals(oneseoPrivacyDetail.getSchoolName(), searchOneseoResDto.schoolName());
+                assertEquals(member.getPhoneNumber(), searchOneseoResDto.phoneNumber());
+                assertEquals(oneseoPrivacyDetail.getGuardianPhoneNumber(), searchOneseoResDto.guardianPhoneNumber());
+                assertEquals(oneseoPrivacyDetail.getSchoolTeacherPhoneNumber(), searchOneseoResDto.schoolTeacherPhoneNumber());
+                assertEquals(entranceTestResult.getFirstTestPassYn(), searchOneseoResDto.firstTestPassYn());
+                assertEquals(entranceTestResult.getAptitudeEvaluationScore(), searchOneseoResDto.aptitudeEvaluationScore());
+                assertEquals(entranceTestResult.getInterviewScore(), searchOneseoResDto.interviewScore());
+                assertEquals(entranceTestResult.getSecondTestPassYn(), searchOneseoResDto.secondTestPassYn());
             }
         }
     }


### PR DESCRIPTION
## 개요

원서 정보 검색 서비스인 `SearchOneseoService`의 단위테스트를 작성하였습니다.

## 본문

test case
- SearchOneseoService 클래스의 execute 메소드는 검색 결과가 없을 때 빈 결과를 반환한다
- SearchOneseoService 클래스의 execute 메소드는 필터링 조건에 따라 적절한 데이터를 반환한다

<br>

<img width="257" alt="image" src="https://github.com/user-attachments/assets/6f26a20e-abc8-45bb-bbd3-6fc0a3126bbb">
