### PR TITLE
[oneseo] 원서 관련 redis 캐시 문제 개선

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestResult.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestResult.java
@@ -20,7 +20,7 @@ public class EntranceTestResult {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "entrance _test_result_id")
+    @Column(name = "entrance_test_result_id")
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/ScreeningChangeHistory.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/ScreeningChangeHistory.java
@@ -19,7 +19,7 @@ public class ScreeningChangeHistory {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "entrance _test_result_id")
+    @Column(name = "entrance_test_result_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -1,6 +1,8 @@
 package team.themoment.hellogsmv3.domain.oneseo.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -9,6 +11,10 @@ import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.DesiredMajorsResDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.FoundOneseoResDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.MiddleSchoolAchievementResDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.OneseoPrivacyDetailResDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.MiddleSchoolAchievement;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.OneseoPrivacyDetail;
@@ -22,6 +28,7 @@ import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import java.util.List;
 
 import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.*;
+import static team.themoment.hellogsmv3.domain.oneseo.service.OneseoService.ONESEO_CACHE_VALUE;
 
 @Service
 @RequiredArgsConstructor
@@ -33,9 +40,10 @@ public class CreateOneseoService {
     private final MemberService memberService;
     private final CalculateGradeService calculateGradeService;
     private final CalculateGedService calculateGedService;
+    private final CacheManager cacheManager;
 
     @Transactional
-    @CacheEvict(value = "oneseo", key = "#memberId")
+    @CacheEvict(value = OneseoService.ONESEO_CACHE_VALUE, key = "#memberId")
     public void execute(OneseoReqDto reqDto, Long memberId) {
         Member currentMember = memberService.findByIdOrThrow(memberId);
 
@@ -48,6 +56,85 @@ public class CreateOneseoService {
         saveEntities(oneseo, oneseoPrivacyDetail, middleSchoolAchievement);
 
         calculateMiddleSchoolAchievement(oneseoPrivacyDetail.getGraduationType(), middleSchoolAchievement, oneseo);
+
+        OneseoPrivacyDetailResDto oneseoPrivacyDetailResDto = buildOneseoPrivacyDetailResDto(currentMember, oneseoPrivacyDetail);
+        MiddleSchoolAchievementResDto middleSchoolAchievementResDto = buildMiddleSchoolAchievementResDto(middleSchoolAchievement);
+        FoundOneseoResDto oneseoResDto = buildOneseoResDto(
+                oneseo,
+                oneseoPrivacyDetailResDto,
+                middleSchoolAchievementResDto
+        );
+
+        Cache cache = cacheManager.getCache(ONESEO_CACHE_VALUE);
+        if (cache != null) {
+            cache.put(memberId, oneseoResDto);
+        }
+    }
+
+    private OneseoPrivacyDetailResDto buildOneseoPrivacyDetailResDto(
+            Member member,
+            OneseoPrivacyDetail oneseoPrivacyDetail
+    ) {
+        return OneseoPrivacyDetailResDto.builder()
+                .name(member.getName())
+                .sex(member.getSex())
+                .birth(member.getBirth())
+                .phoneNumber(member.getPhoneNumber())
+                .graduationType(oneseoPrivacyDetail.getGraduationType())
+                .address(oneseoPrivacyDetail.getAddress())
+                .detailAddress(oneseoPrivacyDetail.getDetailAddress())
+                .guardianName(oneseoPrivacyDetail.getGuardianName())
+                .guardianPhoneNumber(oneseoPrivacyDetail.getGuardianPhoneNumber())
+                .relationshipWithGuardian(oneseoPrivacyDetail.getRelationshipWithGuardian())
+                .schoolName(oneseoPrivacyDetail.getSchoolName())
+                .schoolAddress(oneseoPrivacyDetail.getSchoolAddress())
+                .schoolTeacherName(oneseoPrivacyDetail.getSchoolTeacherName())
+                .schoolTeacherPhoneNumber(oneseoPrivacyDetail.getSchoolTeacherPhoneNumber())
+                .profileImg(oneseoPrivacyDetail.getProfileImg())
+                .build();
+    }
+
+    private MiddleSchoolAchievementResDto buildMiddleSchoolAchievementResDto(
+            MiddleSchoolAchievement middleSchoolAchievement
+    ) {
+        return MiddleSchoolAchievementResDto.builder()
+                .achievement1_2(middleSchoolAchievement.getAchievement1_2())
+                .achievement2_1(middleSchoolAchievement.getAchievement2_1())
+                .achievement2_2(middleSchoolAchievement.getAchievement2_2())
+                .achievement3_1(middleSchoolAchievement.getAchievement3_1())
+                .achievement3_2(middleSchoolAchievement.getAchievement3_2())
+                .generalSubjects(middleSchoolAchievement.getGeneralSubjects())
+                .newSubjects(middleSchoolAchievement.getNewSubjects())
+                .artsPhysicalAchievement(middleSchoolAchievement.getArtsPhysicalAchievement())
+                .artsPhysicalSubjects(middleSchoolAchievement.getArtsPhysicalSubjects())
+                .absentDays(middleSchoolAchievement.getAbsentDays())
+                .attendanceDays(middleSchoolAchievement.getAttendanceDays())
+                .volunteerTime(middleSchoolAchievement.getVolunteerTime())
+                .liberalSystem(middleSchoolAchievement.getLiberalSystem())
+                .freeSemester(middleSchoolAchievement.getFreeSemester())
+                .gedTotalScore(middleSchoolAchievement.getGedTotalScore())
+                .build();
+    }
+
+    private FoundOneseoResDto buildOneseoResDto(
+            Oneseo oneseo,
+            OneseoPrivacyDetailResDto oneseoPrivacyDetailResDto,
+            MiddleSchoolAchievementResDto middleSchoolAchievementResDto
+    ) {
+        DesiredMajors desiredMajors = oneseo.getDesiredMajors();
+
+        return FoundOneseoResDto.builder()
+                .oneseoId(oneseo.getId())
+                .submitCode(oneseo.getOneseoSubmitCode())
+                .wantedScreening(oneseo.getWantedScreening())
+                .desiredMajors(DesiredMajorsResDto.builder()
+                        .firstDesiredMajor(desiredMajors.getFirstDesiredMajor())
+                        .secondDesiredMajor(desiredMajors.getSecondDesiredMajor())
+                        .thirdDesiredMajor(desiredMajors.getThirdDesiredMajor())
+                        .build())
+                .privacyDetail(oneseoPrivacyDetailResDto)
+                .middleSchoolAchievement(middleSchoolAchievementResDto)
+                .build();
     }
 
     private void calculateMiddleSchoolAchievement(GraduationType graduationType, MiddleSchoolAchievement middleSchoolAchievement, Oneseo oneseo) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -1,9 +1,7 @@
 package team.themoment.hellogsmv3.domain.oneseo.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.Cache;
-import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,11 +38,10 @@ public class CreateOneseoService {
     private final MemberService memberService;
     private final CalculateGradeService calculateGradeService;
     private final CalculateGedService calculateGedService;
-    private final CacheManager cacheManager;
 
     @Transactional
-    @CacheEvict(value = OneseoService.ONESEO_CACHE_VALUE, key = "#memberId")
-    public void execute(OneseoReqDto reqDto, Long memberId) {
+    @CachePut(value = OneseoService.ONESEO_CACHE_VALUE, key = "#memberId")
+    public FoundOneseoResDto execute(OneseoReqDto reqDto, Long memberId) {
         Member currentMember = memberService.findByIdOrThrow(memberId);
 
         isExistOneseo(currentMember);
@@ -59,16 +56,11 @@ public class CreateOneseoService {
 
         OneseoPrivacyDetailResDto oneseoPrivacyDetailResDto = buildOneseoPrivacyDetailResDto(currentMember, oneseoPrivacyDetail);
         MiddleSchoolAchievementResDto middleSchoolAchievementResDto = buildMiddleSchoolAchievementResDto(middleSchoolAchievement);
-        FoundOneseoResDto oneseoResDto = buildOneseoResDto(
+        return buildOneseoResDto(
                 oneseo,
                 oneseoPrivacyDetailResDto,
                 middleSchoolAchievementResDto
         );
-
-        Cache cache = cacheManager.getCache(ONESEO_CACHE_VALUE);
-        if (cache != null) {
-            cache.put(memberId, oneseoResDto);
-        }
     }
 
     private OneseoPrivacyDetailResDto buildOneseoPrivacyDetailResDto(

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -2,7 +2,7 @@ package team.themoment.hellogsmv3.domain.oneseo.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.Cache;
-import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,10 +43,10 @@ public class ModifyOneseoService {
     private final MemberService memberService;
     private final CalculateGradeService calculateGradeService;
     private final CalculateGedService calculateGedService;
-    private final CacheManager cacheManager;
 
     @Transactional
-    public void execute(OneseoReqDto reqDto, Long memberId) {
+    @CachePut(value = OneseoService.ONESEO_CACHE_VALUE, key = "#memberId")
+    public FoundOneseoResDto execute(OneseoReqDto reqDto, Long memberId) {
         Member currentMember = memberService.findByIdOrThrow(memberId);
         Oneseo oneseo = oneseoService.findByMemberOrThrow(currentMember);
 
@@ -65,16 +65,11 @@ public class ModifyOneseoService {
 
         OneseoPrivacyDetailResDto oneseoPrivacyDetailResDto = buildOneseoPrivacyDetailResDto(currentMember, oneseoPrivacyDetail);
         MiddleSchoolAchievementResDto middleSchoolAchievementResDto = buildMiddleSchoolAchievementResDto(middleSchoolAchievement);
-        FoundOneseoResDto oneseoResDto = buildOneseoResDto(
+        return buildOneseoResDto(
                 oneseo,
                 oneseoPrivacyDetailResDto,
                 middleSchoolAchievementResDto
         );
-
-        Cache cache = cacheManager.getCache(ONESEO_CACHE_VALUE);
-        if (cache != null) {
-            cache.put(memberId, oneseoResDto);
-        }
     }
 
     private OneseoPrivacyDetailResDto buildOneseoPrivacyDetailResDto(

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -1,6 +1,8 @@
 package team.themoment.hellogsmv3.domain.oneseo.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,6 +10,10 @@ import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.DesiredMajorsResDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.FoundOneseoResDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.MiddleSchoolAchievementResDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.OneseoPrivacyDetailResDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.MiddleSchoolAchievement;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.OneseoPrivacyDetail;
@@ -23,6 +29,8 @@ import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.util.List;
 
+import static team.themoment.hellogsmv3.domain.oneseo.service.OneseoService.*;
+
 @Service
 @RequiredArgsConstructor
 public class ModifyOneseoService {
@@ -35,6 +43,7 @@ public class ModifyOneseoService {
     private final MemberService memberService;
     private final CalculateGradeService calculateGradeService;
     private final CalculateGedService calculateGedService;
+    private final CacheManager cacheManager;
 
     @Transactional
     public void execute(OneseoReqDto reqDto, Long memberId) {
@@ -53,6 +62,85 @@ public class ModifyOneseoService {
         saveModifiedEntities(modifiedOneseo, modifiedOneseoPrivacyDetail, modifiedMiddleSchoolAchievement);
 
         calculateMiddleSchoolAchievement(oneseoPrivacyDetail.getGraduationType(), middleSchoolAchievement, oneseo);
+
+        OneseoPrivacyDetailResDto oneseoPrivacyDetailResDto = buildOneseoPrivacyDetailResDto(currentMember, oneseoPrivacyDetail);
+        MiddleSchoolAchievementResDto middleSchoolAchievementResDto = buildMiddleSchoolAchievementResDto(middleSchoolAchievement);
+        FoundOneseoResDto oneseoResDto = buildOneseoResDto(
+                oneseo,
+                oneseoPrivacyDetailResDto,
+                middleSchoolAchievementResDto
+        );
+
+        Cache cache = cacheManager.getCache(ONESEO_CACHE_VALUE);
+        if (cache != null) {
+            cache.put(memberId, oneseoResDto);
+        }
+    }
+
+    private OneseoPrivacyDetailResDto buildOneseoPrivacyDetailResDto(
+            Member member,
+            OneseoPrivacyDetail oneseoPrivacyDetail
+    ) {
+        return OneseoPrivacyDetailResDto.builder()
+                .name(member.getName())
+                .sex(member.getSex())
+                .birth(member.getBirth())
+                .phoneNumber(member.getPhoneNumber())
+                .graduationType(oneseoPrivacyDetail.getGraduationType())
+                .address(oneseoPrivacyDetail.getAddress())
+                .detailAddress(oneseoPrivacyDetail.getDetailAddress())
+                .guardianName(oneseoPrivacyDetail.getGuardianName())
+                .guardianPhoneNumber(oneseoPrivacyDetail.getGuardianPhoneNumber())
+                .relationshipWithGuardian(oneseoPrivacyDetail.getRelationshipWithGuardian())
+                .schoolName(oneseoPrivacyDetail.getSchoolName())
+                .schoolAddress(oneseoPrivacyDetail.getSchoolAddress())
+                .schoolTeacherName(oneseoPrivacyDetail.getSchoolTeacherName())
+                .schoolTeacherPhoneNumber(oneseoPrivacyDetail.getSchoolTeacherPhoneNumber())
+                .profileImg(oneseoPrivacyDetail.getProfileImg())
+                .build();
+    }
+
+    private MiddleSchoolAchievementResDto buildMiddleSchoolAchievementResDto(
+            MiddleSchoolAchievement middleSchoolAchievement
+    ) {
+        return MiddleSchoolAchievementResDto.builder()
+                .achievement1_2(middleSchoolAchievement.getAchievement1_2())
+                .achievement2_1(middleSchoolAchievement.getAchievement2_1())
+                .achievement2_2(middleSchoolAchievement.getAchievement2_2())
+                .achievement3_1(middleSchoolAchievement.getAchievement3_1())
+                .achievement3_2(middleSchoolAchievement.getAchievement3_2())
+                .generalSubjects(middleSchoolAchievement.getGeneralSubjects())
+                .newSubjects(middleSchoolAchievement.getNewSubjects())
+                .artsPhysicalAchievement(middleSchoolAchievement.getArtsPhysicalAchievement())
+                .artsPhysicalSubjects(middleSchoolAchievement.getArtsPhysicalSubjects())
+                .absentDays(middleSchoolAchievement.getAbsentDays())
+                .attendanceDays(middleSchoolAchievement.getAttendanceDays())
+                .volunteerTime(middleSchoolAchievement.getVolunteerTime())
+                .liberalSystem(middleSchoolAchievement.getLiberalSystem())
+                .freeSemester(middleSchoolAchievement.getFreeSemester())
+                .gedTotalScore(middleSchoolAchievement.getGedTotalScore())
+                .build();
+    }
+
+    private FoundOneseoResDto buildOneseoResDto(
+            Oneseo oneseo,
+            OneseoPrivacyDetailResDto oneseoPrivacyDetailResDto,
+            MiddleSchoolAchievementResDto middleSchoolAchievementResDto
+    ) {
+        DesiredMajors desiredMajors = oneseo.getDesiredMajors();
+
+        return FoundOneseoResDto.builder()
+                .oneseoId(oneseo.getId())
+                .submitCode(oneseo.getOneseoSubmitCode())
+                .wantedScreening(oneseo.getWantedScreening())
+                .desiredMajors(DesiredMajorsResDto.builder()
+                        .firstDesiredMajor(desiredMajors.getFirstDesiredMajor())
+                        .secondDesiredMajor(desiredMajors.getSecondDesiredMajor())
+                        .thirdDesiredMajor(desiredMajors.getThirdDesiredMajor())
+                        .build())
+                .privacyDetail(oneseoPrivacyDetailResDto)
+                .middleSchoolAchievement(middleSchoolAchievementResDto)
+                .build();
     }
 
     private void calculateMiddleSchoolAchievement(GraduationType graduationType, MiddleSchoolAchievement middleSchoolAchievement, Oneseo oneseo) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
@@ -12,6 +12,7 @@ import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 @RequiredArgsConstructor
 public class OneseoService {
 
+    public static final String ONESEO_CACHE_VALUE = "oneseo";
     private final OneseoRepository oneseoRepository;
 
     public Oneseo findByMemberOrThrow(Member member) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
@@ -12,13 +12,15 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.response.FoundOneseoResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.MiddleSchoolAchievementResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.OneseoPrivacyDetailResDto;
 
+import static team.themoment.hellogsmv3.domain.oneseo.service.OneseoService.*;
+
 @Service
 @RequiredArgsConstructor
 public class OneseoTempStorageService {
 
     private final MemberService memberService;
 
-    @CachePut(value = "oneseo", key = "#memberId")
+    @CachePut(value = ONESEO_CACHE_VALUE, key = "#memberId")
     public FoundOneseoResDto execute(OneseoReqDto reqDto,Integer step, Long memberId) {
         Member member = memberService.findByIdOrThrow(memberId);
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
@@ -11,6 +11,8 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
 import team.themoment.hellogsmv3.domain.oneseo.repository.MiddleSchoolAchievementRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRepository;
 
+import static team.themoment.hellogsmv3.domain.oneseo.service.OneseoService.ONESEO_CACHE_VALUE;
+
 @Service
 @RequiredArgsConstructor
 public class QueryOneseoByIdService {
@@ -20,7 +22,7 @@ public class QueryOneseoByIdService {
     private final MemberService memberService;
     private final OneseoService oneseoService;
 
-    @Cacheable(value = "oneseo", key = "#memberId")
+    @Cacheable(value = ONESEO_CACHE_VALUE, key = "#memberId")
     public FoundOneseoResDto execute(Long memberId) {
         Member member = memberService.findByIdOrThrow(memberId);
         Oneseo oneseo = oneseoService.findByMemberOrThrow(member);


### PR DESCRIPTION
## 개요

원서 관련 redis 캐시에서 문제가 발생하여 개선해보았습니다. 원서 관련 테이블의 컬럼명 설정이 잘못 되어있어 수정하였습니다.

## 본문

- 현재 원서 임시 저장시 캐시 생성, 원서 조회시 캐시 확인으로 캐싱이 적용되어 있습니다. 하지만 원서 조회시 캐싱을 적용하는 `@Cacheable` 어노테이션은 캐시가 없다면 response 값을 redis에 캐싱합니다.
어드민 권한을 가진 유저는 특정 사용자의 원서를 수정할 수 있는데 수정 메서드에는 캐시 관련 설정이 되어있지 않습니다. 그렇기 때문에 만약 원서 생성 후 원서 조회(캐시 저장), 그리고 어드민이 원서를 수정한다면 데이터베이스에서는 원서가 수정된 상태이지만 원서 조회를 진행하였기 때문에 수정 전의 캐시 정보가 남아있어 수정 전의 원서가 조회되게 됩니다.
- 위 문제를 해결하기 위해 원서 생성, 수정시에 기존 원서에 대한 캐시 정보가 있다면 수동으로 캐시 정보를 업데이트 하도록 개선하였습니다.

* EntranceTestResult, ScreeningChangeHistory 테이블의 PK 컬럼명이 잘못되어있어 수정하였습니다.