### PR TITLE
[oneseo] 심층 면접 점수 기입 서비스로직 테스트코드 추가

### DIFF
--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyInterviewScoreServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyInterviewScoreServiceTest.java
@@ -50,7 +50,7 @@ public class ModifyInterviewScoreServiceTest {
         private final BigDecimal updatedInterviewScore = BigDecimal.valueOf(99.25);
 
         @Nested
-        @DisplayName("존재하는 회원 ID와 인터뷰 점수가 주어지면")
+        @DisplayName("존재하는 회원 ID와 심층면접 점수가 주어지면")
         class Context_with_existing_member_id_and_interview_score {
 
             EntranceTestResult entranceTestResult;

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyInterviewScoreServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyInterviewScoreServiceTest.java
@@ -1,0 +1,140 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.member.service.MemberService;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.InterviewScoreReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("ModifyInterviewScoreService 클래스의")
+public class ModifyInterviewScoreServiceTest {
+
+    @Mock
+    private MemberService memberService;
+    @Mock
+    private OneseoService oneseoService;
+    @Mock
+    private EntranceTestResultRepository entranceTestResultRepository;
+
+    @InjectMocks
+    private ModifyInterviewScoreService modifyInterviewScoreService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Nested
+    @DisplayName("execute 메소드는")
+    class Describe_execute {
+
+        private final Long memberId = 1L;
+        private final BigDecimal updatedInterviewScore = BigDecimal.valueOf(99.25);
+
+        @Nested
+        @DisplayName("존재하는 회원 ID와 인터뷰 점수가 주어지면")
+        class Context_with_existing_member_id_and_interview_score {
+
+            EntranceTestResult entranceTestResult;
+
+            @BeforeEach
+            void setUp() {
+                Member member = Member.builder()
+                        .id(memberId)
+                        .build();
+
+                Oneseo oneseo = Oneseo.builder()
+                        .member(member)
+                        .build();
+
+                entranceTestResult = EntranceTestResult.builder()
+                        .interviewScore(BigDecimal.valueOf(75))
+                        .build();
+
+                given(memberService.findByIdOrThrow(memberId)).willReturn(member);
+                given(oneseoService.findByMemberOrThrow(member)).willReturn(oneseo);
+                given(entranceTestResultRepository.findByOneseo(oneseo)).willReturn(entranceTestResult);
+            }
+
+            @Test
+            @DisplayName("심층면접 점수를 저장한다.")
+            void it_saves_interview_score() {
+                InterviewScoreReqDto interviewScoreReqDto = new InterviewScoreReqDto(updatedInterviewScore);
+                modifyInterviewScoreService.execute(memberId, interviewScoreReqDto);
+
+                ArgumentCaptor<EntranceTestResult> entranceTestResultCaptor = ArgumentCaptor.forClass(EntranceTestResult.class);
+
+                verify(entranceTestResultRepository).save(entranceTestResultCaptor.capture());
+
+                EntranceTestResult capturedEntranceTestResult = entranceTestResultCaptor.getValue();
+
+                assertEquals(updatedInterviewScore, capturedEntranceTestResult.getInterviewScore());
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 회원 ID가 주어지면")
+        class Context_with_non_existing_member_id {
+
+            @BeforeEach
+            void setUp() {
+                given(memberService.findByIdOrThrow(memberId)).willThrow(new ExpectedException("존재하지 않는 지원자입니다. member ID: ", HttpStatus.NOT_FOUND));
+            }
+
+            @Test
+            @DisplayName("ExpectedException을 던진다")
+            void it_throws_expected_exception() {
+                InterviewScoreReqDto interviewScoreReqDto = new InterviewScoreReqDto(updatedInterviewScore);
+
+                ExpectedException exception = assertThrows(ExpectedException.class, () -> modifyInterviewScoreService.execute(memberId, interviewScoreReqDto));
+
+                assertEquals("존재하지 않는 지원자입니다. member ID: ", exception.getMessage());
+                assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+            }
+        }
+
+        @Nested
+        @DisplayName("원서가 존재하지 않는다면")
+        class Context_with_non_existing_oneseo {
+
+            @BeforeEach
+            void setUp() {
+                Member member = Member.builder()
+                        .id(memberId)
+                        .build();
+
+                given(memberService.findByIdOrThrow(memberId)).willReturn(member);
+                given(oneseoService.findByMemberOrThrow(member)).willThrow(new ExpectedException("해당 지원자의 원서를 찾을 수 없습니다. member ID: " + memberId, HttpStatus.NOT_FOUND));
+            }
+
+            @Test
+            @DisplayName("ExpectedException을 던진다")
+            void it_throws_expected_exception() {
+                InterviewScoreReqDto interviewScoreReqDto = new InterviewScoreReqDto(updatedInterviewScore);
+
+                ExpectedException exception = assertThrows(ExpectedException.class, () -> modifyInterviewScoreService.execute(memberId, interviewScoreReqDto));
+
+                assertEquals("해당 지원자의 원서를 찾을 수 없습니다. member ID: " + memberId, exception.getMessage());
+                assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요

심층 면접 점수 기입 서비스로직 테스트코드를 작성하였습니다.

## 본문

<img width="368" alt="스크린샷 2024-08-05 오전 1 25 03" src="https://github.com/user-attachments/assets/2b43035a-712e-4735-8e61-6e5ed306ea3e">
