### PR TITLE
[oneseo] 입학등록 동의서 제출 여부 수정 기능 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
@@ -50,7 +50,8 @@ public class MemberController {
     @PostMapping("/member/me/send-code-test")
     public CommonApiResponse sendCodeTest(
             @AuthRequest Long memberId,
-            @RequestBody @Valid GenerateCodeReqDto reqDto) {
+            @RequestBody @Valid GenerateCodeReqDto reqDto
+    ) {
         String code = generateTestCodeService.execute(memberId, reqDto);
         return CommonApiResponse.success("전송되었습니다. : " + code);
     }
@@ -107,6 +108,5 @@ public class MemberController {
             @PathVariable Long memberId
     ) {
         return queryMemberAuthInfoByIdService.execute(memberId);
-
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
@@ -39,8 +39,8 @@ public class MemberController {
     @Operation(summary = "인증코드 전송", description = "전화번호를 요청받아 인증코드를 전송합니다.")
     @PostMapping("/member/me/send-code")
     public CommonApiResponse sendCode(
-        @AuthRequest Long memberId, 
-        @RequestBody GenerateCodeReqDto reqDto
+            @AuthRequest Long memberId,
+            @RequestBody @Valid GenerateCodeReqDto reqDto
     ) {
         generateCodeService.execute(memberId, reqDto);
         return CommonApiResponse.success("전송되었습니다.");
@@ -48,7 +48,9 @@ public class MemberController {
 
     @Operation(summary = "인증코드 테스트 전송", description = "전화번호를 요청받아 인증코드를 반환합니다. 횟수가 제한이 없습니다.")
     @PostMapping("/member/me/send-code-test")
-    public CommonApiResponse sendCodeTest(@AuthRequest Long memberId, @RequestBody GenerateCodeReqDto reqDto) {
+    public CommonApiResponse sendCodeTest(
+            @AuthRequest Long memberId,
+            @RequestBody @Valid GenerateCodeReqDto reqDto) {
         String code = generateTestCodeService.execute(memberId, reqDto);
         return CommonApiResponse.success("전송되었습니다. : " + code);
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -136,7 +136,7 @@ public class OneseoController {
     public MockScoreResDto calcMockScore(
             @RequestBody MiddleSchoolAchievementReqDto dto,
             @RequestParam("graduationType") GraduationType graduationType
-        ) {
+    ) {
         return calculateMockScoreService.execute(dto, graduationType);
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -50,6 +50,7 @@ public class OneseoController {
     private final QueryOneseoByIdService queryOneseoByIdService;
     private final CalculateMockScoreService calculateMockScoreService;
     private final OneseoTempStorageService oneseoTempStorageService;
+    private final ModifyEntranceIntentionService modifyEntranceIntentionService;
 
     @Operation(summary = "내 원서 등록", description = "원서를 등록합니다.")
     @PostMapping("/oneseo/me")
@@ -171,5 +172,15 @@ public class OneseoController {
         } catch (IOException ex) {
             throw new RuntimeException("파일 작성과정에서 예외가 발생하였습니다.", ex);
         }
+    }
+
+    @Operation(summary = "입학등록 동의서 제출여부 수정", description = "맴버 id로 원서의 입학등록 동의서 제출여부를 수정합니다.")
+    @PatchMapping("/entrance-intention/{memberId}")
+    public CommonApiResponse modifyEntranceIntention(
+            @PathVariable Long memberId,
+            @RequestBody @Valid EntranceIntentionReqDto reqDto
+    ) {
+        modifyEntranceIntentionService.execute(memberId, reqDto);
+        return CommonApiResponse.success("수정되었습니다.");
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/EntranceIntentionReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/EntranceIntentionReqDto.java
@@ -1,0 +1,10 @@
+package team.themoment.hellogsmv3.domain.oneseo.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
+
+public record EntranceIntentionReqDto(
+        @NotNull
+        YesNo entranceIntentionYn
+) {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/SearchOneseoResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/SearchOneseoResDto.java
@@ -21,6 +21,7 @@ public record SearchOneseoResDto(
         YesNo firstTestPassYn,
         BigDecimal aptitudeEvaluationScore,
         BigDecimal interviewScore,
-        YesNo secondTestPassYn
+        YesNo secondTestPassYn,
+        YesNo entranceIntentionYn
 ) {
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
@@ -10,6 +10,8 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 
+import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.*;
+
 @Getter
 @Entity
 @Table(name = "tb_oneseo", indexes = {
@@ -70,7 +72,11 @@ public class Oneseo {
         return this;
     }
 
+    public void modifyEntranceIntentionYn(YesNo yn) {
+        this.entranceIntentionYn = yn;
+    }
+
     public void switchRealOneseoArrivedYn() {
-        this.realOneseoArrivedYn = this.realOneseoArrivedYn == YesNo.YES ? YesNo.NO : YesNo.YES;
+        this.realOneseoArrivedYn = this.realOneseoArrivedYn == YES ? NO : YES;
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
@@ -94,7 +94,8 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
                         oneseo.entranceTestResult.firstTestPassYn,
                         oneseo.entranceTestResult.aptitudeEvaluationScore,
                         oneseo.entranceTestResult.interviewScore,
-                        oneseo.entranceTestResult.secondTestPassYn
+                        oneseo.entranceTestResult.secondTestPassYn,
+                        oneseo.entranceIntentionYn
                 ))
                 .from(oneseo)
                 .join(oneseo.member, member)

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyEntranceIntentionService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyEntranceIntentionService.java
@@ -1,13 +1,16 @@
 package team.themoment.hellogsmv3.domain.oneseo.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.EntranceIntentionReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
 @RequiredArgsConstructor
@@ -22,8 +25,16 @@ public class ModifyEntranceIntentionService {
         Member member = memberService.findByIdOrThrow(memberId);
         Oneseo oneseo = oneseoService.findByMemberOrThrow(member);
 
+        isAfterFinalTest(oneseo);
+
         oneseo.modifyEntranceIntentionYn(reqDto.entranceIntentionYn());
 
         oneseoRepository.save(oneseo);
+    }
+
+    private void isAfterFinalTest(Oneseo oneseo) {
+        if (oneseo.getDecidedMajor() == null) {
+            throw new ExpectedException("최종 합격자 산출 이전에는 입학등록 동의서 제출 여부를 수정할 수 없습니다.", HttpStatus.BAD_REQUEST);
+        }
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyEntranceIntentionService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyEntranceIntentionService.java
@@ -34,7 +34,7 @@ public class ModifyEntranceIntentionService {
 
     private void isAfterFinalTest(Oneseo oneseo) {
         if (oneseo.getDecidedMajor() == null) {
-            throw new ExpectedException("최종 합격자 산출 이전에는 입학등록 동의서 제출 여부를 수정할 수 없습니다.", HttpStatus.BAD_REQUEST);
+            throw new ExpectedException("최종 합격한 지원자의 원서만 입학등록 동의서 제출여부를 수정할 수 있습니다.", HttpStatus.BAD_REQUEST);
         }
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyEntranceIntentionService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyEntranceIntentionService.java
@@ -1,0 +1,29 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.member.service.MemberService;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.EntranceIntentionReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ModifyEntranceIntentionService {
+
+    private final OneseoRepository oneseoRepository;
+    private final MemberService memberService;
+    private final OneseoService oneseoService;
+
+    @Transactional
+    public void execute(Long memberId, EntranceIntentionReqDto reqDto) {
+        Member member = memberService.findByIdOrThrow(memberId);
+        Oneseo oneseo = oneseoService.findByMemberOrThrow(member);
+
+        oneseo.modifyEntranceIntentionYn(reqDto.entranceIntentionYn());
+
+        oneseoRepository.save(oneseo);
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -68,7 +68,7 @@ public class ModifyOneseoService {
         );
     }
 
-    private static void isBeforeFirstTest(Oneseo oneseo) {
+    private void isBeforeFirstTest(Oneseo oneseo) {
         EntranceTestResult entranceTestResult = oneseo.getEntranceTestResult();
         if (entranceTestResult.getFirstTestPassYn() != null) {
             throw new ExpectedException("1차 전형 결과 산출 이후에는 원서를 수정할 수 없습니다.", HttpStatus.FORBIDDEN);


### PR DESCRIPTION
## 개요

입학등록 동의서 제출 여부 수정 기능을 추가하였습니다.

## 본문

- `/entrance-intention/{memberId}` 입학등록 동의서 제출 여부를 수정할 수 있습니다.
   - 최종 합격한 지원자의 원서만 수정이 가능합니다. (최종 합격자에게 할당되는 `decidedMajor` 필드로 여부 판단)
- 원서 검색 dto에 `entranceIntentionYn` 필드를 추가하였습니다.

* 인증번호 관련 컨트롤러 메서드 파라미터에 `@Valid` 어노테이션이 누락되어있어 추가하였습니다.