### PR TITLE
[oneseo] 실물 원서 제출 여부 변경 테스트 코드 작성

### DIFF
--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.AptitudeEvaluationScoreReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.ArrivedStatusResDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
@@ -87,15 +88,16 @@ public class ModifyRealOneseoArrivedYnServiceTest {
 
             @BeforeEach
             void setUp() {
-                given(memberService.findByIdOrThrow(memberId)).willThrow(new ExpectedException("존재하지 않는 회원입니다.", HttpStatus.NOT_FOUND));
+                given(memberService.findByIdOrThrow(memberId)).willThrow(new ExpectedException("존재하지 않는 지원자입니다. member ID: ", HttpStatus.NOT_FOUND));
             }
 
             @Test
             @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception() {
+
                 ExpectedException exception = assertThrows(ExpectedException.class, () -> modifyRealOneseoArrivedYnService.execute(memberId));
 
-                assertEquals("존재하지 않는 회원입니다.", exception.getMessage());
+                assertEquals("존재하지 않는 지원자입니다. member ID: ", exception.getMessage());
                 assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
             }
         }

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnServiceTest.java
@@ -1,0 +1,103 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.member.service.MemberService;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.ArrivedStatusResDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("ModifyRealOneseoArrivedYnService 클래스의")
+public class ModifyRealOneseoArrivedYnServiceTest {
+
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private OneseoService oneseoService;
+
+    @Mock
+    private OneseoRepository oneseoRepository;
+
+    @InjectMocks
+    private ModifyRealOneseoArrivedYnService modifyRealOneseoArrivedYnService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Nested
+    @DisplayName("execute 메소드는")
+    class Describe_execute {
+        private final Long memberId = 1L;
+
+        @Nested
+        @DisplayName("존재하는 회원 ID가 주어지면")
+        class Context_with_existing_member_id {
+            Oneseo oneseo;
+
+            @BeforeEach
+            void setUp() {
+                Member member = Member.builder()
+                        .id(memberId)
+                        .build();
+
+                oneseo = Oneseo.builder()
+                        .member(member)
+                        .realOneseoArrivedYn(YesNo.NO)
+                        .appliedScreening(Screening.GENERAL)
+                        .build();
+
+                given(memberService.findByIdOrThrow(memberId)).willReturn(member);
+                given(oneseoService.findByMemberOrThrow(member)).willReturn(oneseo);
+                given(oneseoRepository.save(oneseo)).willReturn(oneseo);
+            }
+
+            @Test
+            @DisplayName("원서 도착 여부를 전환하고, 해당 정보를 반환한다.")
+            void it_switch_and_returns_arrived_status() {
+                ArrivedStatusResDto result = modifyRealOneseoArrivedYnService.execute(memberId);
+
+                assertNotNull(result);
+                assertEquals(YesNo.YES, result.realOneseoArrivedYn());
+
+                verify(oneseoRepository, times(1)).save(oneseo);
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 회원 ID가 주어지면")
+        class Context_with_non_existing_member_id {
+
+            @BeforeEach
+            void setUp() {
+                given(memberService.findByIdOrThrow(memberId)).willThrow(new ExpectedException("존재하지 않는 회원입니다.", HttpStatus.NOT_FOUND));
+            }
+
+            @Test
+            @DisplayName("ExpectedException을 던진다")
+            void it_throws_expected_exception() {
+                ExpectedException exception = assertThrows(ExpectedException.class, () -> modifyRealOneseoArrivedYnService.execute(memberId));
+
+                assertEquals("존재하지 않는 회원입니다.", exception.getMessage());
+                assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요

실물 원서 제출 여부 변경 테스트 코드 작성

## 본문

1. 존재하는 회원 ID가 주어지면 원서 도착 여부를 전환하고, 해당 정보를 반환한다.
2. 존재하지 않는 회원 ID가 주어지면 ExpectedException을 던진다.