### PR TITLE
[global] stage 환경 cloud watch 로그 수집 시스템 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,9 @@ dependencies {
 
     /** actuator **/
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    /** logging **/
+    implementation group: 'ca.pjer', name: 'logback-awslogs-appender', version: '1.6.0'
 }
 
 def querydslSrcDir = "$projectDir/build/generated"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,9 @@ server:
       enabled: true
       force: true
 
+logging:
+  config: classpath:logback-spring.xml
+
 spring:
   datasource:
     url: ${DB_URL}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration packagingData="true">
+    <timestamp key="timestamp" datePattern="yyyy-MM-dd-HH-mm-ssSSS"/>
+
+    <appender name="stage_aws_cloud_watch_log" class="ca.pjer.logback.AwsLogsAppender">
+        <layout>
+            <pattern>[%thread] [%date] [%level] [%file:%line] - %msg%n</pattern>
+        </layout>
+        <logGroupName>hellogsm-stage-log</logGroupName>
+        <logStreamUuidPrefix>[hello-gsm]-</logStreamUuidPrefix>
+        <logRegion>ap-northeast-2</logRegion>
+        <maxBatchLogEvents>50</maxBatchLogEvents>
+        <maxFlushTimeMillis>10000</maxFlushTimeMillis>
+        <maxBlockTimeMillis>5000</maxBlockTimeMillis>
+        <retentionTimeDays>0</retentionTimeDays>
+    </appender>
+
+    <property name="CONSOLE_LOG_PATTERN" value="%highlight(%-5level) %date [%thread] %cyan([%C{0} :: %M :: %L]) - %msg%n"/>
+    <appender name="console_log" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <springProfile name="default">
+        <root level="INFO">
+            <appender-ref ref="console_log"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="dev">
+        <root level="INFO">
+            <appender-ref ref="stage_aws_cloud_watch_log"/>
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
## 개요

stage 환경에서 cloud watch 로그그룹에 application 로그를 적재하고 모니터링할 수 있는 시스템을 구축하였습니다.

## 본문

logback-spring.xml의 파일은 아래의 내용을 담고있습니다.
- 기본 profile일 시 콘솔에 로그를 출력합니다.
- stage profile일 시 `hellogsm-stage-log` 로그그룹에 로그스트림을 생성하고 applicaiton 로그를 적재합니다.
   - 10초에 한번씩 로그를 cloud watch로 전송하고, 50개의 로그가 쌓여도 전송합니다.

* 기존 s3, sns 서비스를 사용할때 사용한 iam에 `CloudWatchLogsFullAccess` 권한을 등록하였고, 인스턴스 내부에 aws-cli로 iam의 accessKey, seacretKey를 등록하여 iam 권한을 적용시켰습니다.