### PR TITLE
[oneseo] 심층면점 점수 기입 서비스 로직 테스트 코드 추가

### DIFF
--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyInterviewScoreServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyInterviewScoreServiceTest.java
@@ -1,0 +1,140 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.member.service.MemberService;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.InterviewScoreReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@DisplayName("ModifyInterviewScoreService 클래스의")
+class ModifyInterviewScoreServiceTest {
+
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private OneseoService oneseoService;
+
+    @Mock
+    private EntranceTestResultRepository entranceTestResultRepository;
+
+    @InjectMocks
+    private ModifyInterviewScoreService modifyInterviewScoreService;
+
+    private Long memberId;
+    private InterviewScoreReqDto reqDto;
+    private Member member;
+    private Oneseo oneseo;
+    private EntranceTestResult entranceTestResult;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        memberId = 1L;
+        reqDto = new InterviewScoreReqDto(BigDecimal.valueOf(100));
+        member = mock(Member.class);
+        oneseo = mock(Oneseo.class);
+        entranceTestResult = mock(EntranceTestResult.class);
+    }
+
+    @Nested
+    @DisplayName("execute 메소드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("해당 memberId로 회원을 찾을 수 없는 경우")
+        class Context_when_member_not_found {
+
+            @BeforeEach
+            void setUp() {
+                given(memberService.findByIdOrThrow(memberId)).willThrow(new ExpectedException("존재하지 않는 지원자입니다. member ID: " + memberId, HttpStatus.NOT_FOUND));
+            }
+
+            @Test
+            @DisplayName("ExpectedException을 던진다")
+            void it_throws_ExpectedException() {
+                ExpectedException exception = assertThrows(ExpectedException.class, () -> modifyInterviewScoreService.execute(memberId, reqDto));
+                assertEquals("존재하지 않는 지원자입니다. member ID: " + memberId, exception.getMessage());
+                assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+            }
+        }
+
+        @Nested
+        @DisplayName("해당 memberId로 원서를 찾을 수 없는 경우")
+        class Context_when_oneseo_not_found {
+
+            @BeforeEach
+            void setUp() {
+                given(memberService.findByIdOrThrow(memberId)).willReturn(member);
+                given(oneseoService.findByMemberOrThrow(member)).willThrow(new ExpectedException("해당 지원자의 원서를 찾을 수 없습니다. member ID: " + memberId, HttpStatus.NOT_FOUND));
+            }
+
+            @Test
+            @DisplayName("ExpectedException을 던진다")
+            void it_throws_ExpectedException() {
+                ExpectedException exception = assertThrows(ExpectedException.class, () -> modifyInterviewScoreService.execute(memberId, reqDto));
+                assertEquals("해당 지원자의 원서를 찾을 수 없습니다. member ID: " + memberId, exception.getMessage());
+                assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+            }
+        }
+
+        @Nested
+        @DisplayName("해당 원서의 입학 시험 결과를 찾을 수 없는 경우")
+        class Context_when_entrance_test_result_not_found {
+
+            @BeforeEach
+            void setUp() {
+                given(memberService.findByIdOrThrow(memberId)).willReturn(member);
+                given(oneseoService.findByMemberOrThrow(member)).willReturn(oneseo);
+                given(entranceTestResultRepository.findEntranceTestResultByOneseo(oneseo)).willReturn(Optional.empty());
+            }
+
+            @Test
+            @DisplayName("ExpectedException을 던진다")
+            void it_throws_ExpectedException() {
+                ExpectedException exception = assertThrows(ExpectedException.class, () -> modifyInterviewScoreService.execute(memberId, reqDto));
+                assertEquals("해당 지원자의 입학 시험 결과를 찾을 수 없습니다. member ID: " + memberId, exception.getMessage());
+                assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+            }
+        }
+
+        @Nested
+        @DisplayName("모든 유효성 검증이 성공한 경우")
+        class Context_with_valid_data {
+
+            @BeforeEach
+            void setUp() {
+                given(memberService.findByIdOrThrow(memberId)).willReturn(member);
+                given(oneseoService.findByMemberOrThrow(member)).willReturn(oneseo);
+                given(entranceTestResultRepository.findEntranceTestResultByOneseo(oneseo)).willReturn(Optional.of(entranceTestResult));
+            }
+
+            @Test
+            @DisplayName("인터뷰 점수를 수정하고 저장한다")
+            void it_modifies_and_saves_interview_score() {
+                modifyInterviewScoreService.execute(memberId, reqDto);
+
+                verify(entranceTestResult).modifyInterviewScore(reqDto.interviewScore());
+                verify(entranceTestResultRepository).save(entranceTestResult);
+            }
+        }
+    }
+}

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyInterviewScoreServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyInterviewScoreServiceTest.java
@@ -128,7 +128,7 @@ class ModifyInterviewScoreServiceTest {
             }
 
             @Test
-            @DisplayName("인터뷰 점수를 수정하고 저장한다")
+            @DisplayName("변경된 심층면점 점수를 수정하고 저장한다")
             void it_modifies_and_saves_interview_score() {
                 modifyInterviewScoreService.execute(memberId, reqDto);
 


### PR DESCRIPTION
## 개요

심층면점 점수 기입 서비스 로직 테스트코드를 작성하였습니다.

## 본문

<img width="359" alt="스크린샷 2024-07-28 오전 2 33 05" src="https://github.com/user-attachments/assets/b0c51b57-dd45-433e-86a5-113430d4c380">


- memberId로 회원을 찾을 수 없는 경우
   - ExpectedException을 던진다
- memberId로 조회한 member 엔티티로 원서를 찾을 수 없는 경우
   - ExpectedException을 던진다
- 해당 원서의 입학시험결과 엔티티를 찾을 수 없는 경우
   - ExpectedException을 던진다
- 모든 유효성 검사를 통과했다면
   - 변경된 심층면점점수를 수정하고 저장한다
