### PR TITLE
[oneseo] 수험표 출력 join 쿼리 문제 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.SearchOneseoResDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.QOneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -46,8 +47,9 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
                                 oneseo.oneseoSubmitCode
                         )
                 )
-                .from(oneseo, oneseoPrivacyDetail)
+                .from(oneseo)
                 .join(oneseo.member, member)
+                .join(oneseo.oneseoPrivacyDetail, oneseoPrivacyDetail)
                 .fetch();
     }
 


### PR DESCRIPTION
## 개요

수험표 출력시 비정상적으로 많은 양의 데이터가 반환되는 문제를 해결하였습니다.

<img width="236" alt="스크린샷 2024-08-25 오후 11 20 13" src="https://github.com/user-attachments/assets/407ad29e-ebd9-4e17-a939-6cd39997f98c">

> 실제 원서 개수는 20개지만 400개의 rows가 출력되는 것을 볼 수 있다...

## 본문


<img width="369" alt="스크린샷 2024-08-25 오후 11 23 41" src="https://github.com/user-attachments/assets/694abdcf-d8d3-4405-b771-487cd89addf3">

기존 수험표 출력 쿼리입니다. from 절에 `tb_oneseo`, `tb_oneseo_privacy_detail` 테이블이 지정되어있지만, `tb_oneseo_privacy_detail` 테이블에 대한 조인 문은 존재하지 않습니다.

그렇기 때문에 `tb_oneseo_privacy_detail` 테이블에 대함 검색 결과에 카테시안 곱 현상이 발생하여 문제가 발생한 것으로 보입니다.

문제파악 후  `tb_oneseo_privacy_detail` 테이블에 대한 조인 절을 포함시켜 문제를 해결하였습니다.