### PR TITLE
[onseo] 원서 생성시 접수번호 할당 되도록 변경

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -19,7 +19,6 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.OneseoPrivacyDetail;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
-import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.MiddleSchoolAchievementRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
@@ -28,7 +27,6 @@ import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import java.util.List;
 
 import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.*;
-import static team.themoment.hellogsmv3.domain.oneseo.service.OneseoService.ONESEO_CACHE_VALUE;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -5,6 +5,7 @@ import org.springframework.cache.annotation.CachePut;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.themoment.hellogsmv3.domain.application.type.ScreeningCategory;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
@@ -18,6 +19,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.OneseoPrivacyDetail;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.MiddleSchoolAchievementRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
@@ -50,6 +52,7 @@ public class CreateOneseoService {
         OneseoPrivacyDetail oneseoPrivacyDetail = buildOneseoPrivacyDetail(reqDto, oneseo);
         MiddleSchoolAchievement middleSchoolAchievement = buildMiddleSchoolAchievement(reqDto, oneseo);
 
+        assignSubmitCode(oneseo);
         saveEntities(oneseo, oneseoPrivacyDetail, middleSchoolAchievement);
 
         calculateMiddleSchoolAchievement(oneseoPrivacyDetail.getGraduationType(), middleSchoolAchievement, oneseo);
@@ -61,6 +64,22 @@ public class CreateOneseoService {
                 oneseoPrivacyDetailResDto,
                 middleSchoolAchievementResDto
         );
+    }
+
+    private void assignSubmitCode(Oneseo oneseo) {
+        Integer maxSubmitCodeNumber = oneseoRepository.findMaxSubmitCodeByScreening(oneseo.getWantedScreening());
+        int newSubmitCodeNumber = (maxSubmitCodeNumber != null ? maxSubmitCodeNumber : 0) + 1;
+
+        String submitCode;
+        ScreeningCategory screeningCategory = oneseo.getWantedScreening().getScreeningCategory();
+        switch (screeningCategory) {
+            case GENERAL -> submitCode = "A-" + newSubmitCodeNumber;
+            case SPECIAL -> submitCode = "B-" + newSubmitCodeNumber;
+            case EXTRA -> submitCode = "C-" + newSubmitCodeNumber;
+            default -> throw new IllegalArgumentException("Unexpected value: " + screeningCategory);
+        }
+
+        oneseo.setOneseoSubmitCode(submitCode);
     }
 
     private OneseoPrivacyDetailResDto buildOneseoPrivacyDetailResDto(

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnService.java
@@ -26,30 +26,8 @@ public class ModifyRealOneseoArrivedYnService {
         Oneseo oneseo = oneseoService.findByMemberOrThrow(member);
 
         oneseo.switchRealOneseoArrivedYn();
-        assignSubmitCode(oneseo);
         Oneseo modifiedOneseo = oneseoRepository.save(oneseo);
 
         return new ArrivedStatusResDto(modifiedOneseo.getRealOneseoArrivedYn());
-    }
-
-    private void assignSubmitCode(Oneseo oneseo) {
-        if (oneseo.getRealOneseoArrivedYn().equals(YesNo.NO)) {
-            oneseo.setOneseoSubmitCode(null);
-            return;
-        }
-
-        Integer maxSubmitCodeNumber = oneseoRepository.findMaxSubmitCodeByScreening(oneseo.getWantedScreening());
-        int newSubmitCodeNumber = (maxSubmitCodeNumber != null ? maxSubmitCodeNumber : 0) + 1;
-
-        String submitCode;
-        ScreeningCategory screeningCategory = oneseo.getWantedScreening().getScreeningCategory();
-        switch (screeningCategory) {
-            case GENERAL -> submitCode = "A-" + newSubmitCodeNumber;
-            case SPECIAL -> submitCode = "B-" + newSubmitCodeNumber;
-            case EXTRA -> submitCode = "C-" + newSubmitCodeNumber;
-            default -> throw new IllegalArgumentException("Unexpected value: " + screeningCategory);
-        }
-
-        oneseo.setOneseoSubmitCode(submitCode);
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnService.java
@@ -3,12 +3,10 @@ package team.themoment.hellogsmv3.domain.oneseo.service;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import team.themoment.hellogsmv3.domain.application.type.ScreeningCategory;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.ArrivedStatusResDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
-import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 
 @Service


### PR DESCRIPTION
## 개요

실물 원서 제출을 위해 원서 출력시 접수번호가 필요하기 때문에 접수번호 할당 시점을 원서 생성 시점으로 변경하였습니다.
