### PR TITLE
[member] 인증코드 전송 서비스 테스트코드 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/member/entity/AuthenticationCode.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/entity/AuthenticationCode.java
@@ -23,20 +23,20 @@ public class AuthenticationCode {
     private LocalDateTime createdAt;
     private int count;
 
-    public AuthenticationCode updatedCode(String code, LocalDateTime createdAt, Boolean isTest) {
+    public AuthenticationCode updatedCode(String code, LocalDateTime createdAt, boolean isTest) {
         this.code = code;
         this.createdAt = createdAt;
         this.count = !isTest ? (count + 1) : 0; // 테스트 상황이라면 count가 증가하지 않음
         return this;
     }
 
-    public AuthenticationCode(Long memberId, String code, String phoneNumber, LocalDateTime createdAt) {
+    public AuthenticationCode(Long memberId, String code, String phoneNumber, LocalDateTime createdAt, boolean isTest) {
         this.memberId = memberId;
         this.code = code;
         this.authenticated = false;
         this.phoneNumber = phoneNumber;
         this.createdAt = createdAt;
-        this.count = 1;
+        this.count = !isTest ? 1 : 0;
     }
 
     public void authenticatedAuthenticationCode() {

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/GenerateCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/GenerateCodeService.java
@@ -22,7 +22,7 @@ public abstract class GenerateCodeService {
             boolean isTest) {
 
         return authCode == null ?
-                new AuthenticationCode(memberId, code, phoneNumber, LocalDateTime.now()) :
+                new AuthenticationCode(memberId, code, phoneNumber, LocalDateTime.now(), isTest) :
                 authCode.updatedCode(code, LocalDateTime.now(), isTest);
     }
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImplTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImplTest.java
@@ -1,0 +1,92 @@
+package team.themoment.hellogsmv3.domain.member.service.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.http.HttpStatus;
+import team.themoment.hellogsmv3.domain.member.dto.request.GenerateCodeReqDto;
+import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@DisplayName("GenerateCodeServiceImpl 클래스의")
+class GenerateCodeServiceImplTest {
+
+    @Mock
+    private CodeRepository codeRepository;
+
+    @InjectMocks
+    private GenerateCodeServiceImpl generateCodeServiceImpl;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        private final Long memberId = 1L;
+        private final GenerateCodeReqDto reqDto = new GenerateCodeReqDto("01012345678");
+
+        @Nested
+        @DisplayName("유효한 요청이 주어지면")
+        class Context_with_valid_request {
+
+            @BeforeEach
+            void setUp() {
+                given(codeRepository.findByMemberId(memberId)).willReturn(Optional.empty());
+                given(codeRepository.findByCode(anyString())).willReturn(Optional.empty());
+            }
+
+            @Test
+            @DisplayName("새로운 코드를 생성하고 저장한다")
+            void it_generates_and_saves_a_new_code() {
+                String code = generateCodeServiceImpl.execute(memberId, reqDto);
+
+                assertNotNull(code);
+                assertEquals(6, code.length());
+
+                ArgumentCaptor<AuthenticationCode> authCodeCaptor = ArgumentCaptor.forClass(AuthenticationCode.class);
+                verify(codeRepository).save(authCodeCaptor.capture());
+                AuthenticationCode savedAuthCode = authCodeCaptor.getValue();
+
+                assertEquals(memberId, savedAuthCode.getMemberId());
+                assertEquals(reqDto.phoneNumber(), savedAuthCode.getPhoneNumber());
+                assertEquals(code, savedAuthCode.getCode());
+            }
+        }
+
+        @Nested
+        @DisplayName("요청 제한 횟수를 초과하면")
+        class Context_with_exceeded_request_limit {
+
+            @Mock
+            private AuthenticationCode existingCode;
+
+            @BeforeEach
+            void setUp() {
+                existingCode = mock(AuthenticationCode.class);
+                given(codeRepository.findByMemberId(memberId)).willReturn(Optional.of(existingCode));
+                given(existingCode.getCount()).willReturn(5);
+            }
+
+            @Test
+            @DisplayName("예외를 던진다")
+            void it_throws_an_exception() {
+                ExpectedException exception = assertThrows(ExpectedException.class, () -> generateCodeServiceImpl.execute(memberId, reqDto));
+                assertEquals("너무 많은 요청이 발생했습니다. 잠시 후 다시 시도해주세요. 특정 시간 내 제한 횟수인 5회를 초과하였습니다.", exception.getMessage());
+                assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+            }
+        }
+    }
+}

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImplTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImplTest.java
@@ -63,6 +63,7 @@ class GenerateCodeServiceImplTest {
                 assertEquals(memberId, savedAuthCode.getMemberId());
                 assertEquals(reqDto.phoneNumber(), savedAuthCode.getPhoneNumber());
                 assertEquals(code, savedAuthCode.getCode());
+                assertEquals(1, savedAuthCode.getCount());
             }
         }
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImplTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImplTest.java
@@ -81,7 +81,7 @@ class GenerateCodeServiceImplTest {
             }
 
             @Test
-            @DisplayName("예외를 던진다")
+            @DisplayName("ExpectedException을 던진다")
             void it_throws_an_exception() {
                 ExpectedException exception = assertThrows(ExpectedException.class, () -> generateCodeServiceImpl.execute(memberId, reqDto));
                 assertEquals("너무 많은 요청이 발생했습니다. 잠시 후 다시 시도해주세요. 특정 시간 내 제한 횟수인 5회를 초과하였습니다.", exception.getMessage());

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImplTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImplTest.java
@@ -1,0 +1,68 @@
+package team.themoment.hellogsmv3.domain.member.service.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import team.themoment.hellogsmv3.domain.member.dto.request.GenerateCodeReqDto;
+import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@DisplayName("GenerateTestCodeServiceImpl 클래스의")
+class GenerateTestCodeServiceImplTest {
+
+    @Mock
+    private CodeRepository codeRepository;
+
+    @InjectMocks
+    private GenerateTestCodeServiceImpl generateTestCodeServiceImpl;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        private final Long memberId = 1L;
+        private final GenerateCodeReqDto reqDto = new GenerateCodeReqDto("01012345678");
+
+        @Nested
+        @DisplayName("유효한 요청이 주어지면")
+        class Context_with_valid_request {
+
+            @BeforeEach
+            void setUp() {
+                given(codeRepository.findByMemberId(memberId)).willReturn(Optional.empty());
+                given(codeRepository.findByCode(anyString())).willReturn(Optional.empty());
+            }
+
+            @Test
+            @DisplayName("새로운 테스트 코드를 생성하고 저장한다")
+            void it_generates_and_saves_a_new_test_code() {
+                String code = generateTestCodeServiceImpl.execute(memberId, reqDto);
+
+                assertNotNull(code);
+                assertEquals(6, code.length());
+
+                ArgumentCaptor<AuthenticationCode> authCodeCaptor = ArgumentCaptor.forClass(AuthenticationCode.class);
+                verify(codeRepository).save(authCodeCaptor.capture());
+                AuthenticationCode savedAuthCode = authCodeCaptor.getValue();
+
+                assertEquals(memberId, savedAuthCode.getMemberId());
+                assertEquals(reqDto.phoneNumber(), savedAuthCode.getPhoneNumber());
+                assertEquals(code, savedAuthCode.getCode());
+                assertEquals(0, savedAuthCode.getCount());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요

인증코드 전송 관련 서비스 로직의 테스트코드를 추가하였습니다.

## 본문
`GenerateCodeServiceImpl` 인증코드 전송, `GenerateTestCodeServiceImpl` 인증코드 테스트 전송에 관련된 테스트코드를 작성하였습니다.

`GenerateCodeServiceImpl`

<img width="320" alt="스크린샷 2024-07-27 오후 3 52 30" src="https://github.com/user-attachments/assets/bc6044c3-ba78-4c3a-82cf-41821aa12fc0">

- 유효한 요청이 주어지면
   - 새로운 인증코드를 생성하고 저장
- 요청 제한 횟수를 초과한다면
   - 예외를 던짐

`GenerateTestCodeServiceImpl`

<img width="344" alt="스크린샷 2024-07-27 오후 3 52 49" src="https://github.com/user-attachments/assets/bed0018a-db79-452c-8625-84b00980b458">

- 유효한 요청이 주어지면
   - 새로운 인증코드를 생성하고 저장 (테스트 전송이기 때문에 count는 0회)
