### PR TITLE
[global] 스프링부트 3.xx 버전에 맞도록 QueryDSL 설정 변경하여 오류 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,8 +61,14 @@ dependencies {
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.1'
 }
 
+def querydslSrcDir = "$projectDir/build/generated"
+
 clean {
-    delete file("$projectDir/build/generated")
+    delete file(querydslSrcDir)
+}
+
+tasks.withType(JavaCompile) {
+    options.generatedSourceOutputDirectory = file(querydslSrcDir)
 }
 
 tasks.named('bootBuildImage') {

--- a/build.gradle
+++ b/build.gradle
@@ -61,12 +61,8 @@ dependencies {
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.1'
 }
 
-sourceSets {
-    main {
-        java {
-            srcDirs = ["$projectDir/src/main/java", "$projectDir/build/generated"]
-        }
-    }
+clean {
+    delete file("$projectDir/build/generated")
 }
 
 tasks.named('bootBuildImage') {


### PR DESCRIPTION
## 개요

스프링부트 3.xx 버전에 맞도록 QueryDSL Qclass 생성 및 재생성 관련 코드를 수정하여, 지속적으로 발생하는 Qclass 재생성 관련 문제를 해결하였습니다.

<img width="1723" alt="스크린샷 2024-07-29 오전 3 48 52" src="https://github.com/user-attachments/assets/3b55bddf-42ca-458b-804e-95a155d28ed5">



