### PR TITLE
[global] 누락 된 cors 허용 메서드 PATCH 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -73,6 +73,7 @@ public class SecurityConfig {
                 HttpMethod.GET.name(),
                 HttpMethod.POST.name(),
                 HttpMethod.PUT.name(),
+                HttpMethod.PATCH.name(),
                 HttpMethod.DELETE.name(),
                 HttpMethod.OPTIONS.name()));
 


### PR DESCRIPTION
## 개요

배포 환경(stage)에서 PATCH 메서드의 API에서 500에러가 발생하는것을 확인하였습니다.

cors 설정에서 PATCH method에 대한 allow를 추가하지 않아 발생하는 문제였으므로 누락되어있던 PATCH method allow를 추가하였습니다.