### PR TITLE
[member] 인증번호 전송 기능 aws sns 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 
     /** lombok **/
     compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'\
+    annotationProcessor 'org.projectlombok:lombok'
 
     /** object serialize **/
     implementation 'com.google.code.gson:gson:2.10.1'
@@ -59,6 +59,7 @@ dependencies {
 
     /** aws **/
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.1'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-sns:3.0.1'
 
     /** excel **/
     implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.2.3'

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/SendCodeNotificationService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/SendCodeNotificationService.java
@@ -1,0 +1,5 @@
+package team.themoment.hellogsmv3.domain.member.service;
+
+public interface SendCodeNotificationService {
+    void execute(String phoneNumber, String code);
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImpl.java
@@ -7,6 +7,7 @@ import team.themoment.hellogsmv3.domain.member.dto.request.GenerateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
 import team.themoment.hellogsmv3.domain.member.service.GenerateCodeService;
+import team.themoment.hellogsmv3.domain.member.service.SendCodeNotificationService;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.util.Random;
@@ -16,6 +17,7 @@ import java.util.Random;
 public class GenerateCodeServiceImpl extends GenerateCodeService {
 
     private final CodeRepository codeRepository;
+    private final SendCodeNotificationService sendCodeNotificationService;
     private static final Random RANDOM = new Random();
 
     @Override
@@ -29,16 +31,18 @@ public class GenerateCodeServiceImpl extends GenerateCodeService {
                     "너무 많은 요청이 발생했습니다. 잠시 후 다시 시도해주세요. 특정 시간 내 제한 횟수인 %d회를 초과하였습니다.",
                     LIMIT_COUNT_CODE_REQUEST), HttpStatus.BAD_REQUEST);
 
+        String phoneNumber = reqDto.phoneNumber();
+
         final String code = generateUniqueCode(RANDOM, codeRepository);
 
         codeRepository.save(createAuthenticationCode(
                 authenticationCode,
                 memberId,
                 code,
-                reqDto.phoneNumber(),
+                phoneNumber,
                 false));
 
-        // TODO 문자 발송 로직
+        sendCodeNotificationService.execute(phoneNumber, code);
 
         return code;
     }

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/sns/SendSmsService.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/sns/SendSmsService.java
@@ -1,5 +1,5 @@
 package team.themoment.hellogsmv3.global.thirdParty.aws.sns;
 
 public interface SendSmsService {
-    void execute(String phoneNumber, String message);
+    void execute(String phoneNumber, String contentMessage, String footerMessage);
 }

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/sns/SendSmsService.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/sns/SendSmsService.java
@@ -1,0 +1,5 @@
+package team.themoment.hellogsmv3.global.thirdParty.aws.sns;
+
+public interface SendSmsService {
+    void execute(String phoneNumber, String message);
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/sns/impl/SendCodeNotificationServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/sns/impl/SendCodeNotificationServiceImpl.java
@@ -13,10 +13,20 @@ public class SendCodeNotificationServiceImpl implements SendCodeNotificationServ
 
     @Override
     public void execute(String phoneNumber, String code) {
-        sendSmsService.execute(phoneNumber, createMessage(code));
+        sendSmsService.execute(phoneNumber, createContentMessage(code), createFooterMessage());
     }
 
-    private static String createMessage(String code) {
-        return "[Hello, GSM] 본인인증번호 [" + code + "]를 입력해주세요.";
+    private static String createContentMessage(String code) {
+        return String.format(
+                """
+                [Hello, GSM | 광주소프트웨어마이스터고등학교 입학지원시스템]
+                
+                인증번호 [%s]를 입력해주세요.
+                """, code
+        );
+    }
+
+    private static String createFooterMessage() {
+        return "- 본인이 요청한게 아니라면 행정실 062-949-6800으로 문의해주세요. ";
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/sns/impl/SendCodeNotificationServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/sns/impl/SendCodeNotificationServiceImpl.java
@@ -1,0 +1,22 @@
+package team.themoment.hellogsmv3.global.thirdParty.aws.sns.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.themoment.hellogsmv3.domain.member.service.SendCodeNotificationService;
+import team.themoment.hellogsmv3.global.thirdParty.aws.sns.SendSmsService;
+
+@Service
+@RequiredArgsConstructor
+public class SendCodeNotificationServiceImpl implements SendCodeNotificationService {
+
+    private final SendSmsService sendSmsService;
+
+    @Override
+    public void execute(String phoneNumber, String code) {
+        sendSmsService.execute(phoneNumber, createMessage(code));
+    }
+
+    private static String createMessage(String code) {
+        return "[Hello, GSM] 본인인증번호 [" + code + "]를 입력해주세요.";
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/sns/impl/SendCodeNotificationServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/sns/impl/SendCodeNotificationServiceImpl.java
@@ -27,6 +27,6 @@ public class SendCodeNotificationServiceImpl implements SendCodeNotificationServ
     }
 
     private static String createFooterMessage() {
-        return "- 본인이 요청한게 아니라면 행정실 062-949-6800으로 문의해주세요. ";
+        return "본인이 요청한게 아니라면 행정실 062-949-6800으로 문의해주세요.";
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/sns/impl/SendSmsServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/sns/impl/SendSmsServiceImpl.java
@@ -19,16 +19,23 @@ public class SendSmsServiceImpl implements SendSmsService {
     private final AwsTemplate<Void> executeWithExceptionHandle;
 
     @Override
-    public void execute(String phoneNumber, String message) {
+    public void execute(String phoneNumber, String contentMessage, String footerMessage) {
         executeWithExceptionHandle.execute(() -> {
             smsTemplate.send(
                     createPhoneNumber(phoneNumber),
-                    message,
+                    contentMessage,
                     SmsMessageAttributes.builder()
                             .smsType(TRANSACTIONAL)
                             .senderID(SENDER_ID)
-                            .build()
-            );
+                            .build());
+
+            smsTemplate.send(
+                    createPhoneNumber(phoneNumber),
+                    footerMessage,
+                    SmsMessageAttributes.builder()
+                            .smsType(TRANSACTIONAL)
+                            .senderID(SENDER_ID)
+                            .build());
             return null;
         });
     }

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/sns/impl/SendSmsServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/sns/impl/SendSmsServiceImpl.java
@@ -1,0 +1,39 @@
+package team.themoment.hellogsmv3.global.thirdParty.aws.sns.impl;
+
+import io.awspring.cloud.sns.sms.SmsMessageAttributes;
+import io.awspring.cloud.sns.sms.SnsSmsTemplate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.themoment.hellogsmv3.global.thirdParty.aws.sns.SendSmsService;
+import team.themoment.hellogsmv3.global.thirdParty.aws.sns.template.AwsTemplate;
+
+import static io.awspring.cloud.sns.sms.SmsType.*;
+
+@Service
+@RequiredArgsConstructor
+public class SendSmsServiceImpl implements SendSmsService {
+
+    private static final String SENDER_ID = "hello-gsm";
+    private static final String KR_CODE = "+82";
+    private final SnsSmsTemplate smsTemplate;
+    private final AwsTemplate<Void> executeWithExceptionHandle;
+
+    @Override
+    public void execute(String phoneNumber, String message) {
+        executeWithExceptionHandle.execute(() -> {
+            smsTemplate.send(
+                    createPhoneNumber(phoneNumber),
+                    message,
+                    SmsMessageAttributes.builder()
+                            .smsType(TRANSACTIONAL)
+                            .senderID(SENDER_ID)
+                            .build()
+            );
+            return null;
+        });
+    }
+
+    private static String createPhoneNumber(String phoneNumber) {
+        return KR_CODE + phoneNumber;
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/sns/template/AwsCallBack.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/sns/template/AwsCallBack.java
@@ -1,0 +1,12 @@
+package team.themoment.hellogsmv3.global.thirdParty.aws.sns.template;
+
+import io.awspring.cloud.s3.S3Exception;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+
+import java.io.IOException;
+
+@FunctionalInterface
+public interface AwsCallBack<T> {
+    T execute() throws SdkClientException, S3Exception, AwsServiceException, IOException;
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/sns/template/AwsTemplate.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/sns/template/AwsTemplate.java
@@ -1,0 +1,25 @@
+package team.themoment.hellogsmv3.global.thirdParty.aws.sns.template;
+
+import io.awspring.cloud.s3.S3Exception;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+
+import java.io.IOException;
+
+@Component
+public class AwsTemplate<T> {
+    public T execute(AwsCallBack<T> action) {
+        try {
+            return action.execute();
+        } catch (SdkClientException e) {
+            throw new RuntimeException("클라이언트 측(서버) 문제로 인한 예외 발생", e);
+        } catch (S3Exception e) {
+            throw new RuntimeException("Amazon web service 중 S3에서 예외 발생", e);
+        } catch (AwsServiceException e) {
+            throw new RuntimeException("Amazon web service 에서 예외 발생", e);
+        } catch (IOException e) {
+            throw new RuntimeException("IOException 발생", e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,6 +72,8 @@ spring:
         static: ${AWS_REGION}
       stack:
         auto: false
+      sns:
+        region: ${AWS_SNS_REGION}
 
   servlet:
     multipart:


### PR DESCRIPTION
## 개요


인증번호 전송 로직을 aws sns에 연동하여 인증번호 문자 전송 기능을 구현하였습니다.

<img width="390" alt="스크린샷 2024-08-14 오후 2 55 06" src="https://github.com/user-attachments/assets/ab592f12-5fc1-47e8-8ae8-01cfb2dc2fd3">


## 본문

- `SendCodeNotificationService`를 구현하여 기존 `GenerateCodeServiceImpl`에서 생성된 인증번호를 aws sns를 통해 문자메시지로 전송하도록 연동하였습니다.
- 한국 region에서는 aws sns에서 문자 메시지 전송 기능을 지원하지 않아 작년 구현과 같이 도쿄 region을 사용하였습니다.

- 메시지는 총 두번으로 나누어 발송됩니다. (인증번호 content & 면책조항 footer) 한번 발송시 두번의 메시지가 발송되기 때문에 1회 발송시 비용은 약 `0.02414 * 2 = 0.04828USD`으로 약 65.68원이 발생합니다.