### PR TITLE
fix(oneseo): 검정고시 환산식 소수점 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/MiddleSchoolAchievementReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/MiddleSchoolAchievementReqDto.java
@@ -22,7 +22,6 @@ public record MiddleSchoolAchievementReqDto(
         List<Integer> volunteerTime,
         String liberalSystem,
         String freeSemester,
-        BigDecimal gedTotalScore,
-        BigDecimal gedMaxScore
+        BigDecimal gedTotalScore
 ) {
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/MiddleSchoolAchievementResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/MiddleSchoolAchievementResDto.java
@@ -22,9 +22,7 @@ public record MiddleSchoolAchievementResDto(
         List<Integer> volunteerTime,
         String liberalSystem,
         String freeSemester,
-        BigDecimal gedTotalScore,
-        BigDecimal gedMaxScore
-
+        BigDecimal gedTotalScore
 
 ) {
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
@@ -82,7 +82,4 @@ public class MiddleSchoolAchievement {
 
     @Column(name = "ged_total_score")
     private BigDecimal gedTotalScore;
-
-    @Column(name = "ged_max_score")
-    private BigDecimal gedMaxScore;
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGedService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGedService.java
@@ -27,10 +27,10 @@ public class CalculateGedService {
             throw new IllegalArgumentException("올바르지 않은 graduationType입니다.");
 
         BigDecimal gedTotalScore = dto.gedTotalScore();
-        BigDecimal gedMaxScore = dto.gedMaxScore();
+        BigDecimal gedMaxScore = BigDecimal.valueOf(600);
 
         // 검정고시 평균 점수
-        BigDecimal averageScore = gedTotalScore.divide(gedMaxScore, 2, RoundingMode.HALF_UP)
+        BigDecimal averageScore = gedTotalScore.divide(gedMaxScore, 5, RoundingMode.HALF_UP)
                 .multiply(BigDecimal.valueOf(100));
 
         // 검정고시 교과 성적 환산 점수 (총점: 240점)
@@ -38,6 +38,7 @@ public class CalculateGedService {
 
         // 검정고시 봉사 성적 환산 점수 (총점: 30점)
         BigDecimal gedVolunteerScore = calcGedVolunteerScore(averageScore);
+
         // 검정고시 출결 성적 점수 (총점: 30점)
         BigDecimal gedAttendanceScore = BigDecimal.valueOf(30);
 
@@ -92,14 +93,14 @@ public class CalculateGedService {
 
     private BigDecimal calcGedTotalSubjectsScore(BigDecimal averageScore) {
         return averageScore.subtract(BigDecimal.valueOf(50))
-                .divide(BigDecimal.valueOf(50), 20, RoundingMode.HALF_UP)
+                .divide(BigDecimal.valueOf(50), 5, RoundingMode.HALF_UP)
                 .multiply(BigDecimal.valueOf(240))
                 .setScale(3, RoundingMode.HALF_UP);
     }
 
     private BigDecimal calcGedVolunteerScore(BigDecimal averageScore) {
         return averageScore.subtract(BigDecimal.valueOf(40))
-                .divide(BigDecimal.valueOf(60), 20, RoundingMode.HALF_UP)
+                .divide(BigDecimal.valueOf(60), 5, RoundingMode.HALF_UP)
                 .multiply(BigDecimal.valueOf(30))
                 .setScale(3, RoundingMode.HALF_UP);
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -6,7 +6,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
-import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
@@ -48,7 +47,10 @@ public class CreateOneseoService {
 
         saveEntities(oneseo, oneseoPrivacyDetail, middleSchoolAchievement);
 
-        GraduationType graduationType = oneseoPrivacyDetail.getGraduationType();
+        calculateMiddleSchoolAchievement(oneseoPrivacyDetail.getGraduationType(), middleSchoolAchievement, oneseo);
+    }
+
+    private void calculateMiddleSchoolAchievement(GraduationType graduationType, MiddleSchoolAchievement middleSchoolAchievement, Oneseo oneseo) {
         MiddleSchoolAchievementReqDto data = MiddleSchoolAchievementReqDto.builder()
                 .achievement1_2(middleSchoolAchievement.getAchievement1_2())
                 .achievement2_1(middleSchoolAchievement.getAchievement2_1())

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -64,7 +64,6 @@ public class CreateOneseoService {
                 .liberalSystem(middleSchoolAchievement.getLiberalSystem())
                 .freeSemester(middleSchoolAchievement.getFreeSemester())
                 .gedTotalScore(middleSchoolAchievement.getGedTotalScore())
-                .gedMaxScore(middleSchoolAchievement.getGedMaxScore())
                 .build();
 
         switch (graduationType) {
@@ -130,7 +129,6 @@ public class CreateOneseoService {
                 .liberalSystem(middleSchoolAchievement.liberalSystem())
                 .freeSemester(middleSchoolAchievement.freeSemester())
                 .gedTotalScore(middleSchoolAchievement.gedTotalScore())
-                .gedMaxScore(middleSchoolAchievement.gedMaxScore())
                 .build();
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -69,7 +69,6 @@ public class ModifyOneseoService {
                 .liberalSystem(middleSchoolAchievement.getLiberalSystem())
                 .freeSemester(middleSchoolAchievement.getFreeSemester())
                 .gedTotalScore(middleSchoolAchievement.getGedTotalScore())
-                .gedMaxScore(middleSchoolAchievement.getGedMaxScore())
                 .build();
 
         switch (graduationType) {
@@ -132,7 +131,6 @@ public class ModifyOneseoService {
                 .liberalSystem(updatedMiddleSchoolAchievement.liberalSystem())
                 .freeSemester(updatedMiddleSchoolAchievement.freeSemester())
                 .gedTotalScore(updatedMiddleSchoolAchievement.gedTotalScore())
-                .gedMaxScore(updatedMiddleSchoolAchievement.gedMaxScore())
                 .build();
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -5,7 +5,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
-import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
@@ -22,10 +21,7 @@ import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.ScreeningChangeHistoryRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
-import java.math.BigDecimal;
 import java.util.List;
-
-import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.*;
 
 @Service
 @RequiredArgsConstructor
@@ -56,7 +52,10 @@ public class ModifyOneseoService {
 
         saveModifiedEntities(modifiedOneseo, modifiedOneseoPrivacyDetail, modifiedMiddleSchoolAchievement);
 
-        GraduationType graduationType = oneseoPrivacyDetail.getGraduationType();
+        calculateMiddleSchoolAchievement(oneseoPrivacyDetail.getGraduationType(), middleSchoolAchievement, oneseo);
+    }
+
+    private void calculateMiddleSchoolAchievement(GraduationType graduationType, MiddleSchoolAchievement middleSchoolAchievement, Oneseo oneseo) {
         MiddleSchoolAchievementReqDto data = MiddleSchoolAchievementReqDto.builder()
                 .achievement1_2(middleSchoolAchievement.getAchievement1_2())
                 .achievement2_1(middleSchoolAchievement.getAchievement2_1())

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
@@ -78,7 +78,6 @@ public class OneseoTempStorageService {
                 .liberalSystem(middleSchoolAchievement.liberalSystem())
                 .freeSemester(middleSchoolAchievement.freeSemester())
                 .gedTotalScore(middleSchoolAchievement.gedTotalScore())
-                .gedMaxScore(middleSchoolAchievement.gedMaxScore())
                 .build();
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
@@ -79,7 +79,6 @@ public class QueryOneseoByIdService {
                 .liberalSystem(middleSchoolAchievement.getLiberalSystem())
                 .freeSemester(middleSchoolAchievement.getFreeSemester())
                 .gedTotalScore(middleSchoolAchievement.getGedTotalScore())
-                .gedMaxScore(middleSchoolAchievement.getGedMaxScore())
                 .build();
     }
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGedServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGedServiceTest.java
@@ -63,7 +63,6 @@ class CalculateGedServiceTest {
             void it_calculates_and_saves_results() {
                 reqDto = MiddleSchoolAchievementReqDto.builder()
                         .gedTotalScore(BigDecimal.valueOf(480))
-                        .gedMaxScore(BigDecimal.valueOf(600))
                         .build();
 
                 calculateGedService.execute(reqDto, oneseo, GED);
@@ -76,8 +75,7 @@ class CalculateGedServiceTest {
             @DisplayName("graduationType이 GED라면 올바른 내신 성적을 계산하고 결과를 저장한다")
             void it_ged_calculates_and_save_results() {
                 reqDto = MiddleSchoolAchievementReqDto.builder()
-                        .gedTotalScore(BigDecimal.valueOf(480))
-                        .gedMaxScore(BigDecimal.valueOf(600))
+                        .gedTotalScore(BigDecimal.valueOf(536.91))
                         .build();
 
                 calculateGedService.execute(reqDto, oneseo, GED);
@@ -91,12 +89,12 @@ class CalculateGedServiceTest {
                 EntranceTestFactorsDetail capturedEntranceTestFactorsDetailArgument = entranceTestFactorsDetailArgumentCaptor.getValue();
                 EntranceTestResult capturedEntranceTestResult = entranceTestResultArgumentCaptor.getValue();
 
-                assertEquals(BigDecimal.valueOf(144).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getTotalSubjectsScore());
+                assertEquals(BigDecimal.valueOf(189.528).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getTotalSubjectsScore());
                 assertEquals(BigDecimal.valueOf(30).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getAttendanceScore().setScale(3, UP));
-                assertEquals(BigDecimal.valueOf(20).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getVolunteerScore());
-                assertEquals(BigDecimal.valueOf(50).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getTotalNonSubjectsScore());
+                assertEquals(BigDecimal.valueOf(24.743).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getVolunteerScore());
+                assertEquals(BigDecimal.valueOf(54.743).setScale(3, UP), capturedEntranceTestFactorsDetailArgument.getTotalNonSubjectsScore());
 
-                assertEquals(BigDecimal.valueOf(194).setScale(3, UP), capturedEntranceTestResult.getDocumentEvaluationScore());
+                assertEquals(BigDecimal.valueOf(244.271).setScale(3, UP), capturedEntranceTestResult.getDocumentEvaluationScore());
             }
 
         }
@@ -110,7 +108,6 @@ class CalculateGedServiceTest {
             void it_throw_exception() {
                 reqDto = MiddleSchoolAchievementReqDto.builder()
                         .gedTotalScore(BigDecimal.valueOf(480))
-                        .gedMaxScore(BigDecimal.valueOf(600))
                         .build();
 
                 IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () ->

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoServiceTest.java
@@ -194,7 +194,6 @@ class CreateOneseoServiceTest {
                 assertEquals(liberalSystem, capturedAchievement.getLiberalSystem());
                 assertEquals(freeSemester, capturedAchievement.getFreeSemester());
                 assertEquals(null, capturedAchievement.getGedTotalScore());
-                assertEquals(null, capturedAchievement.getGedMaxScore());
             }
         }
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoServiceTest.java
@@ -218,7 +218,6 @@ class ModifyOneseoServiceTest {
                 assertEquals(liberalSystem, capturedAchievement.getLiberalSystem());
                 assertEquals(freeSemester, capturedAchievement.getFreeSemester());
                 assertEquals(null, capturedAchievement.getGedTotalScore());
-                assertEquals(null, capturedAchievement.getGedMaxScore());
             }
 
             @Test

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdServiceTest.java
@@ -129,7 +129,6 @@ class QueryOneseoByIdServiceTest {
                 assertEquals(middleSchoolAchievement.getLiberalSystem(), middleSchoolAchievementResDto.liberalSystem());
                 assertEquals(middleSchoolAchievement.getFreeSemester(), middleSchoolAchievementResDto.freeSemester());
                 assertEquals(middleSchoolAchievement.getGedTotalScore(), middleSchoolAchievementResDto.gedTotalScore());
-                assertEquals(middleSchoolAchievement.getGedMaxScore(), middleSchoolAchievementResDto.gedMaxScore());
             }
 
             void setUp_it_throws_expected_exception() {
@@ -236,7 +235,6 @@ class QueryOneseoByIdServiceTest {
                 .liberalSystem("자유학년제")
                 .freeSemester(null)
                 .gedTotalScore(bigDecimal)
-                .gedMaxScore(bigDecimal)
                 .build();
     }
 }


### PR DESCRIPTION
## 개요

비즈니스 요구사항 변경으로 인해 `검정고시 만점` 필드는 고정값으로 변경됨에 따라 변경사항들을 반영하였습니다.

## 본문

- MiddleSchoolAchievement 테이블의 `gedMaxScore` 컬럼 삭제
- dto에서 `gedMaxScore`  필드 삭제
- 위의 변경사항에 따른 추가 변경사항, 테스트 코드 수정

## 추가사항
- 작업을 진행하면서 검정고시 환산식에 소수점이  맞지 않아 계산이 제대로 진행되지 않는 부분이 있어 수정하였습니다. 