### PR TITLE
[oneseo] 환산일수 계산 기능 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/MiddleSchoolAchievementResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/MiddleSchoolAchievementResDto.java
@@ -18,6 +18,7 @@ public record MiddleSchoolAchievementResDto(
         List<Integer> artsPhysicalAchievement,
         List<String> artsPhysicalSubjects,
         List<Integer> absentDays,
+        Integer absentDaysCount,
         List<Integer> attendanceDays,
         List<Integer> volunteerTime,
         String liberalSystem,

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -107,6 +107,11 @@ public class CreateOneseoService {
     private MiddleSchoolAchievementResDto buildMiddleSchoolAchievementResDto(
             MiddleSchoolAchievement middleSchoolAchievement
     ) {
+
+        List<Integer> absentDays = middleSchoolAchievement.getAbsentDays();
+        List<Integer> attendanceDays = middleSchoolAchievement.getAttendanceDays();
+        Integer absentDaysCount = OneseoService.calcAbsentDaysCount(absentDays, attendanceDays);
+
         return MiddleSchoolAchievementResDto.builder()
                 .achievement1_2(middleSchoolAchievement.getAchievement1_2())
                 .achievement2_1(middleSchoolAchievement.getAchievement2_1())
@@ -117,8 +122,9 @@ public class CreateOneseoService {
                 .newSubjects(middleSchoolAchievement.getNewSubjects())
                 .artsPhysicalAchievement(middleSchoolAchievement.getArtsPhysicalAchievement())
                 .artsPhysicalSubjects(middleSchoolAchievement.getArtsPhysicalSubjects())
-                .absentDays(middleSchoolAchievement.getAbsentDays())
-                .attendanceDays(middleSchoolAchievement.getAttendanceDays())
+                .absentDays(absentDays)
+                .absentDaysCount(absentDaysCount)
+                .attendanceDays(attendanceDays)
                 .volunteerTime(middleSchoolAchievement.getVolunteerTime())
                 .liberalSystem(middleSchoolAchievement.getLiberalSystem())
                 .freeSemester(middleSchoolAchievement.getFreeSemester())

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -102,6 +102,11 @@ public class ModifyOneseoService {
     private MiddleSchoolAchievementResDto buildMiddleSchoolAchievementResDto(
             MiddleSchoolAchievement middleSchoolAchievement
     ) {
+
+        List<Integer> absentDays = middleSchoolAchievement.getAbsentDays();
+        List<Integer> attendanceDays = middleSchoolAchievement.getAttendanceDays();
+        Integer absentDaysCount = OneseoService.calcAbsentDaysCount(absentDays, attendanceDays);
+
         return MiddleSchoolAchievementResDto.builder()
                 .achievement1_2(middleSchoolAchievement.getAchievement1_2())
                 .achievement2_1(middleSchoolAchievement.getAchievement2_1())
@@ -112,8 +117,9 @@ public class ModifyOneseoService {
                 .newSubjects(middleSchoolAchievement.getNewSubjects())
                 .artsPhysicalAchievement(middleSchoolAchievement.getArtsPhysicalAchievement())
                 .artsPhysicalSubjects(middleSchoolAchievement.getArtsPhysicalSubjects())
-                .absentDays(middleSchoolAchievement.getAbsentDays())
-                .attendanceDays(middleSchoolAchievement.getAttendanceDays())
+                .absentDays(absentDays)
+                .absentDaysCount(absentDaysCount)
+                .attendanceDays(attendanceDays)
                 .volunteerTime(middleSchoolAchievement.getVolunteerTime())
                 .liberalSystem(middleSchoolAchievement.getLiberalSystem())
                 .freeSemester(middleSchoolAchievement.getFreeSemester())

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
@@ -8,12 +8,25 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class OneseoService {
 
     public static final String ONESEO_CACHE_VALUE = "oneseo";
     private final OneseoRepository oneseoRepository;
+
+    public static Integer calcAbsentDaysCount(List<Integer> absentDays, List<Integer> attendanceDays) {
+        if (absentDays == null || attendanceDays == null) {
+            return null;
+        }
+
+        int totalAbsentDays = absentDays.stream().mapToInt(Integer::intValue).sum();
+        int totalAttendanceDays = attendanceDays.stream().mapToInt(Integer::intValue).sum();
+
+        return totalAbsentDays + (totalAttendanceDays / 3);
+    }
 
     public Oneseo findByMemberOrThrow(Member member) {
         return oneseoRepository.findByMember(member)

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoTempStorageService.java
@@ -12,6 +12,8 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.response.FoundOneseoResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.MiddleSchoolAchievementResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.OneseoPrivacyDetailResDto;
 
+import java.util.List;
+
 import static team.themoment.hellogsmv3.domain.oneseo.service.OneseoService.*;
 
 @Service
@@ -65,6 +67,10 @@ public class OneseoTempStorageService {
     ) {
         MiddleSchoolAchievementReqDto middleSchoolAchievement = reqDto.middleSchoolAchievement();
 
+        List<Integer> absentDays = middleSchoolAchievement.absentDays();
+        List<Integer> attendanceDays = middleSchoolAchievement.attendanceDays();
+        Integer absentDaysCount = OneseoService.calcAbsentDaysCount(absentDays, attendanceDays);
+
         return MiddleSchoolAchievementResDto.builder()
                 .achievement1_2(middleSchoolAchievement.achievement1_2())
                 .achievement2_1(middleSchoolAchievement.achievement2_1())
@@ -75,8 +81,9 @@ public class OneseoTempStorageService {
                 .newSubjects(middleSchoolAchievement.newSubjects())
                 .artsPhysicalAchievement(middleSchoolAchievement.artsPhysicalAchievement())
                 .artsPhysicalSubjects(middleSchoolAchievement.artsPhysicalSubjects())
-                .absentDays(middleSchoolAchievement.absentDays())
-                .attendanceDays(middleSchoolAchievement.attendanceDays())
+                .absentDays(absentDays)
+                .absentDaysCount(absentDaysCount)
+                .attendanceDays(attendanceDays)
                 .volunteerTime(middleSchoolAchievement.volunteerTime())
                 .liberalSystem(middleSchoolAchievement.liberalSystem())
                 .freeSemester(middleSchoolAchievement.freeSemester())

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
@@ -11,6 +11,8 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
 import team.themoment.hellogsmv3.domain.oneseo.repository.MiddleSchoolAchievementRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRepository;
 
+import java.util.List;
+
 import static team.themoment.hellogsmv3.domain.oneseo.service.OneseoService.ONESEO_CACHE_VALUE;
 
 @Service
@@ -66,6 +68,11 @@ public class QueryOneseoByIdService {
     private MiddleSchoolAchievementResDto buildMiddleSchoolAchievementResDto(
             MiddleSchoolAchievement middleSchoolAchievement
     ) {
+
+        List<Integer> absentDays = middleSchoolAchievement.getAbsentDays();
+        List<Integer> attendanceDays = middleSchoolAchievement.getAttendanceDays();
+        Integer absentDaysCount = OneseoService.calcAbsentDaysCount(absentDays, attendanceDays);
+
         return MiddleSchoolAchievementResDto.builder()
                 .achievement1_2(middleSchoolAchievement.getAchievement1_2())
                 .achievement2_1(middleSchoolAchievement.getAchievement2_1())
@@ -76,8 +83,9 @@ public class QueryOneseoByIdService {
                 .newSubjects(middleSchoolAchievement.getNewSubjects())
                 .artsPhysicalAchievement(middleSchoolAchievement.getArtsPhysicalAchievement())
                 .artsPhysicalSubjects(middleSchoolAchievement.getArtsPhysicalSubjects())
-                .absentDays(middleSchoolAchievement.getAbsentDays())
-                .attendanceDays(middleSchoolAchievement.getAttendanceDays())
+                .absentDays(absentDays)
+                .absentDaysCount(absentDaysCount)
+                .attendanceDays(attendanceDays)
                 .volunteerTime(middleSchoolAchievement.getVolunteerTime())
                 .liberalSystem(middleSchoolAchievement.getLiberalSystem())
                 .freeSemester(middleSchoolAchievement.getFreeSemester())

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoServiceTest.java
@@ -13,6 +13,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -79,4 +80,40 @@ public class OneseoServiceTest {
             }
         }
     }
+
+    @Nested
+    @DisplayName("calcAbsentDaysCount 메소드는")
+    class Describe_calcAbsentDaysCount {
+
+        @Nested
+        @DisplayName("결석 횟수 list와 지각, 조퇴, 결과 횟수 list를 보내면")
+        class Context_with_absent_attendance_days {
+
+            List<Integer> absentDays = List.of(3, 0, 0);
+            List<Integer> attendanceDays = List.of(0, 0, 0, 1, 0, 1, 0, 2, 2);
+
+            @Test
+            @DisplayName("환산일수를 반환한다.")
+            void it_returns_oneseo() {
+                Integer absentDaysCount = OneseoService.calcAbsentDaysCount(absentDays, attendanceDays);
+                assertEquals(absentDaysCount, 5);
+            }
+        }
+
+        @Nested
+        @DisplayName("null 값이 결석 횟수 list와 지각, 조퇴, 결과 횟수 list를 보내면")
+        class Context_with_null_absent_attendance_days {
+
+            List<Integer> nullAbsentDays = null;
+            List<Integer> nullAttendanceDays = null;
+
+            @Test
+            @DisplayName("null 값을 반환한다.")
+            void it_returns_oneseo() {
+                Integer absentDaysCount = OneseoService.calcAbsentDaysCount(nullAbsentDays, nullAttendanceDays);
+                assertEquals(absentDaysCount, null);
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
## 개요

- `FoundOneseoResDto` 객체 필드에 환산일수 필드를 추가하였습니다.
- 원서 생성, 수정, 임시저장, 내 원서 조회시 환신일수를 계산하므로 원서 공통 서비스에 환산일수 계산 로직을 작성하였습니다.
- 원서 공통 서비스의 환산일수 계산 로직에 대해 테스트코드를 작성하였습니다.