### PR TITLE
[oneseo] 원서 임시 저장 구현

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -158,9 +158,10 @@ public class OneseoController {
     @PostMapping("/temp-storage")
     public CommonApiResponse temp(
             @RequestBody @Valid OneseoReqDto reqDto,
+            @RequestParam Integer step,
             @AuthRequest Long memberId
     ) {
-        oneseoTempStorageService.execute(reqDto, memberId);
+        oneseoTempStorageService.execute(reqDto, step, memberId);
         return CommonApiResponse.success("임시저장되었습니다.");
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -43,6 +43,7 @@ public class OneseoController {
     private final QueryOneseoByIdService queryOneseoByIdService;
     private final UpdateFinalSubmissionService updateFinalSubmissionService;
     private final CalculateMockScoreService calculateMockScoreService;
+    private final OneseoTempStorageService oneseoTempStorageService;
 
     @PostMapping("/oneseo/me")
     public CommonApiResponse create(
@@ -152,5 +153,14 @@ public class OneseoController {
     public List<AdmissionTicketsResDto> getAdmissionTickets(
     ) {
         return queryAdmissionTicketsService.execute();
+    }
+
+    @PostMapping("/temp-storage")
+    public CommonApiResponse temp(
+            @RequestBody @Valid OneseoReqDto reqDto,
+            @AuthRequest Long memberId
+    ) {
+        oneseoTempStorageService.execute(reqDto, memberId);
+        return CommonApiResponse.success("임시저장되었습니다.");
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/FoundOneseoResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/FoundOneseoResDto.java
@@ -1,8 +1,8 @@
 package team.themoment.hellogsmv3.domain.oneseo.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
-import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 
 @Builder
 public record FoundOneseoResDto(
@@ -12,6 +12,8 @@ public record FoundOneseoResDto(
         Screening wantedScreening,
         DesiredMajorsResDto desiredMajors,
         OneseoPrivacyDetailResDto privacyDetail,
-        MiddleSchoolAchievementResDto middleSchoolAchievement
+        MiddleSchoolAchievementResDto middleSchoolAchievement,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        Integer step
 ) {
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -1,6 +1,7 @@
 package team.themoment.hellogsmv3.domain.oneseo.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +33,7 @@ public class CreateOneseoService {
     private final MemberService memberService;
 
     @Transactional
+    @CacheEvict(value = "oneseo", key = "#memberId")
     public void execute(OneseoReqDto reqDto, Long memberId) {
         Member currentMember = memberService.findByIdOrThrow(memberId);
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
@@ -1,0 +1,103 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.stereotype.Service;
+import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.member.service.MemberService;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.DesiredMajorsResDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.FoundOneseoResDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.MiddleSchoolAchievementResDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.OneseoPrivacyDetailResDto;
+
+@Service
+@RequiredArgsConstructor
+public class OneseoTempStorageService {
+
+    private final MemberService memberService;
+
+    @CachePut(value = "oneseo", key = "#memberId")
+    public FoundOneseoResDto execute(OneseoReqDto reqDto, Long memberId) {
+        Member member = memberService.findByIdOrThrow(memberId);
+
+        OneseoPrivacyDetailResDto oneseoPrivacyDetailResDto = buildOneseoPrivacyDetailResDto(member, reqDto);
+        MiddleSchoolAchievementResDto middleSchoolAchievementResDto = buildMiddleSchoolAchievementResDto(reqDto);
+
+        return buildFoundOneseoResDto(
+                reqDto,
+                oneseoPrivacyDetailResDto,
+                middleSchoolAchievementResDto
+        );
+    }
+
+    private OneseoPrivacyDetailResDto buildOneseoPrivacyDetailResDto(
+            Member member,
+            OneseoReqDto reqDto
+    ) {
+
+        return OneseoPrivacyDetailResDto.builder()
+                .name(member.getName())
+                .sex(member.getSex())
+                .birth(member.getBirth())
+                .phoneNumber(member.getPhoneNumber())
+                .graduationType(reqDto.graduationType())
+                .address(reqDto.address())
+                .detailAddress(reqDto.detailAddress())
+                .guardianName(reqDto.guardianName())
+                .guardianPhoneNumber(reqDto.guardianPhoneNumber())
+                .relationshipWithGuardian(reqDto.relationshipWithGuardian())
+                .schoolName(reqDto.schoolName())
+                .schoolAddress(reqDto.schoolAddress())
+                .schoolTeacherName(reqDto.schoolTeacherName())
+                .schoolTeacherPhoneNumber(reqDto.schoolTeacherPhoneNumber())
+                .profileImg(reqDto.profileImg())
+                .build();
+    }
+
+    private MiddleSchoolAchievementResDto buildMiddleSchoolAchievementResDto(
+            OneseoReqDto reqDto
+    ) {
+        MiddleSchoolAchievementReqDto middleSchoolAchievement = reqDto.middleSchoolAchievement();
+
+        return MiddleSchoolAchievementResDto.builder()
+                .achievement1_2(middleSchoolAchievement.achievement1_2())
+                .achievement2_1(middleSchoolAchievement.achievement2_1())
+                .achievement2_2(middleSchoolAchievement.achievement2_2())
+                .achievement3_1(middleSchoolAchievement.achievement3_1())
+                .achievement3_2(middleSchoolAchievement.achievement3_2())
+                .generalSubjects(middleSchoolAchievement.generalSubjects())
+                .newSubjects(middleSchoolAchievement.newSubjects())
+                .artsPhysicalAchievement(middleSchoolAchievement.artsPhysicalAchievement())
+                .artsPhysicalSubjects(middleSchoolAchievement.artsPhysicalSubjects())
+                .absentDays(middleSchoolAchievement.absentDays())
+                .attendanceDays(middleSchoolAchievement.attendanceDays())
+                .volunteerTime(middleSchoolAchievement.volunteerTime())
+                .liberalSystem(middleSchoolAchievement.liberalSystem())
+                .freeSemester(middleSchoolAchievement.freeSemester())
+                .gedTotalScore(middleSchoolAchievement.gedTotalScore())
+                .gedMaxScore(middleSchoolAchievement.gedMaxScore())
+                .build();
+    }
+
+    private FoundOneseoResDto buildFoundOneseoResDto(
+            OneseoReqDto reqDto,
+            OneseoPrivacyDetailResDto oneseoPrivacyDetailResDto,
+            MiddleSchoolAchievementResDto middleSchoolAchievementResDto
+    ) {
+
+        return FoundOneseoResDto.builder()
+                .oneseoId(null)
+                .submitCode(null)
+                .wantedScreening(reqDto.screening())
+                .desiredMajors(DesiredMajorsResDto.builder()
+                        .firstDesiredMajor(reqDto.firstDesiredMajor())
+                        .secondDesiredMajor(reqDto.secondDesiredMajor())
+                        .thirdDesiredMajor(reqDto.thirdDesiredMajor())
+                        .build())
+                .privacyDetail(oneseoPrivacyDetailResDto)
+                .middleSchoolAchievement(middleSchoolAchievementResDto)
+                .build();
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
@@ -19,7 +19,7 @@ public class OneseoTempStorageService {
     private final MemberService memberService;
 
     @CachePut(value = "oneseo", key = "#memberId")
-    public FoundOneseoResDto execute(OneseoReqDto reqDto, Long memberId) {
+    public FoundOneseoResDto execute(OneseoReqDto reqDto,Integer step, Long memberId) {
         Member member = memberService.findByIdOrThrow(memberId);
 
         OneseoPrivacyDetailResDto oneseoPrivacyDetailResDto = buildOneseoPrivacyDetailResDto(member, reqDto);
@@ -28,7 +28,8 @@ public class OneseoTempStorageService {
         return buildFoundOneseoResDto(
                 reqDto,
                 oneseoPrivacyDetailResDto,
-                middleSchoolAchievementResDto
+                middleSchoolAchievementResDto,
+                step
         );
     }
 
@@ -84,7 +85,8 @@ public class OneseoTempStorageService {
     private FoundOneseoResDto buildFoundOneseoResDto(
             OneseoReqDto reqDto,
             OneseoPrivacyDetailResDto oneseoPrivacyDetailResDto,
-            MiddleSchoolAchievementResDto middleSchoolAchievementResDto
+            MiddleSchoolAchievementResDto middleSchoolAchievementResDto,
+            Integer step
     ) {
 
         return FoundOneseoResDto.builder()
@@ -98,6 +100,7 @@ public class OneseoTempStorageService {
                         .build())
                 .privacyDetail(oneseoPrivacyDetailResDto)
                 .middleSchoolAchievement(middleSchoolAchievementResDto)
+                .step(step)
                 .build();
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
@@ -1,18 +1,15 @@
 package team.themoment.hellogsmv3.domain.oneseo.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
-import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
 import team.themoment.hellogsmv3.domain.oneseo.repository.MiddleSchoolAchievementRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRepository;
-import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
-import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +20,7 @@ public class QueryOneseoByIdService {
     private final MemberService memberService;
     private final OneseoService oneseoService;
 
+    @Cacheable(value = "oneseo", key = "#memberId")
     public FoundOneseoResDto execute(Long memberId) {
         Member member = memberService.findByIdOrThrow(memberId);
         Oneseo oneseo = oneseoService.findByMemberOrThrow(member);

--- a/src/main/java/team/themoment/hellogsmv3/global/config/RedisCacheConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/config/RedisCacheConfig.java
@@ -1,0 +1,29 @@
+package team.themoment.hellogsmv3.global.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+
+    @Bean
+    public CacheManager contentCacheManager(RedisConnectionFactory cf) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofDays(4L));
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf).cacheDefaults(redisCacheConfiguration).build();
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/config/RedisConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package team.themoment.hellogsmv3.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}


### PR DESCRIPTION
## 개요

원서 작성 시 사용하는 임시저장 기능을 구현하였습니다.

## 본문

- 임시저장에서는 데이터를 디스크가 아닌 인메모리db인 `redis`에 저장하도록 구현하였습니다.
- `OneseoTempStorageService`에서 데이터를 Redis에 저장하도록 `@CachePut` 어노테이션을 사용하여 임시저장 메서드의 반환값을 캐싱했습니다.
- `QueryOneseoByIdService`에 @Cacheable 어노테이션을 적용하여, 원서 조회 시 Redis에 데이터가 존재하면 캐시된 데이터를 사용하고, 없으면 디스크에서 데이터를 읽어오도록 하였습니다.
- `CreateOneseoService`에 @CacheEvict 어노테이션을 적용하여, 원서 작성 시 Redis에 있는 데이터를 제거하도록 하였습니다.