### PR TITLE
[oneseo] 1차 전형 결과 산출 이후에 원서 수정 막도록 변경

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -1,7 +1,6 @@
 package team.themoment.hellogsmv3.domain.oneseo.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.Cache;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -14,10 +13,7 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.response.DesiredMajorsResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.FoundOneseoResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.MiddleSchoolAchievementResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.OneseoPrivacyDetailResDto;
-import team.themoment.hellogsmv3.domain.oneseo.entity.MiddleSchoolAchievement;
-import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
-import team.themoment.hellogsmv3.domain.oneseo.entity.OneseoPrivacyDetail;
-import team.themoment.hellogsmv3.domain.oneseo.entity.ScreeningChangeHistory;
+import team.themoment.hellogsmv3.domain.oneseo.entity.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
@@ -28,8 +24,6 @@ import team.themoment.hellogsmv3.domain.oneseo.repository.ScreeningChangeHistory
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.util.List;
-
-import static team.themoment.hellogsmv3.domain.oneseo.service.OneseoService.*;
 
 @Service
 @RequiredArgsConstructor
@@ -49,6 +43,8 @@ public class ModifyOneseoService {
     public FoundOneseoResDto execute(OneseoReqDto reqDto, Long memberId) {
         Member currentMember = memberService.findByIdOrThrow(memberId);
         Oneseo oneseo = oneseoService.findByMemberOrThrow(currentMember);
+
+        isBeforeFirstTest(oneseo);
 
         OneseoPrivacyDetail oneseoPrivacyDetail = oneseoPrivacyDetailRepository.findByOneseo(oneseo);
         MiddleSchoolAchievement middleSchoolAchievement = middleSchoolAchievementRepository.findByOneseo(oneseo);
@@ -70,6 +66,13 @@ public class ModifyOneseoService {
                 oneseoPrivacyDetailResDto,
                 middleSchoolAchievementResDto
         );
+    }
+
+    private static void isBeforeFirstTest(Oneseo oneseo) {
+        EntranceTestResult entranceTestResult = oneseo.getEntranceTestResult();
+        if (entranceTestResult.getFirstTestPassYn() != null) {
+            throw new ExpectedException("1차 전형 결과 산출 이후에는 원서를 수정할 수 없습니다.", HttpStatus.FORBIDDEN);
+        }
     }
 
     private OneseoPrivacyDetailResDto buildOneseoPrivacyDetailResDto(

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
         return new TimeBasedFilter()
                 .addFilter(HttpMethod.POST, "/oneseo/v3/temp-storage", startReception, endReception)
                 .addFilter(HttpMethod.POST, "/oneseo/v3/oneseo/me", startReception, endReception)
-                .addFilter(HttpMethod.PATCH, "/oneseo/v3/oneseo/{memberId}", startReception, endReception)
+                .addFilter(HttpMethod.PUT, "/oneseo/v3/oneseo/{memberId}", startReception, endReception)
                 .addFilter(HttpMethod.GET, "/oneseo/v3/oneseo/me", startReception, endReception)
                 .addFilter(HttpMethod.POST, "/oneseo/v3/image", startReception, endReception);
     }

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
         return new TimeBasedFilter()
                 .addFilter(HttpMethod.POST, "/oneseo/v3/temp-storage", startReception, endReception)
                 .addFilter(HttpMethod.POST, "/oneseo/v3/oneseo/me", startReception, endReception)
+                .addFilter(HttpMethod.PATCH, "/oneseo/v3/oneseo/{memberId}", startReception, endReception)
                 .addFilter(HttpMethod.GET, "/oneseo/v3/oneseo/me", startReception, endReception)
                 .addFilter(HttpMethod.POST, "/oneseo/v3/image", startReception, endReception);
     }

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoServiceTest.java
@@ -10,10 +10,7 @@ import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
-import team.themoment.hellogsmv3.domain.oneseo.entity.MiddleSchoolAchievement;
-import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
-import team.themoment.hellogsmv3.domain.oneseo.entity.OneseoPrivacyDetail;
-import team.themoment.hellogsmv3.domain.oneseo.entity.ScreeningChangeHistory;
+import team.themoment.hellogsmv3.domain.oneseo.entity.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
@@ -150,6 +147,9 @@ class ModifyOneseoServiceTest {
                 Oneseo oneseo = Oneseo.builder()
                         .id(1L)
                         .desiredMajors(desiredMajors)
+                        .entranceTestResult(EntranceTestResult.builder()
+                                .firstTestPassYn(null)
+                                .build())
                         .build();
 
                 OneseoPrivacyDetail oneseoPrivacyDetail = OneseoPrivacyDetail.builder()
@@ -168,6 +168,7 @@ class ModifyOneseoServiceTest {
                 given(memberService.findByIdOrThrow(memberId)).willReturn(existingMember);
                 given(oneseoService.findByMemberOrThrow(existingMember)).willReturn(oneseo);
                 given(oneseoPrivacyDetailRepository.findByOneseo(oneseo)).willReturn(oneseoPrivacyDetail);
+                given(middleSchoolAchievementRepository.findByOneseo(oneseo)).willReturn(middleSchoolAchievement);
                 given(middleSchoolAchievementRepository.findByOneseo(oneseo)).willReturn(middleSchoolAchievement);
 
                 modifyOneseoService.execute(oneseoReqDto, memberId);
@@ -234,6 +235,9 @@ class ModifyOneseoServiceTest {
                         .id(1L)
                         .appliedScreening(beforeScreening)
                         .desiredMajors(desiredMajors)
+                        .entranceTestResult(EntranceTestResult.builder()
+                                .firstTestPassYn(null)
+                                .build())
                         .build();
 
                 Member existingMember = mock(Member.class);


### PR DESCRIPTION
## 개요

1차 전형 결과 산출 이후에는 원서 수정이 막히도록 변경하였습니다.

## 본문

- `TimeBsaesFilter`에 (원서 작성 기간에만 요청이 가능하도록) 원서 수정 API를 추가하였습니다.
- 원서 수정 service 로직에 `firstTestPassYn` 필드를 기준으로 1차 전형 결과 산출 이후인지 확인하여 validation 하는 메서드를 추가하였습니다.