### PR TITLE
[oneseo] 원서 조회 dto 스펙에 성적 환산 값 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -130,7 +130,7 @@ public class OneseoController {
 
     @Operation(summary = "모의 성적 계산", description = "성적 점수를 입력받아 모의 성적 환산값을 반환합니다.")
     @PostMapping("/calculate-mock-score")
-    public MockScoreResDto calcMockScore(
+    public CalculatedScoreResDto calcMockScore(
             @RequestBody MiddleSchoolAchievementReqDto dto,
             @RequestParam("graduationType") GraduationType graduationType
     ) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/CalculatedScoreResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/CalculatedScoreResDto.java
@@ -6,8 +6,7 @@ import lombok.Builder;
 import java.math.BigDecimal;
 
 @Builder
-public record MockScoreResDto(
-
+public record CalculatedScoreResDto(
 		@JsonInclude(JsonInclude.Include.NON_NULL)
 		BigDecimal generalSubjectsScore,
 		@JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/FoundOneseoResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/FoundOneseoResDto.java
@@ -14,6 +14,8 @@ public record FoundOneseoResDto(
         OneseoPrivacyDetailResDto privacyDetail,
         MiddleSchoolAchievementResDto middleSchoolAchievement,
         @JsonInclude(JsonInclude.Include.NON_NULL)
+        CalculatedScoreResDto calculatedScoreResDto,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
         Integer step
 ) {
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGedService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGedService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
-import team.themoment.hellogsmv3.domain.oneseo.dto.response.MockScoreResDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.CalculatedScoreResDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestFactorsDetailRepository;
@@ -23,7 +23,7 @@ public class CalculateGedService {
     private final EntranceTestResultRepository entranceTestResultRepository;
     private final EntranceTestFactorsDetailRepository entranceTestFactorsDetailRepository;
 
-    public MockScoreResDto execute(MiddleSchoolAchievementReqDto dto, Oneseo oneseo, GraduationType graduationType) {
+    public CalculatedScoreResDto execute(MiddleSchoolAchievementReqDto dto, Oneseo oneseo, GraduationType graduationType) {
 
         if (!graduationType.equals(GED))
             throw new IllegalArgumentException("올바르지 않은 graduationType입니다.");
@@ -82,16 +82,14 @@ public class CalculateGedService {
                 entranceTestFactorsDetailRepository.save(findEntranceTestFactorsDetail);
                 entranceTestResultRepository.save(findEntranceTestResult);
             }
-
-            return null;
-        } else {
-            return MockScoreResDto.builder()
-                    .totalSubjectsScore(gedTotalSubjectsScore)
-                    .attendanceScore(gedAttendanceScore)
-                    .volunteerScore(gedVolunteerScore)
-                    .totalScore(totalScore)
-                    .build();
         }
+
+        return CalculatedScoreResDto.builder()
+                .totalSubjectsScore(gedTotalSubjectsScore)
+                .attendanceScore(gedAttendanceScore)
+                .volunteerScore(gedVolunteerScore)
+                .totalScore(totalScore)
+                .build();
     }
 
     private static BigDecimal calcGedAvgScore(BigDecimal gedTotalScore, BigDecimal gedMaxScore) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
@@ -3,7 +3,7 @@ package team.themoment.hellogsmv3.domain.oneseo.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
-import team.themoment.hellogsmv3.domain.oneseo.dto.response.MockScoreResDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.CalculatedScoreResDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestFactorsDetailRepository;
@@ -30,7 +30,7 @@ public class CalculateGradeService {
     private BigDecimal score3_1 = BigDecimal.ZERO;
     private BigDecimal score3_2 = BigDecimal.ZERO;
 
-    public MockScoreResDto execute(MiddleSchoolAchievementReqDto dto, Oneseo oneseo, GraduationType graduationType) {
+    public CalculatedScoreResDto execute(MiddleSchoolAchievementReqDto dto, Oneseo oneseo, GraduationType graduationType) {
 
         if (!graduationType.equals(CANDIDATE) && !graduationType.equals(GRADUATE))
             throw new IllegalArgumentException("올바르지 않은 graduationType입니다.");
@@ -102,17 +102,15 @@ public class CalculateGradeService {
                 entranceTestFactorsDetailRepository.save(findEntranceTestFactorsDetail);
                 entranceTestResultRepository.save(findEntranceTestResult);
             }
-
-            return null;
-        } else {
-            return MockScoreResDto.builder()
-                    .generalSubjectsScore(generalSubjectsScore)
-                    .artsPhysicalSubjectsScore(artsPhysicalSubjectsScore)
-                    .attendanceScore(attendanceScore)
-                    .volunteerScore(volunteerScore)
-                    .totalScore(totalScore)
-                    .build();
         }
+
+        return CalculatedScoreResDto.builder()
+                .generalSubjectsScore(generalSubjectsScore)
+                .artsPhysicalSubjectsScore(artsPhysicalSubjectsScore)
+                .attendanceScore(attendanceScore)
+                .volunteerScore(volunteerScore)
+                .totalScore(totalScore)
+                .build();
     }
 
     private BigDecimal calcGeneralSubjectsScore(MiddleSchoolAchievementReqDto dto, GraduationType graduationType, String liberalSystem, String freeSemester) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateMockScoreService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateMockScoreService.java
@@ -3,7 +3,7 @@ package team.themoment.hellogsmv3.domain.oneseo.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
-import team.themoment.hellogsmv3.domain.oneseo.dto.response.MockScoreResDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.CalculatedScoreResDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 
 @Service
@@ -13,7 +13,7 @@ public class CalculateMockScoreService {
     private final CalculateGradeService calculateGradeService;
     private final CalculateGedService calculateGedService;
 
-    public MockScoreResDto execute(MiddleSchoolAchievementReqDto dto, GraduationType graduationType) {
+    public CalculatedScoreResDto execute(MiddleSchoolAchievementReqDto dto, GraduationType graduationType) {
         return switch (graduationType) {
             case CANDIDATE, GRADUATE -> calculateGradeService.execute(dto, null, graduationType);
             case GED -> calculateGedService.execute(dto, null, graduationType);

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -10,10 +10,7 @@ import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
-import team.themoment.hellogsmv3.domain.oneseo.dto.response.DesiredMajorsResDto;
-import team.themoment.hellogsmv3.domain.oneseo.dto.response.FoundOneseoResDto;
-import team.themoment.hellogsmv3.domain.oneseo.dto.response.MiddleSchoolAchievementResDto;
-import team.themoment.hellogsmv3.domain.oneseo.dto.response.OneseoPrivacyDetailResDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.MiddleSchoolAchievement;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.OneseoPrivacyDetail;
@@ -53,14 +50,15 @@ public class CreateOneseoService {
         assignSubmitCode(oneseo);
         saveEntities(oneseo, oneseoPrivacyDetail, middleSchoolAchievement);
 
-        calculateMiddleSchoolAchievement(oneseoPrivacyDetail.getGraduationType(), middleSchoolAchievement, oneseo);
+        CalculatedScoreResDto calculatedScoreResDto = calculateMiddleSchoolAchievement(oneseoPrivacyDetail.getGraduationType(), middleSchoolAchievement, oneseo);
 
         OneseoPrivacyDetailResDto oneseoPrivacyDetailResDto = buildOneseoPrivacyDetailResDto(currentMember, oneseoPrivacyDetail);
         MiddleSchoolAchievementResDto middleSchoolAchievementResDto = buildMiddleSchoolAchievementResDto(middleSchoolAchievement);
         return buildOneseoResDto(
                 oneseo,
                 oneseoPrivacyDetailResDto,
-                middleSchoolAchievementResDto
+                middleSchoolAchievementResDto,
+                calculatedScoreResDto
         );
     }
 
@@ -135,7 +133,8 @@ public class CreateOneseoService {
     private FoundOneseoResDto buildOneseoResDto(
             Oneseo oneseo,
             OneseoPrivacyDetailResDto oneseoPrivacyDetailResDto,
-            MiddleSchoolAchievementResDto middleSchoolAchievementResDto
+            MiddleSchoolAchievementResDto middleSchoolAchievementResDto,
+            CalculatedScoreResDto calculatedScoreResDto
     ) {
         DesiredMajors desiredMajors = oneseo.getDesiredMajors();
 
@@ -150,10 +149,11 @@ public class CreateOneseoService {
                         .build())
                 .privacyDetail(oneseoPrivacyDetailResDto)
                 .middleSchoolAchievement(middleSchoolAchievementResDto)
+                .calculatedScoreResDto(calculatedScoreResDto)
                 .build();
     }
 
-    private void calculateMiddleSchoolAchievement(GraduationType graduationType, MiddleSchoolAchievement middleSchoolAchievement, Oneseo oneseo) {
+    private CalculatedScoreResDto calculateMiddleSchoolAchievement(GraduationType graduationType, MiddleSchoolAchievement middleSchoolAchievement, Oneseo oneseo) {
         MiddleSchoolAchievementReqDto data = MiddleSchoolAchievementReqDto.builder()
                 .achievement1_2(middleSchoolAchievement.getAchievement1_2())
                 .achievement2_1(middleSchoolAchievement.getAchievement2_1())
@@ -169,10 +169,10 @@ public class CreateOneseoService {
                 .gedTotalScore(middleSchoolAchievement.getGedTotalScore())
                 .build();
 
-        switch (graduationType) {
+        return switch (graduationType) {
             case CANDIDATE, GRADUATE -> calculateGradeService.execute(data, oneseo, graduationType);
             case GED -> calculateGedService.execute(data, oneseo, graduationType);
-        }
+        };
     }
 
     private void saveEntities(Oneseo oneseo, OneseoPrivacyDetail oneseoPrivacyDetail, MiddleSchoolAchievement middleSchoolAchievement) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -9,10 +9,7 @@ import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
-import team.themoment.hellogsmv3.domain.oneseo.dto.response.DesiredMajorsResDto;
-import team.themoment.hellogsmv3.domain.oneseo.dto.response.FoundOneseoResDto;
-import team.themoment.hellogsmv3.domain.oneseo.dto.response.MiddleSchoolAchievementResDto;
-import team.themoment.hellogsmv3.domain.oneseo.dto.response.OneseoPrivacyDetailResDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
@@ -57,14 +54,15 @@ public class ModifyOneseoService {
 
         saveModifiedEntities(modifiedOneseo, modifiedOneseoPrivacyDetail, modifiedMiddleSchoolAchievement);
 
-        calculateMiddleSchoolAchievement(oneseoPrivacyDetail.getGraduationType(), middleSchoolAchievement, oneseo);
+        CalculatedScoreResDto calculatedScoreResDto = calculateMiddleSchoolAchievement(oneseoPrivacyDetail.getGraduationType(), middleSchoolAchievement, oneseo);
 
         OneseoPrivacyDetailResDto oneseoPrivacyDetailResDto = buildOneseoPrivacyDetailResDto(currentMember, oneseoPrivacyDetail);
         MiddleSchoolAchievementResDto middleSchoolAchievementResDto = buildMiddleSchoolAchievementResDto(middleSchoolAchievement);
         return buildOneseoResDto(
                 oneseo,
                 oneseoPrivacyDetailResDto,
-                middleSchoolAchievementResDto
+                middleSchoolAchievementResDto,
+                calculatedScoreResDto
         );
     }
 
@@ -130,7 +128,8 @@ public class ModifyOneseoService {
     private FoundOneseoResDto buildOneseoResDto(
             Oneseo oneseo,
             OneseoPrivacyDetailResDto oneseoPrivacyDetailResDto,
-            MiddleSchoolAchievementResDto middleSchoolAchievementResDto
+            MiddleSchoolAchievementResDto middleSchoolAchievementResDto,
+            CalculatedScoreResDto calculatedScoreResDto
     ) {
         DesiredMajors desiredMajors = oneseo.getDesiredMajors();
 
@@ -145,10 +144,11 @@ public class ModifyOneseoService {
                         .build())
                 .privacyDetail(oneseoPrivacyDetailResDto)
                 .middleSchoolAchievement(middleSchoolAchievementResDto)
+                .calculatedScoreResDto(calculatedScoreResDto)
                 .build();
     }
 
-    private void calculateMiddleSchoolAchievement(GraduationType graduationType, MiddleSchoolAchievement middleSchoolAchievement, Oneseo oneseo) {
+    private CalculatedScoreResDto calculateMiddleSchoolAchievement(GraduationType graduationType, MiddleSchoolAchievement middleSchoolAchievement, Oneseo oneseo) {
         MiddleSchoolAchievementReqDto data = MiddleSchoolAchievementReqDto.builder()
                 .achievement1_2(middleSchoolAchievement.getAchievement1_2())
                 .achievement2_1(middleSchoolAchievement.getAchievement2_1())
@@ -164,10 +164,10 @@ public class ModifyOneseoService {
                 .gedTotalScore(middleSchoolAchievement.getGedTotalScore())
                 .build();
 
-        switch (graduationType) {
+        return switch (graduationType) {
             case CANDIDATE, GRADUATE -> calculateGradeService.execute(data, oneseo, graduationType);
             case GED -> calculateGedService.execute(data, oneseo, graduationType);
-        }
+        };
     }
 
     private Oneseo buildOneseo(OneseoReqDto reqDto, Oneseo oneseo, Member currentMember) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
@@ -9,7 +9,6 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.response.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
-import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestFactorsDetailRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.MiddleSchoolAchievementRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRepository;
 
@@ -23,7 +22,6 @@ public class QueryOneseoByIdService {
 
     private final OneseoPrivacyDetailRepository oneseoPrivacyDetailRepository;
     private final MiddleSchoolAchievementRepository middleSchoolAchievementRepository;
-    private final EntranceTestFactorsDetailRepository entranceTestFactorsDetailRepository;
     private final MemberService memberService;
     private final OneseoService oneseoService;
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
@@ -8,6 +8,8 @@ import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
+import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestFactorsDetailRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.MiddleSchoolAchievementRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRepository;
 
@@ -21,6 +23,7 @@ public class QueryOneseoByIdService {
 
     private final OneseoPrivacyDetailRepository oneseoPrivacyDetailRepository;
     private final MiddleSchoolAchievementRepository middleSchoolAchievementRepository;
+    private final EntranceTestFactorsDetailRepository entranceTestFactorsDetailRepository;
     private final MemberService memberService;
     private final OneseoService oneseoService;
 
@@ -31,14 +34,39 @@ public class QueryOneseoByIdService {
         OneseoPrivacyDetail oneseoPrivacyDetail = oneseoPrivacyDetailRepository.findByOneseo(oneseo);
         MiddleSchoolAchievement middleSchoolAchievement = middleSchoolAchievementRepository.findByOneseo(oneseo);
 
+        CalculatedScoreResDto calculatedScoreResDto = buildCalculatedScoreResDto(oneseo, oneseoPrivacyDetail.getGraduationType());
+
         OneseoPrivacyDetailResDto oneseoPrivacyDetailResDto = buildOneseoPrivacyDetailResDto(member, oneseoPrivacyDetail);
         MiddleSchoolAchievementResDto middleSchoolAchievementResDto = buildMiddleSchoolAchievementResDto(middleSchoolAchievement);
 
         return buildFoundOneseoResDto(
                 oneseo,
                 oneseoPrivacyDetailResDto,
-                middleSchoolAchievementResDto
+                middleSchoolAchievementResDto,
+                calculatedScoreResDto
         );
+    }
+    private CalculatedScoreResDto buildCalculatedScoreResDto(Oneseo oneseo, GraduationType graduationType) {
+        EntranceTestResult entranceTestResult = oneseo.getEntranceTestResult();
+        EntranceTestFactorsDetail entranceTestFactorsDetail = entranceTestResult.getEntranceTestFactorsDetail();
+
+        return switch (graduationType) {
+            case CANDIDATE, GRADUATE ->
+                CalculatedScoreResDto.builder()
+                        .generalSubjectsScore(entranceTestFactorsDetail.getGeneralSubjectsScore())
+                        .artsPhysicalSubjectsScore(entranceTestFactorsDetail.getArtsPhysicalSubjectsScore())
+                        .attendanceScore(entranceTestFactorsDetail.getAttendanceScore())
+                        .volunteerScore(entranceTestFactorsDetail.getVolunteerScore())
+                        .totalScore(entranceTestResult.getDocumentEvaluationScore())
+                        .build();
+            case GED ->
+                CalculatedScoreResDto.builder()
+                        .totalSubjectsScore(entranceTestFactorsDetail.getTotalSubjectsScore())
+                        .attendanceScore(entranceTestFactorsDetail.getAttendanceScore())
+                        .volunteerScore(entranceTestFactorsDetail.getVolunteerScore())
+                        .totalScore(entranceTestResult.getDocumentEvaluationScore())
+                        .build();
+        };
     }
 
     private OneseoPrivacyDetailResDto buildOneseoPrivacyDetailResDto(
@@ -96,7 +124,8 @@ public class QueryOneseoByIdService {
     private FoundOneseoResDto buildFoundOneseoResDto(
             Oneseo oneseo,
             OneseoPrivacyDetailResDto oneseoPrivacyDetailResDto,
-            MiddleSchoolAchievementResDto middleSchoolAchievementResDto
+            MiddleSchoolAchievementResDto middleSchoolAchievementResDto,
+            CalculatedScoreResDto calculatedScoreResDto
     ) {
         DesiredMajors desiredMajors = oneseo.getDesiredMajors();
 
@@ -111,6 +140,7 @@ public class QueryOneseoByIdService {
                         .build())
                 .privacyDetail(oneseoPrivacyDetailResDto)
                 .middleSchoolAchievement(middleSchoolAchievementResDto)
+                .calculatedScoreResDto(calculatedScoreResDto)
                 .build();
     }
 }


### PR DESCRIPTION
## 개요

작성한 원서 출력시 지원자의 성적 환산 값들이 필요합니다. 기존에는 해당 값을 fe 단에서 직접 계산하여 사용했는데, 서버 단에서 계산 로직을 가져가는 것이 일관성이 있다고 생각되어 원서 조회 res dto의 스펙에 성적 환산 값을 추가하였습니다.

## 본문

- 모의성적 계산 res dto의 스펙이 원서 조회시 필요한 스펙과 동일하여 해당 res dto객체의 이름을 공통으로 사용할 수 있게 변경 후 재사용 하였습니다. (MockScoreResDto -> CalculatedScoreResDto)