### PR TITLE
[oneseo] 원서 관련 변경된 테이블 컬럼 스펙에 맞춰 엔티티 필드 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestResult.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestResult.java
@@ -48,10 +48,6 @@ public class EntranceTestResult {
     @Column(name = "second_test_pass_yn")
     private YesNo secondTestPassYn;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "decided_major")
-    private Major decidedMajor;
-
     public void modifyAptitudeEvaluationScore(BigDecimal aptitudeEvaluationScore) {
         this.aptitudeEvaluationScore = aptitudeEvaluationScore;
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
@@ -6,6 +6,7 @@ import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 
@@ -54,6 +55,14 @@ public class Oneseo {
     @Enumerated(EnumType.STRING)
     @Column(name = "applied_screening", nullable = false)
     private Screening appliedScreening;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "entrance_intention_yn")
+    private YesNo entranceIntentionYn;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "decided_major")
+    private Major decidedMajor;
 
     public Oneseo setOneseoSubmitCode(String submitCode) {
         this.oneseoSubmitCode = submitCode;

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelService.java
@@ -164,7 +164,7 @@ public class DownloadExcelService {
                     String.valueOf(entranceTestResult.getAptitudeEvaluationScore()),
                     String.valueOf(entranceTestResult.getInterviewScore()),
                     String.valueOf(finalScore),
-                    String.valueOf(entranceTestResult.getDecidedMajor()),
+                    String.valueOf(oneseo.getDecidedMajor()),
                     oneseo.getMember().getPhoneNumber(),
                     oneseoPrivacyDetail.getGuardianPhoneNumber(),
                     oneseoPrivacyDetail.getSchoolTeacherPhoneNumber()

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelServiceTest.java
@@ -154,7 +154,7 @@ public class DownloadExcelServiceTest {
                     String.valueOf(entranceTestResult.getAptitudeEvaluationScore()),
                     String.valueOf(entranceTestResult.getInterviewScore()),
                     String.valueOf(46.334),
-                    String.valueOf(entranceTestResult.getDecidedMajor()),
+                    String.valueOf(oneseo.getDecidedMajor()),
                     oneseo.getMember().getPhoneNumber(),
                     oneseoPrivacyDetail.getGuardianPhoneNumber(),
                     oneseoPrivacyDetail.getSchoolTeacherPhoneNumber()
@@ -196,6 +196,7 @@ public class DownloadExcelServiceTest {
                     .oneseoSubmitCode(submitCode)
                     .desiredMajors(desiredMajors)
                     .appliedScreening(screening)
+                    .decidedMajor(Major.IOT)
                     .build();
         }
 
@@ -217,7 +218,6 @@ public class DownloadExcelServiceTest {
                     .secondTestPassYn(yn)
                     .aptitudeEvaluationScore(BigDecimal.valueOf(70))
                     .interviewScore(BigDecimal.valueOf(60))
-                    .decidedMajor(Major.IOT)
                     .build();
         }
 


### PR DESCRIPTION
## 개요

Oneseo 테이블의 변경된 테이블 컬럼 스펙에 따라 엔티티 필드를 수정하였습니다.

`entrance_intention_yn` column 추가, `decide_major` column 위치변경 (tb_entrance_test_result -> tb_oneseo)