### PR TITLE
[oneseo] 원서 검색 N+1 문제 개선, 프로젝션 적용

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
@@ -27,6 +27,12 @@ public class Oneseo {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @OneToOne(mappedBy = "oneseo")
+    private EntranceTestResult entranceTestResult;
+
+    @OneToOne(mappedBy = "oneseo")
+    private OneseoPrivacyDetail oneseoPrivacyDetail;
+
     @Column(name = "oneseo_submit_code")
     private String oneseoSubmitCode;
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsmv3.domain.oneseo.repository.custom;
 
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.SearchOneseoResDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,7 +16,7 @@ public interface CustomOneseoRepository {
 
     Integer findMaxSubmitCodeByScreening(Screening screening);
 
-    Page<Oneseo> findAllByKeywordAndScreeningAndSubmissionStatusAndTestResult(
+    Page<SearchOneseoResDto> findAllByKeywordAndScreeningAndSubmissionStatusAndTestResult(
             String keyword,
             ScreeningCategory screening,
             YesNo isSubmitted,

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.SearchOneseoResDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -60,7 +61,7 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
     }
 
     @Override
-    public Page<Oneseo> findAllByKeywordAndScreeningAndSubmissionStatusAndTestResult(
+    public Page<SearchOneseoResDto> findAllByKeywordAndScreeningAndSubmissionStatusAndTestResult(
             String keyword,
             ScreeningCategory screeningTag,
             YesNo isSubmitted,
@@ -75,10 +76,27 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
                 testResultTag
         );
 
-        List<Oneseo> oneseos = queryFactory.selectFrom(oneseo)
-                .leftJoin(oneseo.member, member).fetchJoin()
-                .leftJoin(oneseo.oneseoPrivacyDetail, oneseoPrivacyDetail).fetchJoin()
-                .leftJoin(oneseo.entranceTestResult, entranceTestResult).fetchJoin()
+        List<SearchOneseoResDto> oneseos = queryFactory
+                .select(Projections.constructor(
+                        SearchOneseoResDto.class,
+                        oneseo.member.id,
+                        oneseo.oneseoSubmitCode,
+                        oneseo.realOneseoArrivedYn,
+                        oneseo.member.name,
+                        oneseo.appliedScreening,
+                        oneseo.oneseoPrivacyDetail.schoolName,
+                        oneseo.member.phoneNumber,
+                        oneseo.oneseoPrivacyDetail.guardianPhoneNumber,
+                        oneseo.oneseoPrivacyDetail.schoolTeacherPhoneNumber,
+                        oneseo.entranceTestResult.firstTestPassYn,
+                        oneseo.entranceTestResult.aptitudeEvaluationScore,
+                        oneseo.entranceTestResult.interviewScore,
+                        oneseo.entranceTestResult.secondTestPassYn
+                ))
+                .from(oneseo)
+                .leftJoin(oneseo.member, member)
+                .leftJoin(oneseo.oneseoPrivacyDetail, oneseoPrivacyDetail)
+                .leftJoin(oneseo.entranceTestResult, entranceTestResult)
                 .where(builder)
                 .orderBy(oneseo.oneseoSubmitCode.desc())
                 .offset(pageable.getOffset())

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
@@ -77,8 +77,8 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
 
         List<Oneseo> oneseos = queryFactory.selectFrom(oneseo)
                 .leftJoin(oneseo.member, member).fetchJoin()
-                .leftJoin(oneseoPrivacyDetail).on(oneseoPrivacyDetail.oneseo.eq(oneseo))
-                .leftJoin(entranceTestResult).on(entranceTestResult.id.eq(oneseo.id))
+                .leftJoin(oneseo.oneseoPrivacyDetail, oneseoPrivacyDetail).fetchJoin()
+                .leftJoin(oneseo.entranceTestResult, entranceTestResult).fetchJoin()
                 .where(builder)
                 .orderBy(oneseo.oneseoSubmitCode.desc())
                 .offset(pageable.getOffset())

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
@@ -94,9 +94,9 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
                         oneseo.entranceTestResult.secondTestPassYn
                 ))
                 .from(oneseo)
-                .leftJoin(oneseo.member, member)
-                .leftJoin(oneseo.oneseoPrivacyDetail, oneseoPrivacyDetail)
-                .leftJoin(oneseo.entranceTestResult, entranceTestResult)
+                .join(oneseo.member, member)
+                .join(oneseo.oneseoPrivacyDetail, oneseoPrivacyDetail)
+                .join(oneseo.entranceTestResult, entranceTestResult)
                 .where(builder)
                 .orderBy(oneseo.oneseoSubmitCode.desc())
                 .offset(pageable.getOffset())

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoService.java
@@ -15,20 +15,15 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.OneseoPrivacyDetail;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
-import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
-import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class SearchOneseoService {
 
     private final OneseoRepository oneseoRepository;
-    private final OneseoPrivacyDetailRepository oneseoPrivacyDetailRepository;
-    private final EntranceTestResultRepository entranceTestResultRepository;
 
     public SearchOneseosResDto execute(
             Integer page,
@@ -82,8 +77,8 @@ public class SearchOneseoService {
 
     private SearchOneseoResDto buildSearchOneseoResDto(Oneseo oneseo) {
         Member member = oneseo.getMember();
-        OneseoPrivacyDetail oneseoPrivacyDetail = oneseoPrivacyDetailRepository.findByOneseo(oneseo);
-        EntranceTestResult entranceTestResult = entranceTestResultRepository.findByOneseo(oneseo);
+        OneseoPrivacyDetail oneseoPrivacyDetail = oneseo.getOneseoPrivacyDetail();
+        EntranceTestResult entranceTestResult = oneseo.getEntranceTestResult();
 
         return SearchOneseoResDto.builder()
                 .memberId(member.getId())

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoService.java
@@ -35,7 +35,7 @@ public class SearchOneseoService {
     ) {
 
         Pageable pageable = PageRequest.of(page, size);
-        Page<Oneseo> oneseoPage = findOneseoByTagsAndKeyword(
+        Page<SearchOneseoResDto> oneseoPage = findOneseoByTagsAndKeyword(
                 testResultTag,
                 screeningTag,
                 isSubmitted,
@@ -48,18 +48,13 @@ public class SearchOneseoService {
                 .totalElements(oneseoPage.getTotalElements())
                 .build();
 
-        List<Oneseo> oneseos = oneseoPage.getContent();
-        List<SearchOneseoResDto> searchOneseoResDtos = oneseos.stream()
-                .map(this::buildSearchOneseoResDto)
-                .toList();
-
         return SearchOneseosResDto.builder()
                 .info(infoDto)
-                .oneseos(searchOneseoResDtos)
+                .oneseos(oneseoPage.getContent())
                 .build();
     }
 
-    private Page<Oneseo> findOneseoByTagsAndKeyword(
+    private Page<SearchOneseoResDto> findOneseoByTagsAndKeyword(
             TestResultTag testResultTag,
             ScreeningCategory screeningTag,
             YesNo isSubmitted,
@@ -73,27 +68,5 @@ public class SearchOneseoService {
                 testResultTag,
                 pageable
         );
-    }
-
-    private SearchOneseoResDto buildSearchOneseoResDto(Oneseo oneseo) {
-        Member member = oneseo.getMember();
-        OneseoPrivacyDetail oneseoPrivacyDetail = oneseo.getOneseoPrivacyDetail();
-        EntranceTestResult entranceTestResult = oneseo.getEntranceTestResult();
-
-        return SearchOneseoResDto.builder()
-                .memberId(member.getId())
-                .submitCode(oneseo.getOneseoSubmitCode())
-                .realOneseoArrivedYn(oneseo.getRealOneseoArrivedYn())
-                .name(member.getName())
-                .screening(oneseo.getAppliedScreening())
-                .schoolName(oneseoPrivacyDetail.getSchoolName())
-                .phoneNumber(member.getPhoneNumber())
-                .guardianPhoneNumber(oneseoPrivacyDetail.getGuardianPhoneNumber())
-                .schoolTeacherPhoneNumber(oneseoPrivacyDetail.getSchoolTeacherPhoneNumber())
-                .firstTestPassYn(entranceTestResult.getFirstTestPassYn())
-                .aptitudeEvaluationScore(entranceTestResult.getAptitudeEvaluationScore())
-                .interviewScore(entranceTestResult.getInterviewScore())
-                .secondTestPassYn(entranceTestResult.getSecondTestPassYn())
-                .build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
   jpa:
     database-platform: ${DB_PLATFORM}
     hibernate:
-      ddl-auto: ${HIBERNATE_DDL_AUTO}
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
   jpa:
     database-platform: ${DB_PLATFORM}
     hibernate:
-      ddl-auto: update
+      ddl-auto: ${HIBERNATE_DDL_AUTO}
     show-sql: true
     properties:
       hibernate:

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
@@ -33,18 +33,14 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening.*;
+import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.*;
 
 @DisplayName("SearchOneseoService 클래스의")
 class SearchOneseoServiceTest {
 
     @Mock
     private OneseoRepository oneseoRepository;
-
-    @Mock
-    private OneseoPrivacyDetailRepository oneseoPrivacyDetailRepository;
-
-    @Mock
-    private EntranceTestResultRepository entranceTestResultRepository;
 
     @InjectMocks
     private SearchOneseoService searchOneseoService;
@@ -62,7 +58,7 @@ class SearchOneseoServiceTest {
         private final int size = 3;
         private final TestResultTag testResultTag = TestResultTag.ALL;
         private final ScreeningCategory screeningTag = ScreeningCategory.GENERAL;
-        private final YesNo isSubmitted = YesNo.YES;
+        private final YesNo isSubmitted = YES;
         private final String keyword = "최장우";
 
         @Nested
@@ -103,9 +99,10 @@ class SearchOneseoServiceTest {
             void setUp() {
                 Pageable pageable = PageRequest.of(page, size);
                 member = buildMember();
+                oneseo = buildOneseo();
 
                 oneseoPrivacyDetail = buildOneseoPrivacyDetail();
-                entranceTestResult = mock(EntranceTestResult.class);
+                entranceTestResult = buildEntranceTestResult();
 
                 SearchOneseoResDto searchOneseoResDto = buildSearchOneseDto(member, oneseo, oneseoPrivacyDetail, entranceTestResult);
                 Page<SearchOneseoResDto> oneseoPage = new PageImpl<>(List.of(searchOneseoResDto), pageable, 1);
@@ -113,7 +110,6 @@ class SearchOneseoServiceTest {
                 given(oneseoRepository.findAllByKeywordAndScreeningAndSubmissionStatusAndTestResult(
                         keyword, screeningTag, isSubmitted, testResultTag, pageable
                 )).willReturn(oneseoPage);
-                stubEntranceTestResult(entranceTestResult);
             }
 
             @Test
@@ -160,7 +156,12 @@ class SearchOneseoServiceTest {
     }
 
     private Oneseo buildOneseo() {
-
+        return Oneseo.builder()
+                .id(1L)
+                .oneseoSubmitCode("A-1")
+                .realOneseoArrivedYn(YES)
+                .appliedScreening(GENERAL)
+                .build();
     }
 
     private SearchOneseoResDto buildSearchOneseDto(Member member, Oneseo oneseo, OneseoPrivacyDetail oneseoPrivacyDetail, EntranceTestResult entranceTestResult) {
@@ -181,10 +182,13 @@ class SearchOneseoServiceTest {
                 .build();
     }
 
-    private void stubEntranceTestResult(EntranceTestResult entranceTestResult) {
-        given(entranceTestResult.getFirstTestPassYn()).willReturn(YesNo.YES);
-        given(entranceTestResult.getAptitudeEvaluationScore()).willReturn(BigDecimal.TEN);
-        given(entranceTestResult.getInterviewScore()).willReturn(BigDecimal.TEN);
-        given(entranceTestResult.getFirstTestPassYn()).willReturn(YesNo.YES);
+    private EntranceTestResult buildEntranceTestResult() {
+        return EntranceTestResult.builder()
+                .id(1L)
+                .firstTestPassYn(YES)
+                .aptitudeEvaluationScore(BigDecimal.TEN)
+                .interviewScore(BigDecimal.TEN)
+                .secondTestPassYn(YES)
+                .build();
     }
 }

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
@@ -103,17 +103,16 @@ class SearchOneseoServiceTest {
             void setUp() {
                 Pageable pageable = PageRequest.of(page, size);
                 member = buildMember();
-                oneseo = buildOneseo(member);
-                Page<Oneseo> oneseoPage = new PageImpl<>(List.of(oneseo), pageable, 1);
 
                 oneseoPrivacyDetail = buildOneseoPrivacyDetail();
                 entranceTestResult = mock(EntranceTestResult.class);
 
+                oneseo = buildOneseo(member, oneseoPrivacyDetail, entranceTestResult);
+                Page<Oneseo> oneseoPage = new PageImpl<>(List.of(oneseo), pageable, 1);
+
                 given(oneseoRepository.findAllByKeywordAndScreeningAndSubmissionStatusAndTestResult(
                         keyword, screeningTag, isSubmitted, testResultTag, pageable
                 )).willReturn(oneseoPage);
-                given(oneseoPrivacyDetailRepository.findByOneseo(oneseo)).willReturn(oneseoPrivacyDetail);
-                given(entranceTestResultRepository.findByOneseo(oneseo)).willReturn(entranceTestResult);
                 stubEntranceTestResult(entranceTestResult);
             }
 
@@ -160,12 +159,14 @@ class SearchOneseoServiceTest {
                 .build();
     }
 
-    private Oneseo buildOneseo(Member member) {
+    private Oneseo buildOneseo(Member member, OneseoPrivacyDetail oneseoPrivacyDetail, EntranceTestResult entranceTestResult) {
         return Oneseo.builder()
                 .member(member)
                 .oneseoSubmitCode("submit code")
                 .realOneseoArrivedYn(YesNo.YES)
                 .appliedScreening(Screening.GENERAL)
+                .oneseoPrivacyDetail(oneseoPrivacyDetail)
+                .entranceTestResult(entranceTestResult)
                 .build();
     }
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
@@ -72,7 +72,7 @@ class SearchOneseoServiceTest {
             @BeforeEach
             void setUp() {
                 Pageable pageable = PageRequest.of(page, size);
-                Page<Oneseo> emptyPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
+                Page<SearchOneseoResDto> emptyPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
 
                 given(oneseoRepository.findAllByKeywordAndScreeningAndSubmissionStatusAndTestResult(
                         keyword, screeningTag, isSubmitted, testResultTag, pageable
@@ -107,8 +107,8 @@ class SearchOneseoServiceTest {
                 oneseoPrivacyDetail = buildOneseoPrivacyDetail();
                 entranceTestResult = mock(EntranceTestResult.class);
 
-                oneseo = buildOneseo(member, oneseoPrivacyDetail, entranceTestResult);
-                Page<Oneseo> oneseoPage = new PageImpl<>(List.of(oneseo), pageable, 1);
+                SearchOneseoResDto searchOneseoResDto = buildSearchOneseDto(member, oneseo, oneseoPrivacyDetail, entranceTestResult);
+                Page<SearchOneseoResDto> oneseoPage = new PageImpl<>(List.of(searchOneseoResDto), pageable, 1);
 
                 given(oneseoRepository.findAllByKeywordAndScreeningAndSubmissionStatusAndTestResult(
                         keyword, screeningTag, isSubmitted, testResultTag, pageable
@@ -159,14 +159,25 @@ class SearchOneseoServiceTest {
                 .build();
     }
 
-    private Oneseo buildOneseo(Member member, OneseoPrivacyDetail oneseoPrivacyDetail, EntranceTestResult entranceTestResult) {
-        return Oneseo.builder()
-                .member(member)
-                .oneseoSubmitCode("submit code")
-                .realOneseoArrivedYn(YesNo.YES)
-                .appliedScreening(Screening.GENERAL)
-                .oneseoPrivacyDetail(oneseoPrivacyDetail)
-                .entranceTestResult(entranceTestResult)
+    private Oneseo buildOneseo() {
+
+    }
+
+    private SearchOneseoResDto buildSearchOneseDto(Member member, Oneseo oneseo, OneseoPrivacyDetail oneseoPrivacyDetail, EntranceTestResult entranceTestResult) {
+        return SearchOneseoResDto.builder()
+                .memberId(member.getId())
+                .submitCode(oneseo.getOneseoSubmitCode())
+                .realOneseoArrivedYn(oneseo.getRealOneseoArrivedYn())
+                .name(member.getName())
+                .screening(oneseo.getAppliedScreening())
+                .schoolName(oneseoPrivacyDetail.getSchoolName())
+                .phoneNumber(member.getPhoneNumber())
+                .guardianPhoneNumber(oneseoPrivacyDetail.getGuardianPhoneNumber())
+                .schoolTeacherPhoneNumber(oneseoPrivacyDetail.getSchoolTeacherPhoneNumber())
+                .firstTestPassYn(entranceTestResult.getFirstTestPassYn())
+                .aptitudeEvaluationScore(entranceTestResult.getAptitudeEvaluationScore())
+                .interviewScore(entranceTestResult.getInterviewScore())
+                .secondTestPassYn(entranceTestResult.getSecondTestPassYn())
                 .build();
     }
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
@@ -20,10 +20,7 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.response.SearchOneseosResDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.OneseoPrivacyDetail;
-import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
-import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
-import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 
 import java.math.BigDecimal;
@@ -104,7 +101,7 @@ class SearchOneseoServiceTest {
                 oneseoPrivacyDetail = buildOneseoPrivacyDetail();
                 entranceTestResult = buildEntranceTestResult();
 
-                SearchOneseoResDto searchOneseoResDto = buildSearchOneseDto(member, oneseo, oneseoPrivacyDetail, entranceTestResult);
+                SearchOneseoResDto searchOneseoResDto = buildSearchOneseoDto(member, oneseo, oneseoPrivacyDetail, entranceTestResult);
                 Page<SearchOneseoResDto> oneseoPage = new PageImpl<>(List.of(searchOneseoResDto), pageable, 1);
 
                 given(oneseoRepository.findAllByKeywordAndScreeningAndSubmissionStatusAndTestResult(
@@ -164,7 +161,7 @@ class SearchOneseoServiceTest {
                 .build();
     }
 
-    private SearchOneseoResDto buildSearchOneseDto(Member member, Oneseo oneseo, OneseoPrivacyDetail oneseoPrivacyDetail, EntranceTestResult entranceTestResult) {
+    private SearchOneseoResDto buildSearchOneseoDto(Member member, Oneseo oneseo, OneseoPrivacyDetail oneseoPrivacyDetail, EntranceTestResult entranceTestResult) {
         return SearchOneseoResDto.builder()
                 .memberId(member.getId())
                 .submitCode(oneseo.getOneseoSubmitCode())


### PR DESCRIPTION
## 개요

N+1 문제가 발생하던 원서 조회 기능을 개선하였습니다.

## 문제상황

`Oneseo`엔티티와 `OneseoPrivacyDetail`, `EntranceTestResult`엔티티는 1:1 연관관계로 매핑되어있습니다.

기존 원서 검색시에는 `Oneseo`엔티티를 조회 후 map으로 순회하며 `OneseoPrivacyDetail`, `EntranceTestResult`엔티티를 조회하였습니다. 이런 방식은 1 (root = oneseoes) + 2N (OneseoPrivacyDetail, EntranceTestResult) 만큼의 추가 쿼리가 발생하므로 성능 저하가 발생합니다.

## 해결

<img width="445" alt="Oneseo 엔티티 양방향 연관관계 매핑 추가" src="https://github.com/user-attachments/assets/a80a23aa-2ff4-4783-b7ab-6fc3ce225e5e">

`Oneseo` 엔티티에서 `OneseoPrivacyDetail`, `EntranceTestResult` 엔티티에 대한 양방향 연관관계를 만들어 fetch join하여 문제를 해결하였습니다. 하지만 세 엔티티를 페치조인하니 select 절의 컬럼 수가 상당히 많아졌습니다. (30개)

페치조인보다 일반조인을 하여 원서 검색시 필요한 필드만 조회하는것이 더 성능이 좋을것이라 생각하여 프로젝션을 적용하여 필요한 필드 가져와 DTO로 바로 조회하는 방법을 선택하였습니다.

최종적으로 원서 검색을 쿼리 1번으로 최적화 하였고 프로젝션을 적용하여 필요한 필드만 조회하도록 개선하였습니다.

<img width="384" alt="fetch join과 프로젝션 쿼리 비교" src="https://github.com/user-attachments/assets/08760f18-c170-4c7f-987f-2c2e781a7e3c">
