### PR TITLE
[member] 테스트코드 셋업과정에서 발생하는 오류 해결

### DIFF
--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
@@ -52,7 +52,8 @@ class CommonCodeServiceTest {
                     memberId,
                     validCode,
                     validPhoneNumber,
-                    LocalDateTime.now()
+                    LocalDateTime.now(),
+                    false
             );
         }
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberServiceTest.java
@@ -8,7 +8,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
-import team.themoment.hellogsmv3.domain.member.dto.CreateMemberReqDto;
+import team.themoment.hellogsmv3.domain.member.dto.request.CreateMemberReqDto;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.entity.type.AuthReferrerType;
 import team.themoment.hellogsmv3.domain.member.entity.type.Role;
@@ -67,6 +67,7 @@ class CreateMemberServiceTest {
                         .id(memberId)
                         .email("jangwooooo@example.com")
                         .authReferrerType(AuthReferrerType.GOOGLE)
+                        .role(Role.UNAUTHENTICATED)
                         .build();
                 given(memberRepository.findById(memberId)).willReturn(Optional.of(existingMember));
                 willDoNothing().given(commonCodeService).validateAndDelete(memberId, reqDto.code(), reqDto.phoneNumber());


### PR DESCRIPTION
## 본문

`CreateMemberServiceTest`와 `CommonCodeServiceTest`의 setUp 과정에서 발생하는 오류 해결
