### PR TITLE
[oneseo] QueryTestResultService 서비스 테스트코드 추가

### DIFF
--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryTestResultServiceTest.java
@@ -40,12 +40,16 @@ public class QueryTestResultServiceTest {
     @Nested
     @DisplayName("execute 메소드는")
     class Describe_execute {
+
         private final Long memberId = 1L;
+
         @Nested
         @DisplayName("존재하는 회원 ID가 주어지고")
         class Context_with_existing_member_id {
+
             private Member member;
             private Long OneseoId = 1L;
+
             @BeforeEach
             void setUp() {
                 member = Member.builder()
@@ -57,10 +61,13 @@ public class QueryTestResultServiceTest {
                         .build();
                 given(memberService.findByIdOrThrow(memberId)).willReturn(member);
             }
+
             @Nested
             @DisplayName("해당 회원의 시험 결과가 존재하면")
             class Context_with_existing_test_result {
+
                 private Oneseo oneseo;
+
                 @BeforeEach
                 void setUp() {
                     oneseo = Oneseo.builder()
@@ -76,41 +83,51 @@ public class QueryTestResultServiceTest {
                             .build();
                     given(oneseoService.findByMemberOrThrow(member)).willReturn(oneseo);
                 }
+
                 @Test
                 @DisplayName("해당 회원의 시험 결과를 반환한다.")
                 void it_returns_test_result_of_the_member() {
                     FoundMemberTestResDto result = queryTestResultService.execute(memberId);
+
                     assertEquals(YesNo.YES, result.firstTestPassYn());
                     assertEquals(YesNo.YES, result.secondTestPassYn());
                 }
             }
+
             @Nested
             @DisplayName("해당 회원의 시험 결과가 존재하지 않으면")
             class Context_with_non_existing_test_result {
+
                 @BeforeEach
                 void setUp() {
                     given(oneseoService.findByMemberOrThrow(member)).willThrow(new ExpectedException("해당 지원자의 원서를 찾을 수 없습니다. member ID: " + member.getId(), HttpStatus.NOT_FOUND));
                 }
+
                 @Test
                 @DisplayName("ExpectedException을 던진다.")
                 void it_returns_expected_exception() {
                     ExpectedException exception = assertThrows(ExpectedException.class, () -> queryTestResultService.execute(memberId));
+
                     assertEquals("해당 지원자의 원서를 찾을 수 없습니다. member ID: " + member.getId(), exception.getMessage());
                     assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
                 }
             }
         }
+
         @Nested
         @DisplayName("존재하지 않는 회원 ID가 주어지면")
         class Context_with_non_existing_member_id {
+
             @BeforeEach
             void setUp() {
                 given(memberService.findByIdOrThrow(memberId)).willThrow(new ExpectedException("존재하지 않는 지원자입니다. member ID: " + memberId, HttpStatus.NOT_FOUND));
             }
+
             @Test
             @DisplayName("ExpectedException을 던진다.")
             void it_throws_expected_exception() {
                 ExpectedException exception = assertThrows(ExpectedException.class, () -> queryTestResultService.execute(memberId));
+
                 assertEquals("존재하지 않는 지원자입니다. member ID: " + memberId, exception.getMessage());
                 assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
             }

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryTestResultServiceTest.java
@@ -1,0 +1,113 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.HttpStatus;
+import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberTestResDto;
+import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
+import team.themoment.hellogsmv3.domain.member.service.MemberService;
+import team.themoment.hellogsmv3.domain.member.service.QueryTestResultService;
+import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+@DisplayName("QueryTestResultService 클래스의")
+public class QueryTestResultServiceTest {
+    @Mock
+    private MemberService memberService;
+    @Mock
+    private OneseoService oneseoService;
+    @InjectMocks
+    private QueryTestResultService queryTestResultService;
+
+    @Nested
+    @DisplayName("execute 메소드는")
+    class Describe_execute {
+        private final Long memberId = 1L;
+        @Nested
+        @DisplayName("존재하는 회원 ID가 주어지고")
+        class Context_with_existing_member_id {
+            private Member member;
+            private Long OneseoId = 1L;
+            @BeforeEach
+            void setUp() {
+                member = Member.builder()
+                        .id(memberId)
+                        .name("홍길동")
+                        .birth(LocalDate.of(2009,1, 1))
+                        .phoneNumber("01012345678")
+                        .sex(Sex.MALE)
+                        .build();
+                given(memberService.findByIdOrThrow(memberId)).willReturn(member);
+            }
+            @Nested
+            @DisplayName("해당 회원의 시험 결과가 존재하면")
+            class Context_with_existing_test_result {
+                private Oneseo oneseo;
+                @BeforeEach
+                void setUp() {
+                    oneseo = Oneseo.builder()
+                            .id(OneseoId)
+                            .member(member)
+                            .entranceTestResult(
+                                    EntranceTestResult.builder()
+                                            .id(1L)
+                                            .firstTestPassYn(YesNo.YES)
+                                            .secondTestPassYn(YesNo.YES)
+                                            .build()
+                            )
+                            .build();
+                    given(oneseoService.findByMemberOrThrow(member)).willReturn(oneseo);
+                }
+                @Test
+                @DisplayName("해당 회원의 시험 결과를 반환한다.")
+                void it_returns_test_result_of_the_member() {
+                    FoundMemberTestResDto result = queryTestResultService.execute(memberId);
+                    assertEquals(YesNo.YES, result.firstTestPassYn());
+                    assertEquals(YesNo.YES, result.secondTestPassYn());
+                }
+            }
+            @Nested
+            @DisplayName("해당 회원의 시험 결과가 존재하지 않으면")
+            class Context_with_non_existing_test_result {
+                @BeforeEach
+                void setUp() {
+                    given(oneseoService.findByMemberOrThrow(member)).willThrow(new ExpectedException("해당 지원자의 원서를 찾을 수 없습니다. member ID: " + member.getId(), HttpStatus.NOT_FOUND));
+                }
+                @Test
+                @DisplayName("ExpectedException을 던진다.")
+                void it_returns_expected_exception() {
+                    ExpectedException exception = assertThrows(ExpectedException.class, () -> queryTestResultService.execute(memberId));
+                    assertEquals("해당 지원자의 원서를 찾을 수 없습니다. member ID: " + member.getId(), exception.getMessage());
+                    assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+                }
+            }
+        }
+        @Nested
+        @DisplayName("존재하지 않는 회원 ID가 주어지면")
+        class Context_with_non_existing_member_id {
+            @BeforeEach
+            void setUp() {
+                given(memberService.findByIdOrThrow(memberId)).willThrow(new ExpectedException("존재하지 않는 지원자입니다. member ID: " + memberId, HttpStatus.NOT_FOUND));
+            }
+            @Test
+            @DisplayName("ExpectedException을 던진다.")
+            void it_throws_expected_exception() {
+                ExpectedException exception = assertThrows(ExpectedException.class, () -> queryTestResultService.execute(memberId));
+                assertEquals("존재하지 않는 지원자입니다. member ID: " + memberId, exception.getMessage());
+                assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+            }
+        }
+    }
+}

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryTestResultServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberTestResDto;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
@@ -30,6 +31,11 @@ public class QueryTestResultServiceTest {
     private OneseoService oneseoService;
     @InjectMocks
     private QueryTestResultService queryTestResultService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
 
     @Nested
     @DisplayName("execute 메소드는")


### PR DESCRIPTION
## 개요

QueryTestResultService 서비스 테스트 코드 추가했습니다.

## 본문

입학시험 결과를 query하는 서비스로 memberId를 통해 조회합니다.
1. 회원이 존재하고 원서가 존재하는 경우
2. 회원이 존재하고 원서가 없는경우
3. 회원이 존재하지 않는 경우
에 대해 테스트합니다.


