### PR TITLE
[oneseo] ModifyEntranceIntentionService 테스트 추가

### DIFF
--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyEntranceIntentionServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyEntranceIntentionServiceTest.java
@@ -46,7 +46,8 @@ public class ModifyEntranceIntentionServiceTest {
     class Describe_execute {
 
         private final Long memberId = 1L;
-        private final YesNo entranceIntentionYn = YesNo.YES;
+        private final YesNo defaultYn = YesNo.YES;
+        private final YesNo targetYn = YesNo.NO;
 
         @Nested
         @DisplayName("존재하는 회원 ID가 주어지면")
@@ -78,6 +79,7 @@ public class ModifyEntranceIntentionServiceTest {
                         oneseo = Oneseo.builder()
                                 .member(member)
                                 .decidedMajor(Major.SW)
+                                .entranceIntentionYn(defaultYn)
                                 .build();
 
                         given(oneseoService.findByMemberOrThrow(member)).willReturn(oneseo);
@@ -86,7 +88,7 @@ public class ModifyEntranceIntentionServiceTest {
                     @Test
                     @DisplayName("입학 의사 여부를 수정하고 저장한다.")
                     void it_saves_entrance_intention() {
-                        EntranceIntentionReqDto reqDto = new EntranceIntentionReqDto(entranceIntentionYn);
+                        EntranceIntentionReqDto reqDto = new EntranceIntentionReqDto(targetYn);
                         modifyEntranceIntentionService.execute(memberId, reqDto);
 
                         ArgumentCaptor<Oneseo> oneseoCaptor = ArgumentCaptor.forClass(Oneseo.class);
@@ -95,7 +97,7 @@ public class ModifyEntranceIntentionServiceTest {
 
                         Oneseo capturedOneseo = oneseoCaptor.getValue();
 
-                        assertEquals(entranceIntentionYn, capturedOneseo.getEntranceIntentionYn());
+                        assertEquals(targetYn, capturedOneseo.getEntranceIntentionYn());
                     }
                 }
 
@@ -116,7 +118,7 @@ public class ModifyEntranceIntentionServiceTest {
                     @Test
                     @DisplayName("ExpectedException을 던진다")
                     void it_throws_expected_exception() {
-                        EntranceIntentionReqDto reqDto = new EntranceIntentionReqDto(entranceIntentionYn);
+                        EntranceIntentionReqDto reqDto = new EntranceIntentionReqDto(defaultYn);
 
                         ExpectedException exception = assertThrows(ExpectedException.class, () -> modifyEntranceIntentionService.execute(memberId, reqDto));
 
@@ -138,7 +140,7 @@ public class ModifyEntranceIntentionServiceTest {
                 @Test
                 @DisplayName("ExpectedException을 던진다")
                 void it_throws_expected_exception() {
-                    EntranceIntentionReqDto reqDto = new EntranceIntentionReqDto(entranceIntentionYn);
+                    EntranceIntentionReqDto reqDto = new EntranceIntentionReqDto(defaultYn);
 
                     ExpectedException exception = assertThrows(ExpectedException.class, () -> modifyEntranceIntentionService.execute(memberId, reqDto));
 
@@ -160,7 +162,7 @@ public class ModifyEntranceIntentionServiceTest {
             @Test
             @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception() {
-                EntranceIntentionReqDto reqDto = new EntranceIntentionReqDto(entranceIntentionYn);
+                EntranceIntentionReqDto reqDto = new EntranceIntentionReqDto(defaultYn);
 
                 ExpectedException exception = assertThrows(ExpectedException.class, () -> modifyEntranceIntentionService.execute(memberId, reqDto));
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyEntranceIntentionServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyEntranceIntentionServiceTest.java
@@ -1,0 +1,172 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.member.service.MemberService;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.EntranceIntentionReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("ModifyEntranceIntentionService 클래스의")
+public class ModifyEntranceIntentionServiceTest {
+
+    @Mock
+    private MemberService memberService;
+    @Mock
+    private OneseoService oneseoService;
+    @Mock
+    private OneseoRepository oneseoRepository;
+
+    @InjectMocks
+    private ModifyEntranceIntentionService modifyEntranceIntentionService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Nested
+    @DisplayName("execute 메소드는")
+    class Describe_execute {
+
+        private final Long memberId = 1L;
+        private final YesNo entranceIntentionYn = YesNo.YES;
+
+        @Nested
+        @DisplayName("존재하는 회원 ID가 주어지면")
+        class Context_with_existing_member_id {
+
+            Member member;
+
+            @BeforeEach
+            void setUp() {
+                member = Member.builder()
+                        .id(memberId)
+                        .build();
+
+                given(memberService.findByIdOrThrow(memberId)).willReturn(member);
+            }
+
+            @Nested
+            @DisplayName("원서가 있다면")
+            class Context_with_existing_oneseo {
+
+                @Nested
+                @DisplayName("최종합격된 원서라면")
+                class Context_with_final_oneseo {
+
+                    Oneseo oneseo;
+
+                    @BeforeEach
+                    void setUp() {
+                        oneseo = Oneseo.builder()
+                                .member(member)
+                                .decidedMajor(Major.SW)
+                                .build();
+
+                        given(oneseoService.findByMemberOrThrow(member)).willReturn(oneseo);
+                    }
+
+                    @Test
+                    @DisplayName("입학 의사 여부를 수정하고 저장한다.")
+                    void it_saves_entrance_intention() {
+                        EntranceIntentionReqDto reqDto = new EntranceIntentionReqDto(entranceIntentionYn);
+                        modifyEntranceIntentionService.execute(memberId, reqDto);
+
+                        ArgumentCaptor<Oneseo> oneseoCaptor = ArgumentCaptor.forClass(Oneseo.class);
+
+                        verify(oneseoRepository).save(oneseoCaptor.capture());
+
+                        Oneseo capturedOneseo = oneseoCaptor.getValue();
+
+                        assertEquals(entranceIntentionYn, capturedOneseo.getEntranceIntentionYn());
+                    }
+                }
+
+                @Nested
+                @DisplayName("최종합격된 원서가 아니라면")
+                class Context_with_non_final_oneseo {
+
+                    @BeforeEach
+                    void setUp() {
+                        Oneseo oneseo = Oneseo.builder()
+                                .member(member)
+                                .decidedMajor(null) // 최종 합격하지 않은 상태
+                                .build();
+
+                        given(oneseoService.findByMemberOrThrow(member)).willReturn(oneseo);
+                    }
+
+                    @Test
+                    @DisplayName("ExpectedException을 던진다")
+                    void it_throws_expected_exception() {
+                        EntranceIntentionReqDto reqDto = new EntranceIntentionReqDto(entranceIntentionYn);
+
+                        ExpectedException exception = assertThrows(ExpectedException.class, () -> modifyEntranceIntentionService.execute(memberId, reqDto));
+
+                        assertEquals("최종 합격한 지원자의 원서만 입학등록 동의서 제출여부를 수정할 수 있습니다.", exception.getMessage());
+                        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+                    }
+                }
+            }
+
+            @Nested
+            @DisplayName("원서가 없다면")
+            class Context_with_non_existing_oneseo {
+
+                @BeforeEach
+                void setUp() {
+                    given(oneseoService.findByMemberOrThrow(member)).willThrow(new ExpectedException("해당 지원자의 원서를 찾을 수 없습니다. member ID: " + memberId, HttpStatus.NOT_FOUND));
+                }
+
+                @Test
+                @DisplayName("ExpectedException을 던진다")
+                void it_throws_expected_exception() {
+                    EntranceIntentionReqDto reqDto = new EntranceIntentionReqDto(entranceIntentionYn);
+
+                    ExpectedException exception = assertThrows(ExpectedException.class, () -> modifyEntranceIntentionService.execute(memberId, reqDto));
+
+                    assertEquals("해당 지원자의 원서를 찾을 수 없습니다. member ID: " + memberId, exception.getMessage());
+                    assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+                }
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 회원 ID가 주어지면")
+        class Context_with_non_existing_member_id {
+
+            @BeforeEach
+            void setUp() {
+                given(memberService.findByIdOrThrow(memberId)).willThrow(new ExpectedException("존재하지 않는 지원자입니다. member ID: " + memberId, HttpStatus.NOT_FOUND));
+            }
+
+            @Test
+            @DisplayName("ExpectedException을 던진다")
+            void it_throws_expected_exception() {
+                EntranceIntentionReqDto reqDto = new EntranceIntentionReqDto(entranceIntentionYn);
+
+                ExpectedException exception = assertThrows(ExpectedException.class, () -> modifyEntranceIntentionService.execute(memberId, reqDto));
+
+                assertEquals("존재하지 않는 지원자입니다. member ID: " + memberId, exception.getMessage());
+                assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요

ModifyEntranceIntentionService 테스트 코드 추가했습니다.

## 본문
ModifyEntranceIntentionService는 최종합격자의 입학여부(입학 의사)를 수정하는 서비스입니다.

1. 존재하는 회원 id가 주어지고 최종합격된 원서가 있을 때 -> 입학 의사 수정
2. 존재하는 회원 id가 주어지고 최종합격되지 않은 원서가 있을 때 -> ExpectedException
3. 존재하는 회원 id가 주어지고 원서가 없을 때 -> ExpectedException
4. 존재하지 않는 회원 id가 주어졌을때 -> ExpectedException
위 테스트 케이스들에 대해 작성했습니다.