### PR TITLE
[oneseo] MiddleSchoolAchievement 컨버트 메서드 null check 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/global/common/converter/IntegerListConverter.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/common/converter/IntegerListConverter.java
@@ -24,6 +24,7 @@ public class IntegerListConverter implements AttributeConverter<List<Integer>, S
     @Override
     public List<Integer> convertToEntityAttribute(String data) {
         try {
+            if (data == null) return null;
             return mapper.readValue(data, List.class);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
## 개요

MiddleSchoolAchievement의 중학교 성적 데이터를 저장하는 컬럼의 Convert 메서드의 null check를 추가하였습니다.

## 본문

DML로 직접 DB에 데이터를 insert 할때 중학교 성적 column에 NULL을 할당한다면 JPA 단에서 NULL 값을 Integer List로 변환하려하기 때문에 NPE가 발생합니다.

원서 생성 API를 사용해 원서를 저장한다면 DB 저장시 컨버트 메서드를 통해 Null값을 String으로 변환해 저장하기 때문에 NPE가 발생하지 않았습니다.

위의 상황을 고려하여 String to Integer List 변환 메서드에 null check를 추가하였습니다.