### PR TITLE
[member] 전형 결과 조회 기능 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
@@ -7,7 +7,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import team.themoment.hellogsmv3.domain.member.dto.request.CreateMemberReqDto;
-import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberTestRequestResDto;
+import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberTestResDto;
 import team.themoment.hellogsmv3.domain.member.entity.type.Role;
 import team.themoment.hellogsmv3.domain.member.service.*;
 import team.themoment.hellogsmv3.domain.member.dto.request.AuthenticateCodeReqDto;
@@ -111,7 +111,7 @@ public class MemberController {
 
     @Operation(summary = "전형 결과 조회", description = "본인의 1차 전형, 2차 전형의 결과를 조회합니다.")
     @GetMapping("/test-result/me")
-    public FoundMemberTestRequestResDto testResult(
+    public FoundMemberTestResDto testResult(
             @AuthRequest Long memberId
     ) {
         return queryTestResultService.execute(memberId);

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
@@ -7,15 +7,13 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import team.themoment.hellogsmv3.domain.member.dto.request.CreateMemberReqDto;
+import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberTestRequestResDto;
 import team.themoment.hellogsmv3.domain.member.entity.type.Role;
-import team.themoment.hellogsmv3.domain.member.service.CreateMemberService;
+import team.themoment.hellogsmv3.domain.member.service.*;
 import team.themoment.hellogsmv3.domain.member.dto.request.AuthenticateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.dto.request.GenerateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberAuthInfoResDto;
 import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberResDto;
-import team.themoment.hellogsmv3.domain.member.service.AuthenticateCodeService;
-import team.themoment.hellogsmv3.domain.member.service.QueryMemberAuthInfoByIdService;
-import team.themoment.hellogsmv3.domain.member.service.QueryMemberByIdService;
 import team.themoment.hellogsmv3.domain.member.service.impl.GenerateCodeServiceImpl;
 import team.themoment.hellogsmv3.domain.member.service.impl.GenerateTestCodeServiceImpl;
 import team.themoment.hellogsmv3.global.common.handler.annotation.AuthRequest;
@@ -35,6 +33,7 @@ public class MemberController {
     private final QueryMemberByIdService queryMemberByIdService;
     private final CreateMemberService createMemberService;
     private final QueryMemberAuthInfoByIdService queryMemberAuthInfoByIdService;
+    private final QueryTestResultService queryTestResultService;
 
     @Operation(summary = "인증코드 전송", description = "전화번호를 요청받아 인증코드를 전송합니다.")
     @PostMapping("/member/me/send-code")
@@ -108,5 +107,13 @@ public class MemberController {
             @PathVariable Long memberId
     ) {
         return queryMemberAuthInfoByIdService.execute(memberId);
+    }
+
+    @Operation(summary = "전형 결과 조회", description = "본인의 1차 전형, 2차 전형의 결과를 조회합니다.")
+    @GetMapping("/test-result/me")
+    public FoundMemberTestRequestResDto testResult(
+            @AuthRequest Long memberId
+    ) {
+        return queryTestResultService.execute(memberId);
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/dto/response/FoundMemberTestRequestResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/dto/response/FoundMemberTestRequestResDto.java
@@ -1,0 +1,11 @@
+package team.themoment.hellogsmv3.domain.member.dto.response;
+
+import lombok.Builder;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
+
+@Builder
+public record FoundMemberTestRequestResDto(
+        YesNo firstTestPassYn,
+        YesNo secondTestPassYn
+) {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/dto/response/FoundMemberTestResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/dto/response/FoundMemberTestResDto.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 
 @Builder
-public record FoundMemberTestRequestResDto(
+public record FoundMemberTestResDto(
         YesNo firstTestPassYn,
         YesNo secondTestPassYn
 ) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryTestResultService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryTestResultService.java
@@ -2,7 +2,7 @@ package team.themoment.hellogsmv3.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberTestRequestResDto;
+import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberTestResDto;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
@@ -15,13 +15,13 @@ public class QueryTestResultService {
     private final MemberService memberService;
     private final OneseoService oneseoService;
 
-    public FoundMemberTestRequestResDto execute(Long memberId) {
+    public FoundMemberTestResDto execute(Long memberId) {
         Member member = memberService.findByIdOrThrow(memberId);
         Oneseo oneseo = oneseoService.findByMemberOrThrow(member);
 
         EntranceTestResult entranceTestResult = oneseo.getEntranceTestResult();
 
-        return new FoundMemberTestRequestResDto(
+        return new FoundMemberTestResDto(
                 entranceTestResult.getFirstTestPassYn(),
                 entranceTestResult.getSecondTestPassYn()
         );

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryTestResultService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryTestResultService.java
@@ -1,0 +1,29 @@
+package team.themoment.hellogsmv3.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberTestRequestResDto;
+import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.service.OneseoService;
+
+@Service
+@RequiredArgsConstructor
+public class QueryTestResultService {
+
+    private final MemberService memberService;
+    private final OneseoService oneseoService;
+
+    public FoundMemberTestRequestResDto execute(Long memberId) {
+        Member member = memberService.findByIdOrThrow(memberId);
+        Oneseo oneseo = oneseoService.findByMemberOrThrow(member);
+
+        EntranceTestResult entranceTestResult = oneseo.getEntranceTestResult();
+
+        return new FoundMemberTestRequestResDto(
+                entranceTestResult.getFirstTestPassYn(),
+                entranceTestResult.getSecondTestPassYn()
+        );
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -231,6 +231,10 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/member/v3/auth-info/{memberId}").hasAnyAuthority(
                         Role.ADMIN.name()
                 )
+                .requestMatchers(HttpMethod.GET, "/member/v3/test-result/me").hasAnyAuthority(
+                        Role.APPLICANT.name(),
+                        Role.ROOT.name()
+                )
 
                 // oneseo
                 .requestMatchers("/oneseo/v3/oneseo/me").hasAnyAuthority(


### PR DESCRIPTION
## 개요

전형 결과 조회 API를 추가하였습니다.

## 본문

- `/member/v3/test-result` 해당 지원자의 1차 전형, 2차 전형의 결과를 조회합니다.
- 지원자의 전형 결과를 조회하는 것이기 때문에 해당 로직을 member 도메인 패키지에 두었습니다. 