### PR TITLE
[oneseo] 원서 검색 총 원서 개수 조회 로직 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.SearchOneseoResDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
@@ -103,11 +104,15 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        return new PageImpl<>(
-                oneseos,
-                pageable,
-                oneseos.size()
-        );
+        return PageableExecutionUtils.getPage(oneseos, pageable, () -> getTotalCount(builder));
+    }
+
+    private long getTotalCount(BooleanBuilder builder) {
+        return queryFactory
+                .select(oneseo.count())
+                .from(oneseo)
+                .where(builder)
+                .fetchFirst();
     }
 
     private BooleanBuilder createBooleanBuilder(


### PR DESCRIPTION
## 개요

원서 검색시 `totalElements - 총 원서 개수` 필드가 모든 페이지의 총 원서 개수가 아닌 현재 페이지의 원서 개수를 출력하는 이슈가 있어 해결하였습니다.

## 본문

- 기존에는 검색된 페이지의 원서 size를 `totalElements` 값으로 설정하였습니다. 해당 부분을 count 쿼리 메서드를 추가하여 검색 조건에 맞는 모든 원서의 개수를 `totalElements` 값으로 설정하도록 변경하였습니다.
- `PageableExecutionUtils` 클래스를 활용하여 count 쿼리가 필요없는 상황에서는 count 쿼리를 날리지 않도록 최적화 하였습니다.
   - count 쿼리가 필요없는 상황: 컨텐츠 사이즈가 페이지 사이즈 보다 작을때, 마지막 페이지일때