### PR TITLE
[oneseo] 원서 검색 쿼리 잘못된 조건 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
@@ -205,7 +205,7 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
             case FALL ->
                     builder.andAnyOf(
                             entranceTestResult.firstTestPassYn.eq(YesNo.NO),
-                            entranceTestResult.firstTestPassYn.eq(YesNo.NO)
+                            entranceTestResult.secondTestPassYn.eq(YesNo.NO)
                     );
         }
     }


### PR DESCRIPTION
## 개요

원서 검색 쿼리에서 잘못된 조건이 걸리는 부분이 존재하여 수정하였습니다.

## 본문

원서 검색 쿼리인 `findAllByKeywordAndScreeningAndSubmissionStatusAndTestResult` 메서드의 where절을 build하는 부분에서 `FALL` case에 대해 1차시험결과에 대한 조건만 걸고 있었습니다.   

`andAnyOf`를 통해 1,2차 중 하나라도 FALL인 유저가 필터링되도록 수정하였습니다.