### PR TITLE
[oneseo] 졸업자, 검정고시 지원자는 중학교 관련 정보를 받지 않도록 변경

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/OneseoReqDto.java
@@ -44,7 +44,6 @@ public record OneseoReqDto(
         GraduationType graduationType,
 
         @Schema(description = "담임선생님 이름", defaultValue = "김선생")
-        @NotBlank
         String schoolTeacherName,
 
         @Schema(description = "담임선생님 전화번호", nullable = true, defaultValue = "01000000000")

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -26,6 +26,7 @@ import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.util.List;
 
+import static team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType.*;
 import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.*;
 
 @Service
@@ -42,6 +43,9 @@ public class CreateOneseoService {
     @Transactional
     @CachePut(value = OneseoService.ONESEO_CACHE_VALUE, key = "#memberId")
     public FoundOneseoResDto execute(OneseoReqDto reqDto, Long memberId) {
+
+        isValidMiddleSchoolInfo(reqDto);
+
         Member currentMember = memberService.findByIdOrThrow(memberId);
 
         isExistOneseo(currentMember);
@@ -239,6 +243,23 @@ public class CreateOneseoService {
         if (oneseoRepository.existsByMember(currentMember)) {
             throw new ExpectedException("이미 원서가 존재합니다.", HttpStatus.BAD_REQUEST);
         }
+    }
+
+    private void isValidMiddleSchoolInfo(OneseoReqDto reqDto) {
+        if (
+                reqDto.graduationType().equals(CANDIDATE) && (
+                        isBlankString(reqDto.schoolTeacherName()) ||
+                        isBlankString(reqDto.schoolTeacherPhoneNumber()) ||
+                        isBlankString(reqDto.schoolName()) ||
+                        isBlankString(reqDto.schoolAddress())
+                )
+        ) {
+            throw new ExpectedException("중학교 졸업예정인 지원자는 현재 재학 중인 중학교 정보를 필수로 입력해야 합니다.", HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private boolean isBlankString(String target) {
+        return target == null || target.isBlank();
     }
 
     private List<Integer> validationGeneralAchievement(List<Integer> achievements)  {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -68,6 +68,23 @@ public class CreateOneseoService {
         );
     }
 
+    private void isValidMiddleSchoolInfo(OneseoReqDto reqDto) {
+        if (
+                reqDto.graduationType().equals(CANDIDATE) && (
+                        isBlankString(reqDto.schoolTeacherName()) ||
+                                isBlankString(reqDto.schoolTeacherPhoneNumber()) ||
+                                isBlankString(reqDto.schoolName()) ||
+                                isBlankString(reqDto.schoolAddress())
+                )
+        ) {
+            throw new ExpectedException("중학교 졸업예정인 지원자는 현재 재학 중인 중학교 정보를 필수로 입력해야 합니다.", HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private boolean isBlankString(String target) {
+        return target == null || target.isBlank();
+    }
+
     private void assignSubmitCode(Oneseo oneseo) {
         Integer maxSubmitCodeNumber = oneseoRepository.findMaxSubmitCodeByScreening(oneseo.getWantedScreening());
         int newSubmitCodeNumber = (maxSubmitCodeNumber != null ? maxSubmitCodeNumber : 0) + 1;
@@ -243,23 +260,6 @@ public class CreateOneseoService {
         if (oneseoRepository.existsByMember(currentMember)) {
             throw new ExpectedException("이미 원서가 존재합니다.", HttpStatus.BAD_REQUEST);
         }
-    }
-
-    private void isValidMiddleSchoolInfo(OneseoReqDto reqDto) {
-        if (
-                reqDto.graduationType().equals(CANDIDATE) && (
-                        isBlankString(reqDto.schoolTeacherName()) ||
-                        isBlankString(reqDto.schoolTeacherPhoneNumber()) ||
-                        isBlankString(reqDto.schoolName()) ||
-                        isBlankString(reqDto.schoolAddress())
-                )
-        ) {
-            throw new ExpectedException("중학교 졸업예정인 지원자는 현재 재학 중인 중학교 정보를 필수로 입력해야 합니다.", HttpStatus.BAD_REQUEST);
-        }
-    }
-
-    private boolean isBlankString(String target) {
-        return target == null || target.isBlank();
     }
 
     private List<Integer> validationGeneralAchievement(List<Integer> achievements)  {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -26,8 +26,8 @@ import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.util.List;
 
-import static team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType.*;
 import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.*;
+import static team.themoment.hellogsmv3.domain.oneseo.service.OneseoService.isValidMiddleSchoolInfo;
 
 @Service
 @RequiredArgsConstructor
@@ -66,23 +66,6 @@ public class CreateOneseoService {
                 oneseoPrivacyDetailResDto,
                 middleSchoolAchievementResDto
         );
-    }
-
-    private void isValidMiddleSchoolInfo(OneseoReqDto reqDto) {
-        if (
-                reqDto.graduationType().equals(CANDIDATE) && (
-                        isBlankString(reqDto.schoolTeacherName()) ||
-                                isBlankString(reqDto.schoolTeacherPhoneNumber()) ||
-                                isBlankString(reqDto.schoolName()) ||
-                                isBlankString(reqDto.schoolAddress())
-                )
-        ) {
-            throw new ExpectedException("중학교 졸업예정인 지원자는 현재 재학 중인 중학교 정보를 필수로 입력해야 합니다.", HttpStatus.BAD_REQUEST);
-        }
-    }
-
-    private boolean isBlankString(String target) {
-        return target == null || target.isBlank();
     }
 
     private void assignSubmitCode(Oneseo oneseo) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -25,6 +25,8 @@ import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.util.List;
 
+import static team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType.CANDIDATE;
+
 @Service
 @RequiredArgsConstructor
 public class ModifyOneseoService {
@@ -41,6 +43,9 @@ public class ModifyOneseoService {
     @Transactional
     @CachePut(value = OneseoService.ONESEO_CACHE_VALUE, key = "#memberId")
     public FoundOneseoResDto execute(OneseoReqDto reqDto, Long memberId) {
+
+        isValidMiddleSchoolInfo(reqDto);
+
         Member currentMember = memberService.findByIdOrThrow(memberId);
         Oneseo oneseo = oneseoService.findByMemberOrThrow(currentMember);
 
@@ -66,6 +71,23 @@ public class ModifyOneseoService {
                 oneseoPrivacyDetailResDto,
                 middleSchoolAchievementResDto
         );
+    }
+
+    private void isValidMiddleSchoolInfo(OneseoReqDto reqDto) {
+        if (
+                reqDto.graduationType().equals(CANDIDATE) && (
+                        isBlankString(reqDto.schoolTeacherName()) ||
+                                isBlankString(reqDto.schoolTeacherPhoneNumber()) ||
+                                isBlankString(reqDto.schoolName()) ||
+                                isBlankString(reqDto.schoolAddress())
+                )
+        ) {
+            throw new ExpectedException("중학교 졸업예정인 지원자는 현재 재학 중인 중학교 정보를 필수로 입력해야 합니다.", HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private boolean isBlankString(String target) {
+        return target == null || target.isBlank();
     }
 
     private void isBeforeFirstTest(Oneseo oneseo) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -25,7 +25,7 @@ import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.util.List;
 
-import static team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType.CANDIDATE;
+import static team.themoment.hellogsmv3.domain.oneseo.service.OneseoService.isValidMiddleSchoolInfo;
 
 @Service
 @RequiredArgsConstructor
@@ -71,23 +71,6 @@ public class ModifyOneseoService {
                 oneseoPrivacyDetailResDto,
                 middleSchoolAchievementResDto
         );
-    }
-
-    private void isValidMiddleSchoolInfo(OneseoReqDto reqDto) {
-        if (
-                reqDto.graduationType().equals(CANDIDATE) && (
-                        isBlankString(reqDto.schoolTeacherName()) ||
-                                isBlankString(reqDto.schoolTeacherPhoneNumber()) ||
-                                isBlankString(reqDto.schoolName()) ||
-                                isBlankString(reqDto.schoolAddress())
-                )
-        ) {
-            throw new ExpectedException("중학교 졸업예정인 지원자는 현재 재학 중인 중학교 정보를 필수로 입력해야 합니다.", HttpStatus.BAD_REQUEST);
-        }
-    }
-
-    private boolean isBlankString(String target) {
-        return target == null || target.isBlank();
     }
 
     private void isBeforeFirstTest(Oneseo oneseo) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
@@ -4,11 +4,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.util.List;
+
+import static team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType.CANDIDATE;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +29,23 @@ public class OneseoService {
         int totalAttendanceDays = attendanceDays.stream().mapToInt(Integer::intValue).sum();
 
         return totalAbsentDays + (totalAttendanceDays / 3);
+    }
+
+    public static void isValidMiddleSchoolInfo(OneseoReqDto reqDto) {
+        if (
+                reqDto.graduationType().equals(CANDIDATE) && (
+                        isBlankString(reqDto.schoolTeacherName()) ||
+                        isBlankString(reqDto.schoolTeacherPhoneNumber()) ||
+                        isBlankString(reqDto.schoolName()) ||
+                        isBlankString(reqDto.schoolAddress())
+                )
+        ) {
+            throw new ExpectedException("중학교 졸업예정인 지원자는 현재 재학 중인 중학교 정보를 필수로 입력해야 합니다.", HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private static boolean isBlankString(String target) {
+        return target == null || target.isBlank();
     }
 
     public Oneseo findByMemberOrThrow(Member member) {


### PR DESCRIPTION
## 개요

졸업자, 검정고시 지원자는 중학교 관련 정보들을 받지 않도록 변경하였습니다.

## 본문

- 졸업자, 검정고시 지원자는 중학교 이름, 중학교 위치, 담임선생님 성함, 담임선생님 전화번호 정보를 원서 생성, 수정시 받지 않도록 변경하였습니다. (nullable)
- 변경에 추가로 중학교 졸업예정인 지원자는 위의 정보를 입력하지 않았을때 원서 생성, 수정을 막는 validation 메서드를 만들었습니다.