### PR TITLE
[global] 특정 기간에만 사용 사능한 API 검증용 custom filter 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/global/config/PropertiesScanConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/config/PropertiesScanConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ConfigurationPropertiesScan(basePackages = {
+                "team.themoment.hellogsmv3.global.security.data",
                 "team.themoment.hellogsmv3.global.security.auth",
                 "team.themoment.hellogsmv3.global.thirdParty.aws.s3.properties"})
 public class PropertiesScanConfig {

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -24,7 +24,6 @@ import team.themoment.hellogsmv3.global.security.handler.CustomAuthenticationEnt
 import team.themoment.hellogsmv3.global.security.handler.CustomUrlAuthenticationSuccessHandler;
 
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.Arrays;
 
 @Configuration

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsmv3.global.security;
 
+import jakarta.servlet.Filter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,19 +17,36 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import team.themoment.hellogsmv3.domain.member.entity.type.Role;
 import team.themoment.hellogsmv3.global.common.logging.LoggingFilter;
 import team.themoment.hellogsmv3.global.security.auth.AuthEnvironment;
+import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
+import team.themoment.hellogsmv3.global.security.filter.TimeBasedFilter;
 import team.themoment.hellogsmv3.global.security.handler.CustomAccessDeniedHandler;
 import team.themoment.hellogsmv3.global.security.handler.CustomAuthenticationEntryPoint;
 import team.themoment.hellogsmv3.global.security.handler.CustomUrlAuthenticationSuccessHandler;
 
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
+    private final ScheduleEnvironment scheduleEnv;
     private final AuthEnvironment authEnv;
     private final CustomAccessDeniedHandler accessDeniedHandler;
     private final CustomAuthenticationEntryPoint authenticationEntryPoint;
     private final LoggingFilter loggingFilter;
+
+    @Bean
+    public Filter timeBasedFilter() {
+        LocalDateTime startReception = scheduleEnv.startReceptionDate();
+        LocalDateTime endReception = scheduleEnv.endReceptionDate();
+
+        return new TimeBasedFilter()
+                .addFilter(HttpMethod.POST, "/oneseo/v3/temp-storage", startReception, endReception)
+                .addFilter(HttpMethod.POST, "/oneseo/v3/oneseo/me", startReception, endReception)
+                .addFilter(HttpMethod.GET, "/oneseo/v3/oneseo/me", startReception, endReception)
+                .addFilter(HttpMethod.POST, "/oneseo/v3/image", startReception, endReception);
+    }
 
     @Configuration
     @EnableWebSecurity

--- a/src/main/java/team/themoment/hellogsmv3/global/security/data/ScheduleEnvironment.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/data/ScheduleEnvironment.java
@@ -1,0 +1,12 @@
+package team.themoment.hellogsmv3.global.security.data;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.LocalDateTime;
+
+@ConfigurationProperties(prefix = "schedule")
+public record ScheduleEnvironment(
+    LocalDateTime startReceptionDate,
+    LocalDateTime endReceptionDate
+) {
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/security/filter/TimeBasedFilter.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/filter/TimeBasedFilter.java
@@ -1,0 +1,86 @@
+package team.themoment.hellogsmv3.global.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class TimeBasedFilter extends OncePerRequestFilter {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private final Map<String, TimeRange> urlTimeRanges = new HashMap<>();
+
+    private static class TimeRange {
+        private final LocalDateTime startTime;
+        private final LocalDateTime endTime;
+
+        public TimeRange(LocalDateTime startTime, LocalDateTime endTime) {
+            this.startTime = startTime;
+            this.endTime = endTime;
+        }
+
+        public boolean isWithinRange(LocalDateTime currentTime) {
+            return currentTime.isAfter(startTime) && currentTime.isBefore(endTime);
+        }
+    }
+
+    public TimeBasedFilter addFilter(HttpMethod httpMethod, String url, LocalDateTime startTime, LocalDateTime endTime) {
+        urlTimeRanges.put(url + ":" + httpMethod, new TimeRange(startTime, endTime));
+        return this;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String requestUrl = request.getRequestURI();
+        HttpMethod requestMethod;
+
+        try {
+            requestMethod = HttpMethod.valueOf(request.getMethod());
+        } catch (IllegalArgumentException e) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "유효하지 않은 HTTP 메서드 입니다. : " + request.getMethod());
+            return;
+        }
+
+        LocalDateTime currentTime = LocalDateTime.now();
+        String timeRangeKey = requestUrl + ":" + requestMethod;
+
+        if (urlTimeRanges.containsKey(timeRangeKey)) {
+            TimeRange timeRange = urlTimeRanges.get(timeRangeKey);
+
+            if (timeRange.isWithinRange(currentTime)) {
+                filterChain.doFilter(request, response);
+            } else {
+                String message = String.format("%s 요청이 거부되었습니다. " +
+                        "현재 시간: %s, 해당 요청은 %s ~ %s 이내에만 처리 가능합니다.", timeRangeKey, currentTime, timeRange.startTime, timeRange.endTime);
+                log.warn(message);
+                sendErrorResponse(response, message);
+            }
+
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, String message) throws IOException {
+        response.setCharacterEncoding("utf-8");
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write(objectMapper.writeValueAsString(
+                CommonApiResponse.error(message, HttpStatus.FORBIDDEN)
+        ));
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/security/filter/TimeBasedFilter.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/filter/TimeBasedFilter.java
@@ -37,14 +37,14 @@ public class TimeBasedFilter extends OncePerRequestFilter {
         }
     }
 
-    public TimeBasedFilter addFilter(HttpMethod httpMethod, String url, LocalDateTime startTime, LocalDateTime endTime) {
-        urlTimeRanges.put(url + ":" + httpMethod, new TimeRange(startTime, endTime));
+    public TimeBasedFilter addFilter(HttpMethod httpMethod, String uri, LocalDateTime startTime, LocalDateTime endTime) {
+        urlTimeRanges.put(uri + ":" + httpMethod, new TimeRange(startTime, endTime));
         return this;
     }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        String requestUrl = request.getRequestURI();
+        String requestUri = request.getRequestURI();
         HttpMethod requestMethod;
 
         try {
@@ -55,7 +55,7 @@ public class TimeBasedFilter extends OncePerRequestFilter {
         }
 
         LocalDateTime currentTime = LocalDateTime.now();
-        String timeRangeKey = requestUrl + ":" + requestMethod;
+        String timeRangeKey = requestUri + ":" + requestMethod;
 
         if (urlTimeRanges.containsKey(timeRangeKey)) {
             TimeRange timeRange = urlTimeRanges.get(timeRangeKey);

--- a/src/main/java/team/themoment/hellogsmv3/global/security/filter/TimeBasedFilter.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/filter/TimeBasedFilter.java
@@ -21,24 +21,16 @@ import java.util.Map;
 public class TimeBasedFilter extends OncePerRequestFilter {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    private final Map<String, TimeRange> urlTimeRanges = new HashMap<>();
+    private final Map<String, RequestPeriod> urlRequestPeriods = new HashMap<>();
 
-    private static class TimeRange {
-        private final LocalDateTime startTime;
-        private final LocalDateTime endTime;
-
-        public TimeRange(LocalDateTime startTime, LocalDateTime endTime) {
-            this.startTime = startTime;
-            this.endTime = endTime;
-        }
-
+    private record RequestPeriod(LocalDateTime startTime, LocalDateTime endTime) {
         public boolean isWithinRange(LocalDateTime currentTime) {
             return currentTime.isAfter(startTime) && currentTime.isBefore(endTime);
         }
     }
 
     public TimeBasedFilter addFilter(HttpMethod httpMethod, String uri, LocalDateTime startTime, LocalDateTime endTime) {
-        urlTimeRanges.put(uri + ":" + httpMethod, new TimeRange(startTime, endTime));
+        urlRequestPeriods.put(uri + ":" + httpMethod, new RequestPeriod(startTime, endTime));
         return this;
     }
 
@@ -55,16 +47,16 @@ public class TimeBasedFilter extends OncePerRequestFilter {
         }
 
         LocalDateTime currentTime = LocalDateTime.now();
-        String timeRangeKey = requestUri + ":" + requestMethod;
+        String requestPeriodKey = requestUri + ":" + requestMethod;
 
-        if (urlTimeRanges.containsKey(timeRangeKey)) {
-            TimeRange timeRange = urlTimeRanges.get(timeRangeKey);
+        if (urlRequestPeriods.containsKey(requestPeriodKey)) {
+            RequestPeriod requestPeriod = urlRequestPeriods.get(requestPeriodKey);
 
-            if (timeRange.isWithinRange(currentTime)) {
+            if (requestPeriod.isWithinRange(currentTime)) {
                 filterChain.doFilter(request, response);
             } else {
                 String message = String.format("%s 요청이 거부되었습니다. " +
-                        "현재 시간: %s, 해당 요청은 %s ~ %s 이내에만 처리 가능합니다.", timeRangeKey, currentTime, timeRange.startTime, timeRange.endTime);
+                        "현재 시간: %s, 해당 요청은 %s ~ %s 이내에만 처리 가능합니다.", requestPeriodKey, currentTime, requestPeriod.startTime, requestPeriod.endTime);
                 log.warn(message);
                 sendErrorResponse(response, message);
             }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -87,6 +87,10 @@ auth:
   loginEndPointBaseUri: /auth/v3/oauth2/authorization
   loginProcessingUri: /login/oauth2/code/*
 
+schedule:
+  startReceptionDate: ${START_RECEPTION_DATE}
+  endReceptionDate: ${END_RECEPTION_DATE}
+
 springdoc:
   api-docs:
     path: /api-docs


### PR DESCRIPTION
## 개요

특정 기간에만 사용 사능한 API 검증용 custom filter를 추가하였습니다.

## 본문

입학요강을 바탕으로  원서 임시저장, 원서 저장, 내 원서 조회, 증명사진 등록하기 기능을 `10월 14일 09:00` ~ `10월 17일 17:00` 해당 기간 사이에만 사용 가능하도록 TimeBasedFilter를 구현하였습니다.

`TimeBasedFilter`에 startTime, endTime을 env로 받아 `SecurityConfig`에서 기간을 제한할 API url, method를 등록시켜 특정 기간 이외의 시간에 요청을 보내면 403 예외를 발생시키도록 구현하였습니다.

> application.yml 파일이 변경되어 노션을 참고하여 로컬 환경에 반영 부탁드립니다.