### PR TITLE
[oneseo] 원서 엑셀 출력 및 원서 관련 서비스 희망전형 적용 전형으로 변경

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
@@ -58,7 +58,7 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
         return queryFactory
                 .select(oneseo.oneseoSubmitCode.substring(2).castToNum(Integer.class))
                 .from(oneseo)
-                .where(oneseo.appliedScreening.eq(screening))
+                .where(oneseo.wantedScreening.eq(screening))
                 .orderBy(oneseo.oneseoSubmitCode.substring(2).castToNum(Integer.class).desc())
                 .fetchFirst();
     }
@@ -86,7 +86,7 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
                         oneseo.oneseoSubmitCode,
                         oneseo.realOneseoArrivedYn,
                         oneseo.member.name,
-                        oneseo.appliedScreening,
+                        oneseo.wantedScreening,
                         oneseo.oneseoPrivacyDetail.schoolName,
                         oneseo.member.phoneNumber,
                         oneseo.oneseoPrivacyDetail.guardianPhoneNumber,
@@ -157,16 +157,16 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
         switch (screeningTag) {
             case GENERAL ->
                     builder.and(
-                            oneseo.appliedScreening.eq(Screening.GENERAL)
+                            oneseo.wantedScreening.eq(Screening.GENERAL)
                     );
             case SPECIAL ->
                     builder.and(
-                            oneseo.appliedScreening.eq(Screening.SPECIAL)
+                            oneseo.wantedScreening.eq(Screening.SPECIAL)
                     );
             case EXTRA ->
                     builder.andAnyOf(
-                            oneseo.appliedScreening.eq(Screening.EXTRA_ADMISSION),
-                            oneseo.appliedScreening.eq(Screening.EXTRA_VETERANS)
+                            oneseo.wantedScreening.eq(Screening.EXTRA_ADMISSION),
+                            oneseo.wantedScreening.eq(Screening.EXTRA_VETERANS)
                     );
         }
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnService.java
@@ -38,11 +38,11 @@ public class ModifyRealOneseoArrivedYnService {
             return;
         }
 
-        Integer maxSubmitCodeNumber = oneseoRepository.findMaxSubmitCodeByScreening(oneseo.getAppliedScreening());
+        Integer maxSubmitCodeNumber = oneseoRepository.findMaxSubmitCodeByScreening(oneseo.getWantedScreening());
         int newSubmitCodeNumber = (maxSubmitCodeNumber != null ? maxSubmitCodeNumber : 0) + 1;
 
         String submitCode;
-        ScreeningCategory screeningCategory = oneseo.getAppliedScreening().getScreeningCategory();
+        ScreeningCategory screeningCategory = oneseo.getWantedScreening().getScreeningCategory();
         switch (screeningCategory) {
             case GENERAL -> submitCode = "A-" + newSubmitCodeNumber;
             case SPECIAL -> submitCode = "B-" + newSubmitCodeNumber;

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoServiceTest.java
@@ -231,7 +231,7 @@ class ModifyOneseoServiceTest {
 
                 Oneseo oneseo = Oneseo.builder()
                         .id(1L)
-                        .appliedScreening(beforeScreening)
+                        .wantedScreening(beforeScreening)
                         .desiredMajors(desiredMajors)
                         .build();
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnServiceTest.java
@@ -62,7 +62,7 @@ public class ModifyRealOneseoArrivedYnServiceTest {
                 oneseo = Oneseo.builder()
                         .member(member)
                         .realOneseoArrivedYn(YesNo.NO)
-                        .appliedScreening(Screening.GENERAL)
+                        .wantedScreening(Screening.GENERAL)
                         .build();
 
                 given(memberService.findByIdOrThrow(memberId)).willReturn(member);

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
@@ -123,7 +123,7 @@ class SearchOneseoServiceTest {
                 assertEquals(oneseo.getOneseoSubmitCode(), searchOneseoResDto.submitCode());
                 assertEquals(oneseo.getRealOneseoArrivedYn(), searchOneseoResDto.realOneseoArrivedYn());
                 assertEquals(member.getName(), searchOneseoResDto.name());
-                assertEquals(oneseo.getAppliedScreening(), searchOneseoResDto.screening());
+                assertEquals(oneseo.getWantedScreening(), searchOneseoResDto.screening());
                 assertEquals(oneseoPrivacyDetail.getSchoolName(), searchOneseoResDto.schoolName());
                 assertEquals(member.getPhoneNumber(), searchOneseoResDto.phoneNumber());
                 assertEquals(oneseoPrivacyDetail.getGuardianPhoneNumber(), searchOneseoResDto.guardianPhoneNumber());
@@ -157,7 +157,7 @@ class SearchOneseoServiceTest {
                 .id(1L)
                 .oneseoSubmitCode("A-1")
                 .realOneseoArrivedYn(YES)
-                .appliedScreening(GENERAL)
+                .wantedScreening(GENERAL)
                 .build();
     }
 
@@ -167,7 +167,7 @@ class SearchOneseoServiceTest {
                 .submitCode(oneseo.getOneseoSubmitCode())
                 .realOneseoArrivedYn(oneseo.getRealOneseoArrivedYn())
                 .name(member.getName())
-                .screening(oneseo.getAppliedScreening())
+                .screening(oneseo.getWantedScreening())
                 .schoolName(oneseoPrivacyDetail.getSchoolName())
                 .phoneNumber(member.getPhoneNumber())
                 .guardianPhoneNumber(oneseoPrivacyDetail.getGuardianPhoneNumber())


### PR DESCRIPTION
## 개요

원서 관련 서비스 로직에서 희망전형을 적용전형으로 변경하였습니다.

## 본문
- #134 해당 PR에서 원서 엑셀 출력의 변경사항을 테스트코드에 반영하지 않아 수정하였습니다.
- `appliedScreening - 적용전형`은 1차 배치 이후에 값이 들어가기 때문에 **수험표 출력 기능은 appliedScreening을 사용하고, 나머지 기능들은 wanatedScreening을 사용하도록 변경**하였습니다.