### PR TITLE
[oneseo] 원서 임시저장시 null일 수 있는 필드 처리용 dto 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -147,7 +147,7 @@ public class OneseoController {
     @Operation(summary = "원서 임시 저장", description = "원서 정보를 임시 저장합니다.")
     @PostMapping("/temp-storage")
     public CommonApiResponse temp(
-            @RequestBody @Valid OneseoReqDto reqDto,
+            @RequestBody @Valid OneseoTempReqDto reqDto,
             @RequestParam Integer step,
             @AuthRequest Long memberId
     ) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoTempReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoTempReqDto.java
@@ -9,40 +9,31 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 
-@ValidDesiredMajors
-public record OneseoReqDto(
+public record OneseoTempReqDto(
         @Schema(description = "보호자 이름", defaultValue = "김보호")
-        @NotBlank
         String guardianName,
 
         @Schema(description = "보호자 전화번호", defaultValue = "01000000000")
-        @NotBlank
         @Pattern(regexp = "^0(?:\\d|\\d{2})(?:\\d{3}|\\d{4})\\d{4}$", message = "유요한 전화번호가 아닙니다.")
         String guardianPhoneNumber,
 
         @Schema(description = "보호자와 관계", defaultValue = "모")
-        @NotBlank
         String relationshipWithGuardian,
 
         @Schema(description = "증명사진 URL", defaultValue = "https://abc.com")
-        @NotBlank
         @Pattern(regexp = "^https:\\/\\/[^\\s/$.?#].[^\\s]*$", message = "유효한 이미지 URL이 아닙니다.")
         String profileImg,
 
         @Schema(description = "주소", defaultValue = "광주광역시 광산구 송정동 상무대로 312")
-        @NotBlank
         String address,
 
         @Schema(description = "상세주소", defaultValue = "101동 1001호")
-        @NotBlank
         String detailAddress,
 
         @Schema(description = "지원자 졸업상태", defaultValue = "CANDIDATE", allowableValues = {"CANDIDATE", "GED", "GRADUATE"})
-        @NotNull
         GraduationType graduationType,
 
         @Schema(description = "담임선생님 이름", defaultValue = "김선생")
-        @NotBlank
         String schoolTeacherName,
 
         @Schema(description = "담임선생님 전화번호", nullable = true, defaultValue = "01000000000")
@@ -50,15 +41,12 @@ public record OneseoReqDto(
         String schoolTeacherPhoneNumber,
 
         @Schema(description = "1지망 학과", defaultValue = "SW", allowableValues = {"SW", "AI", "IOT"})
-        @NotNull
         Major firstDesiredMajor,
 
         @Schema(description = "2지망 학과", defaultValue = "AI", allowableValues = {"SW", "AI", "IOT"})
-        @NotNull
         Major secondDesiredMajor,
 
         @Schema(description = "3지망 학과", defaultValue = "IOT", allowableValues = {"SW", "AI", "IOT"})
-        @NotNull
         Major thirdDesiredMajor,
 
         MiddleSchoolAchievementReqDto middleSchoolAchievement,
@@ -70,7 +58,6 @@ public record OneseoReqDto(
         String schoolAddress,
 
         @Schema(description = "자원자 전형", defaultValue = "GENERAL", allowableValues = {"GENERAL", "SPECIAL", "EXTRA_VETERANS", "EXTRA_ADMISSION"})
-        @NotNull
         Screening screening
 ) {
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
-import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoTempReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.DesiredMajorsResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.FoundOneseoResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.MiddleSchoolAchievementResDto;
@@ -21,7 +21,7 @@ public class OneseoTempStorageService {
     private final MemberService memberService;
 
     @CachePut(value = ONESEO_CACHE_VALUE, key = "#memberId")
-    public FoundOneseoResDto execute(OneseoReqDto reqDto,Integer step, Long memberId) {
+    public FoundOneseoResDto execute(OneseoTempReqDto reqDto, Integer step, Long memberId) {
         Member member = memberService.findByIdOrThrow(memberId);
 
         OneseoPrivacyDetailResDto oneseoPrivacyDetailResDto = buildOneseoPrivacyDetailResDto(member, reqDto);
@@ -37,7 +37,7 @@ public class OneseoTempStorageService {
 
     private OneseoPrivacyDetailResDto buildOneseoPrivacyDetailResDto(
             Member member,
-            OneseoReqDto reqDto
+            OneseoTempReqDto reqDto
     ) {
 
         return OneseoPrivacyDetailResDto.builder()
@@ -60,7 +60,7 @@ public class OneseoTempStorageService {
     }
 
     private MiddleSchoolAchievementResDto buildMiddleSchoolAchievementResDto(
-            OneseoReqDto reqDto
+            OneseoTempReqDto reqDto
     ) {
         MiddleSchoolAchievementReqDto middleSchoolAchievement = reqDto.middleSchoolAchievement();
 
@@ -84,7 +84,7 @@ public class OneseoTempStorageService {
     }
 
     private FoundOneseoResDto buildFoundOneseoResDto(
-            OneseoReqDto reqDto,
+            OneseoTempReqDto reqDto,
             OneseoPrivacyDetailResDto oneseoPrivacyDetailResDto,
             MiddleSchoolAchievementResDto middleSchoolAchievementResDto,
             Integer step


### PR DESCRIPTION
## 개요

원서 임시저장시 request body의 모든 필드가 nullable 해야하기 때문에 원서 임시저장 용 dto 객체를 추가하여 적용하였습니다.