### PR TITLE
[oneseo] 원서 조회 dto 스펙에 개별 교과성적 환산점수 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/CalculatedScoreResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/CalculatedScoreResDto.java
@@ -10,6 +10,8 @@ public record CalculatedScoreResDto(
 		@JsonInclude(JsonInclude.Include.NON_NULL)
 		BigDecimal generalSubjectsScore,
 		@JsonInclude(JsonInclude.Include.NON_NULL)
+		GeneralSubjectsScoreDetailResDto generalSubjectsScoreDetail,
+		@JsonInclude(JsonInclude.Include.NON_NULL)
 		BigDecimal artsPhysicalSubjectsScore,
 		@JsonInclude(JsonInclude.Include.NON_NULL)
 		BigDecimal totalSubjectsScore,

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/GeneralSubjectsScoreDetailResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/GeneralSubjectsScoreDetailResDto.java
@@ -1,0 +1,17 @@
+package team.themoment.hellogsmv3.domain.oneseo.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record GeneralSubjectsScoreDetailResDto(
+        BigDecimal score1_2,
+        BigDecimal score2_1,
+        BigDecimal score2_2,
+        BigDecimal score3_1,
+        BigDecimal score3_2
+) {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.CalculatedScoreResDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.response.GeneralSubjectsScoreDetailResDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestFactorsDetailRepository;
@@ -102,6 +103,23 @@ public class CalculateGradeService {
                 entranceTestFactorsDetailRepository.save(findEntranceTestFactorsDetail);
                 entranceTestResultRepository.save(findEntranceTestResult);
             }
+
+            return CalculatedScoreResDto.builder()
+                    .generalSubjectsScore(generalSubjectsScore)
+                    .artsPhysicalSubjectsScore(artsPhysicalSubjectsScore)
+                    .attendanceScore(attendanceScore)
+                    .volunteerScore(volunteerScore)
+                    .totalScore(totalScore)
+                    .generalSubjectsScoreDetail(
+                            GeneralSubjectsScoreDetailResDto.builder()
+                                    .score1_2(score1_2)
+                                    .score2_1(score2_1)
+                                    .score2_2(score2_2)
+                                    .score3_1(score3_1)
+                                    .score3_2(score3_2)
+                                    .build()
+                    )
+                    .build();
         }
 
         return CalculatedScoreResDto.builder()


### PR DESCRIPTION
## 개요

- 지원자의 원서 출력시 개별 교과성적 환산점수가 필요해 원서 조회 res dto의 CalculatedScoreResDto 필드에 개별 교과성적 환산점수 필드를 추가하였습니다.
<img width="356" alt="스크린샷 2024-09-08 오후 6 39 30" src="https://github.com/user-attachments/assets/23757bc1-8c2f-4841-9a87-4e2d569ca2d6">
