### PR TITLE
[oneseo] 성적 환산 서비스 로직 테스트코드 추가

### DIFF
--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGedServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGedServiceTest.java
@@ -1,0 +1,123 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestFactorsDetail;
+import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestFactorsDetailRepository;
+import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
+
+import java.math.BigDecimal;
+
+import static java.math.RoundingMode.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType.CANDIDATE;
+import static team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType.GED;
+
+@DisplayName("CalculateGedService 클래스의")
+class CalculateGedServiceTest {
+
+    @Mock
+    private EntranceTestResultRepository entranceTestResultRepository;
+
+    @Mock
+    private EntranceTestFactorsDetailRepository entranceTestFactorsDetailRepository;
+
+    @InjectMocks
+    private CalculateGedService calculateGedService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Nested
+    @DisplayName("execute 메소드는")
+    class Describe_execute {
+
+        private MiddleSchoolAchievementReqDto reqDto;
+        private Oneseo oneseo;
+
+        @BeforeEach
+        void setUp() {
+            oneseo = mock(Oneseo.class);
+        }
+
+        @Nested
+        @DisplayName("올바른 graduationType이 주어지면")
+        class Context_with_valid_graduationType {
+
+            @Test
+            @DisplayName("성적을 계산하고 결과를 저장한다")
+            void it_calculates_and_saves_results() {
+                reqDto = MiddleSchoolAchievementReqDto.builder()
+                        .gedTotalScore(BigDecimal.valueOf(480))
+                        .gedMaxScore(BigDecimal.valueOf(600))
+                        .build();
+
+                calculateGedService.execute(reqDto, oneseo, GED);
+
+                verify(entranceTestFactorsDetailRepository).save(any(EntranceTestFactorsDetail.class));
+                verify(entranceTestResultRepository).save(any(EntranceTestResult.class));
+            }
+        }
+
+        @Test
+        @DisplayName("graduationType이 GED라면 올바른 내신 성적을 계산하고 결과를 저장한다")
+        void it_ged_calculates_and_save_results() {
+            reqDto = MiddleSchoolAchievementReqDto.builder()
+                    .gedTotalScore(BigDecimal.valueOf(480))
+                    .gedMaxScore(BigDecimal.valueOf(600))
+                    .build();
+
+            calculateGedService.execute(reqDto, oneseo, GED);
+
+            ArgumentCaptor<EntranceTestFactorsDetail> entranceTestFactorsDetailArgumentCaptor = ArgumentCaptor.forClass(EntranceTestFactorsDetail.class);
+            ArgumentCaptor<EntranceTestResult> entranceTestResultArgumentCaptor = ArgumentCaptor.forClass(EntranceTestResult.class);
+
+            verify(entranceTestFactorsDetailRepository).save(entranceTestFactorsDetailArgumentCaptor.capture());
+            verify(entranceTestResultRepository).save(entranceTestResultArgumentCaptor.capture());
+
+            EntranceTestFactorsDetail capturedEntranceTestFactorsDetailArgument = entranceTestFactorsDetailArgumentCaptor.getValue();
+            EntranceTestResult capturedEntranceTestResult = entranceTestResultArgumentCaptor.getValue();
+
+            assertEquals(BigDecimal.valueOf(144).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getTotalSubjectsScore());
+            assertEquals(BigDecimal.valueOf(30).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getAttendanceScore().setScale(3, UP));
+            assertEquals(BigDecimal.valueOf(20).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getVolunteerScore());
+            assertEquals(BigDecimal.valueOf(50).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getTotalNonSubjectsScore());
+
+            assertEquals(BigDecimal.valueOf(194).setScale(3, UP), capturedEntranceTestResult.getDocumentEvaluationScore());
+        }
+
+
+        @Nested
+        @DisplayName("유효하지 않은 graduationType이 주어지면")
+        class Context_with_invalid_graduationType {
+
+            @Test
+            @DisplayName("예외를 던진다")
+            void it_throw_exception() {
+                reqDto = MiddleSchoolAchievementReqDto.builder()
+                        .gedTotalScore(BigDecimal.valueOf(480))
+                        .gedMaxScore(BigDecimal.valueOf(600))
+                        .build();
+
+                IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () ->
+                        calculateGedService.execute(reqDto, oneseo, CANDIDATE));
+
+                assertEquals("올바르지 않은 graduationType입니다.", illegalArgumentException.getMessage());
+            }
+        }
+    }
+}

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGedServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGedServiceTest.java
@@ -71,35 +71,35 @@ class CalculateGedServiceTest {
                 verify(entranceTestFactorsDetailRepository).save(any(EntranceTestFactorsDetail.class));
                 verify(entranceTestResultRepository).save(any(EntranceTestResult.class));
             }
+
+            @Test
+            @DisplayName("graduationType이 GED라면 올바른 내신 성적을 계산하고 결과를 저장한다")
+            void it_ged_calculates_and_save_results() {
+                reqDto = MiddleSchoolAchievementReqDto.builder()
+                        .gedTotalScore(BigDecimal.valueOf(480))
+                        .gedMaxScore(BigDecimal.valueOf(600))
+                        .build();
+
+                calculateGedService.execute(reqDto, oneseo, GED);
+
+                ArgumentCaptor<EntranceTestFactorsDetail> entranceTestFactorsDetailArgumentCaptor = ArgumentCaptor.forClass(EntranceTestFactorsDetail.class);
+                ArgumentCaptor<EntranceTestResult> entranceTestResultArgumentCaptor = ArgumentCaptor.forClass(EntranceTestResult.class);
+
+                verify(entranceTestFactorsDetailRepository).save(entranceTestFactorsDetailArgumentCaptor.capture());
+                verify(entranceTestResultRepository).save(entranceTestResultArgumentCaptor.capture());
+
+                EntranceTestFactorsDetail capturedEntranceTestFactorsDetailArgument = entranceTestFactorsDetailArgumentCaptor.getValue();
+                EntranceTestResult capturedEntranceTestResult = entranceTestResultArgumentCaptor.getValue();
+
+                assertEquals(BigDecimal.valueOf(144).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getTotalSubjectsScore());
+                assertEquals(BigDecimal.valueOf(30).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getAttendanceScore().setScale(3, UP));
+                assertEquals(BigDecimal.valueOf(20).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getVolunteerScore());
+                assertEquals(BigDecimal.valueOf(50).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getTotalNonSubjectsScore());
+
+                assertEquals(BigDecimal.valueOf(194).setScale(3, UP), capturedEntranceTestResult.getDocumentEvaluationScore());
+            }
+
         }
-
-        @Test
-        @DisplayName("graduationType이 GED라면 올바른 내신 성적을 계산하고 결과를 저장한다")
-        void it_ged_calculates_and_save_results() {
-            reqDto = MiddleSchoolAchievementReqDto.builder()
-                    .gedTotalScore(BigDecimal.valueOf(480))
-                    .gedMaxScore(BigDecimal.valueOf(600))
-                    .build();
-
-            calculateGedService.execute(reqDto, oneseo, GED);
-
-            ArgumentCaptor<EntranceTestFactorsDetail> entranceTestFactorsDetailArgumentCaptor = ArgumentCaptor.forClass(EntranceTestFactorsDetail.class);
-            ArgumentCaptor<EntranceTestResult> entranceTestResultArgumentCaptor = ArgumentCaptor.forClass(EntranceTestResult.class);
-
-            verify(entranceTestFactorsDetailRepository).save(entranceTestFactorsDetailArgumentCaptor.capture());
-            verify(entranceTestResultRepository).save(entranceTestResultArgumentCaptor.capture());
-
-            EntranceTestFactorsDetail capturedEntranceTestFactorsDetailArgument = entranceTestFactorsDetailArgumentCaptor.getValue();
-            EntranceTestResult capturedEntranceTestResult = entranceTestResultArgumentCaptor.getValue();
-
-            assertEquals(BigDecimal.valueOf(144).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getTotalSubjectsScore());
-            assertEquals(BigDecimal.valueOf(30).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getAttendanceScore().setScale(3, UP));
-            assertEquals(BigDecimal.valueOf(20).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getVolunteerScore());
-            assertEquals(BigDecimal.valueOf(50).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getTotalNonSubjectsScore());
-
-            assertEquals(BigDecimal.valueOf(194).setScale(3, UP), capturedEntranceTestResult.getDocumentEvaluationScore());
-        }
-
 
         @Nested
         @DisplayName("유효하지 않은 graduationType이 주어지면")

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeServiceTest.java
@@ -12,17 +12,18 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchieveme
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestFactorsDetail;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
-import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestFactorsDetailRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
 
+import static java.math.RoundingMode.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType.*;
 
 @DisplayName("CalculateGradeService 클래스의")
 class CalculateGradeServiceTest {
@@ -50,18 +51,6 @@ class CalculateGradeServiceTest {
 
         @BeforeEach
         void setUp() {
-            reqDto = MiddleSchoolAchievementReqDto.builder()
-                    .achievement1_2(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 0))
-                    .achievement2_1(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 4))
-                    .achievement2_2(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 4))
-                    .artsPhysicalAchievement(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 5))
-                    .absentDays(Arrays.asList(3, 0, 0))
-                    .attendanceDays(Arrays.asList(0, 0, 0, 0, 0, 0, 0, 0, 0))
-                    .volunteerTime(Arrays.asList(10, 0, 2))
-                    .liberalSystem("자유학기제")
-                    .freeSemester("3-1")
-                    .build();
-
             oneseo = mock(Oneseo.class);
         }
 
@@ -72,16 +61,40 @@ class CalculateGradeServiceTest {
             @Test
             @DisplayName("내신 성적을 계산하고 결과를 저장한다")
             void it_calculates_and_saves_results() {
-                calculateGradeService.execute(reqDto, oneseo, GraduationType.CANDIDATE);
+                reqDto = MiddleSchoolAchievementReqDto.builder()
+                        .achievement1_2(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 0))
+                        .achievement2_1(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 4))
+                        .achievement2_2(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 4))
+                        .artsPhysicalAchievement(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 5))
+                        .absentDays(Arrays.asList(3, 0, 0))
+                        .attendanceDays(Arrays.asList(0, 0, 0, 0, 0, 0, 0, 0, 0))
+                        .volunteerTime(Arrays.asList(10, 0, 2))
+                        .liberalSystem("자유학기제")
+                        .freeSemester("3-1")
+                        .build();
+
+                calculateGradeService.execute(reqDto, oneseo, CANDIDATE);
 
                 verify(entranceTestFactorsDetailRepository).save(any(EntranceTestFactorsDetail.class));
                 verify(entranceTestResultRepository).save(any(EntranceTestResult.class));
             }
 
             @Test
-            @DisplayName("내신 성적을 계산하고 결과를 반환한다")
-            void it_calculates_and_returns_results() {
-                calculateGradeService.execute(reqDto, oneseo, GraduationType.CANDIDATE);
+            @DisplayName("graduationType이 CANDIDATE라면 올바른 내신 성적을 계산하고 결과를 저장한다")
+            void it_candidate_calculates_and_save_results() {
+                reqDto = MiddleSchoolAchievementReqDto.builder()
+                        .achievement1_2(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 0))
+                        .achievement2_1(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 4))
+                        .achievement2_2(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 4))
+                        .artsPhysicalAchievement(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 5))
+                        .absentDays(Arrays.asList(3, 0, 0))
+                        .attendanceDays(Arrays.asList(0, 0, 0, 0, 0, 0, 0, 0, 0))
+                        .volunteerTime(Arrays.asList(10, 0, 2))
+                        .liberalSystem("자유학기제")
+                        .freeSemester("3-1")
+                        .build();
+
+                calculateGradeService.execute(reqDto, oneseo, CANDIDATE);
 
                 ArgumentCaptor<EntranceTestFactorsDetail> entranceTestFactorsDetailArgumentCaptor = ArgumentCaptor.forClass(EntranceTestFactorsDetail.class);
                 ArgumentCaptor<EntranceTestResult> entranceTestResultArgumentCaptor = ArgumentCaptor.forClass(EntranceTestResult.class);
@@ -92,7 +105,88 @@ class CalculateGradeServiceTest {
                 EntranceTestFactorsDetail capturedEntranceTestFactorsDetailArgument = entranceTestFactorsDetailArgumentCaptor.getValue();
                 EntranceTestResult capturedEntranceTestResult = entranceTestResultArgumentCaptor.getValue();
 
-                assertEquals(BigDecimal.valueOf(272.20), capturedEntranceTestResult.getDocumentEvaluationScore());
+                assertEquals(BigDecimal.valueOf(177.2).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getGeneralSubjectsScore());
+                assertEquals(BigDecimal.valueOf(60).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getArtsPhysicalSubjectsScore());
+                assertEquals(BigDecimal.valueOf(237.2).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getTotalSubjectsScore());
+                assertEquals(BigDecimal.valueOf(21).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getAttendanceScore());
+                assertEquals(BigDecimal.valueOf(14).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getVolunteerScore());
+                assertEquals(BigDecimal.valueOf(35).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getTotalNonSubjectsScore());
+                assertEquals(BigDecimal.valueOf(54).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getScore1_2());
+                assertEquals(BigDecimal.valueOf(52.8).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getScore2_1());
+                assertEquals(BigDecimal.valueOf(70.4).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getScore2_2());
+                assertEquals(BigDecimal.valueOf(0.0).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getScore3_1().setScale(3, UP));
+                assertEquals(BigDecimal.valueOf(0.0).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getScore3_2().setScale(3, UP));
+
+                assertEquals(BigDecimal.valueOf(272.2).setScale(3, UP), capturedEntranceTestResult.getDocumentEvaluationScore());
+            }
+
+            @Test
+            @DisplayName("graduationType이 GRADUATE라면 올바른 내신 성적을 계산하고 결과를 저장한다")
+            void it_graduate_calculates_and_save_results() {
+                reqDto = MiddleSchoolAchievementReqDto.builder()
+                        .achievement1_2(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 0))
+                        .achievement2_2(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 0))
+                        .achievement3_1(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 5))
+                        .achievement3_2(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 5))
+                        .artsPhysicalAchievement(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 5))
+                        .absentDays(Arrays.asList(3, 0, 0))
+                        .attendanceDays(Arrays.asList(0, 0, 0, 0, 0, 0, 0, 0, 0))
+                        .volunteerTime(Arrays.asList(10, 0, 10))
+                        .liberalSystem("자유학기제")
+                        .freeSemester("2-1")
+                        .build();
+
+                calculateGradeService.execute(reqDto, oneseo, GRADUATE);
+
+                ArgumentCaptor<EntranceTestFactorsDetail> entranceTestFactorsDetailArgumentCaptor = ArgumentCaptor.forClass(EntranceTestFactorsDetail.class);
+                ArgumentCaptor<EntranceTestResult> entranceTestResultArgumentCaptor = ArgumentCaptor.forClass(EntranceTestResult.class);
+
+                verify(entranceTestFactorsDetailRepository).save(entranceTestFactorsDetailArgumentCaptor.capture());
+                verify(entranceTestResultRepository).save(entranceTestResultArgumentCaptor.capture());
+
+                EntranceTestFactorsDetail capturedEntranceTestFactorsDetailArgument = entranceTestFactorsDetailArgumentCaptor.getValue();
+                EntranceTestResult capturedEntranceTestResult = entranceTestResultArgumentCaptor.getValue();
+
+                assertEquals(BigDecimal.valueOf(180).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getGeneralSubjectsScore());
+                assertEquals(BigDecimal.valueOf(60).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getArtsPhysicalSubjectsScore());
+                assertEquals(BigDecimal.valueOf(240).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getTotalSubjectsScore());
+                assertEquals(BigDecimal.valueOf(21).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getAttendanceScore());
+                assertEquals(BigDecimal.valueOf(22).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getVolunteerScore());
+                assertEquals(BigDecimal.valueOf(43).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getTotalNonSubjectsScore());
+                assertEquals(BigDecimal.valueOf(36).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getScore1_2());
+                assertEquals(BigDecimal.valueOf(0.0).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getScore2_1().setScale(3, UP));
+                assertEquals(BigDecimal.valueOf(36).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getScore2_2());
+                assertEquals(BigDecimal.valueOf(54).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getScore3_1().setScale(3, UP));
+                assertEquals(BigDecimal.valueOf(54).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getScore3_2().setScale(3, UP));
+
+                assertEquals(BigDecimal.valueOf(283).setScale(3, UP), capturedEntranceTestResult.getDocumentEvaluationScore());
+            }
+        }
+
+        @Nested
+        @DisplayName("유효하지 않은 graduationType이 주어지면")
+        class Context_with_invalid_graduationType {
+
+            @Test
+            @DisplayName("예외를 던진다")
+            void it_throw_exception() {
+                reqDto = MiddleSchoolAchievementReqDto.builder()
+                        .achievement1_2(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 0))
+                        .achievement2_2(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 0))
+                        .achievement3_1(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 5))
+                        .achievement3_2(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 5))
+                        .artsPhysicalAchievement(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 5))
+                        .absentDays(Arrays.asList(3, 0, 0))
+                        .attendanceDays(Arrays.asList(0, 0, 0, 0, 0, 0, 0, 0, 0))
+                        .volunteerTime(Arrays.asList(10, 0, 10))
+                        .liberalSystem("자유학기제")
+                        .freeSemester("2-1")
+                        .build();
+
+                IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () ->
+                        calculateGradeService.execute(reqDto, oneseo, GED));
+
+                assertEquals("올바르지 않은 graduationType입니다.", illegalArgumentException.getMessage());
             }
         }
     }

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeServiceTest.java
@@ -1,0 +1,99 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestFactorsDetail;
+import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
+import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestFactorsDetailRepository;
+import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("CalculateGradeService 클래스의")
+class CalculateGradeServiceTest {
+
+    @Mock
+    private EntranceTestResultRepository entranceTestResultRepository;
+
+    @Mock
+    private EntranceTestFactorsDetailRepository entranceTestFactorsDetailRepository;
+
+    @InjectMocks
+    private CalculateGradeService calculateGradeService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Nested
+    @DisplayName("execute 메소드는")
+    class Describe_execute {
+
+        private MiddleSchoolAchievementReqDto reqDto;
+        private Oneseo oneseo;
+
+        @BeforeEach
+        void setUp() {
+            reqDto = MiddleSchoolAchievementReqDto.builder()
+                    .achievement1_2(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 0))
+                    .achievement2_1(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 4))
+                    .achievement2_2(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 4))
+                    .artsPhysicalAchievement(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 5))
+                    .absentDays(Arrays.asList(3, 0, 0))
+                    .attendanceDays(Arrays.asList(0, 0, 0, 0, 0, 0, 0, 0, 0))
+                    .volunteerTime(Arrays.asList(10, 0, 2))
+                    .liberalSystem("자유학기제")
+                    .freeSemester("3-1")
+                    .build();
+
+            oneseo = mock(Oneseo.class);
+        }
+
+        @Nested
+        @DisplayName("올바른 graduationType이 주어지면")
+        class Context_with_valid_graduationType {
+
+            @Test
+            @DisplayName("내신 성적을 계산하고 결과를 저장한다")
+            void it_calculates_and_saves_results() {
+                calculateGradeService.execute(reqDto, oneseo, GraduationType.CANDIDATE);
+
+                verify(entranceTestFactorsDetailRepository).save(any(EntranceTestFactorsDetail.class));
+                verify(entranceTestResultRepository).save(any(EntranceTestResult.class));
+            }
+
+            @Test
+            @DisplayName("내신 성적을 계산하고 결과를 반환한다")
+            void it_calculates_and_returns_results() {
+                calculateGradeService.execute(reqDto, oneseo, GraduationType.CANDIDATE);
+
+                ArgumentCaptor<EntranceTestFactorsDetail> entranceTestFactorsDetailArgumentCaptor = ArgumentCaptor.forClass(EntranceTestFactorsDetail.class);
+                ArgumentCaptor<EntranceTestResult> entranceTestResultArgumentCaptor = ArgumentCaptor.forClass(EntranceTestResult.class);
+
+                verify(entranceTestFactorsDetailRepository).save(entranceTestFactorsDetailArgumentCaptor.capture());
+                verify(entranceTestResultRepository).save(entranceTestResultArgumentCaptor.capture());
+
+                EntranceTestFactorsDetail capturedEntranceTestFactorsDetailArgument = entranceTestFactorsDetailArgumentCaptor.getValue();
+                EntranceTestResult capturedEntranceTestResult = entranceTestResultArgumentCaptor.getValue();
+
+                assertEquals(BigDecimal.valueOf(272.20), capturedEntranceTestResult.getDocumentEvaluationScore());
+            }
+        }
+    }
+}

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeServiceTest.java
@@ -59,7 +59,7 @@ class CalculateGradeServiceTest {
         class Context_with_valid_graduationType {
 
             @Test
-            @DisplayName("내신 성적을 계산하고 결과를 저장한다")
+            @DisplayName("성적을 계산하고 결과를 저장한다")
             void it_calculates_and_saves_results() {
                 reqDto = MiddleSchoolAchievementReqDto.builder()
                         .achievement1_2(Arrays.asList(5, 5, 5, 5, 5, 5, 5, 5, 0))


### PR DESCRIPTION
## 개요

중학교, 검정고시 성적 환산 서비스 로직 테스트코드를 추가하였습니다.

## 본문

중학교 성적 환산 서비스 로직

<img width="577" alt="스크린샷 2024-07-29 오전 3 05 16" src="https://github.com/user-attachments/assets/f22f1609-b735-4e17-9bc3-13dfdb38fed1">

- 올바른 graduationType이 주어졌다면
    - 성적을 환산하고 저장합니다.
    - 졸업예정자라면 올바른 내신 성적을 환산하고 결과를 저장합니다.
    - 졸업자라면 올바른 내신 성적을 환산하고 결과를 저장합니다.
- graduationType이 올바르지 않다면
   - 예외를 던집니다.


검정고시 성적 환산 서비스 로직

<img width="562" alt="스크린샷 2024-07-29 오전 3 08 36" src="https://github.com/user-attachments/assets/46372e1e-8a15-4cca-bd50-582182f4bcf2">

- 올바른 graduationType이 주어졌다면
    - 성적을 환산하고 저장합니다.
    - 검정고시 지원자라면 올바른 내신 성적을 환산하고 결과를 저장합니다.
- graduationType이 올바르지 않다면
   - 예외를 던집니다.