### PR TITLE
[global] 이미지 업로드 API response 스펙에 맞도록 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/s3/controller/S3Controller.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/s3/controller/S3Controller.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
+import team.themoment.hellogsmv3.global.thirdParty.aws.s3.dto.response.UploadImageResDto;
 import team.themoment.hellogsmv3.global.thirdParty.aws.s3.service.UploadImageService;
 
 @Tag(name = "ThirdParty API", description = "증명사진 등록 관련 API입니다.")
@@ -21,10 +22,10 @@ public class S3Controller {
 
     @Operation(summary = "증명사진 등록", description = "증명사진 이미지를 요청받아 등록합니다.")
     @PostMapping("/image")
-    public CommonApiResponse uploadImage(
+    public UploadImageResDto uploadImage(
             @RequestParam(value = "file") MultipartFile multipartFile
     ) {
         String fileUrl = uploadImageService.execute(multipartFile);
-        return CommonApiResponse.success(fileUrl);
+        return new UploadImageResDto(fileUrl);
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/s3/dto/response/UploadImageResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/aws/s3/dto/response/UploadImageResDto.java
@@ -1,0 +1,6 @@
+package team.themoment.hellogsmv3.global.thirdParty.aws.s3.dto.response;
+
+public record UploadImageResDto(
+        String url
+) {
+}


### PR DESCRIPTION
## 개요

이미지 업로드 API의 response 스펙이 API 문서 스펙과 맞지 않아 수정하였습니다.


<img width="642" alt="수정전" src="https://github.com/user-attachments/assets/b793d95c-c94e-4160-a102-9cabc384bcd3">

> 수정 전


<img width="696" alt="수정후" src="https://github.com/user-attachments/assets/9b0b31c0-9a43-4265-a9e3-ebfbac147383">

> 수정 후
