### PR TITLE
[global] X_HG_ENV header name 변경

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/global/security/handler/CustomUrlAuthenticationSuccessHandler.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/handler/CustomUrlAuthenticationSuccessHandler.java
@@ -30,7 +30,7 @@ public class CustomUrlAuthenticationSuccessHandler implements AuthenticationSucc
         boolean isAdmin = authentication.getAuthorities().stream()
                 .anyMatch(authority -> Role.ADMIN.name().equals(authority.getAuthority()));
 
-        String dryrun = request.getHeader(X_H_ENV.getContent());
+        String dryrun = request.getHeader(X_HG_ENV.getContent());
         boolean isDryrun = Boolean.parseBoolean(dryrun != null ? dryrun : "false");
 
         String redirectUrlWithParameter = UriComponentsBuilder


### PR DESCRIPTION
## 개요

#124 해당 PR에서 수정한 X_HG_ENV enum class 이름을 수정하지 않은 부분이 있어 ci 도중 컴파일 오류가 발생하여 수정하였습니다.