### PR TITLE
[oneseo] 원서 조회시 교과성적 dto 추가되도록 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
@@ -56,6 +56,15 @@ public class QueryOneseoByIdService {
                         .attendanceScore(entranceTestFactorsDetail.getAttendanceScore())
                         .volunteerScore(entranceTestFactorsDetail.getVolunteerScore())
                         .totalScore(entranceTestResult.getDocumentEvaluationScore())
+                        .generalSubjectsScoreDetail(
+                                GeneralSubjectsScoreDetailResDto.builder()
+                                        .score1_2(entranceTestFactorsDetail.getScore1_2())
+                                        .score2_1(entranceTestFactorsDetail.getScore2_1())
+                                        .score2_2(entranceTestFactorsDetail.getScore2_2())
+                                        .score3_1(entranceTestFactorsDetail.getScore3_1())
+                                        .score3_2(entranceTestFactorsDetail.getScore3_2())
+                                        .build()
+                        )
                         .build();
             case GED ->
                 CalculatedScoreResDto.builder()


### PR DESCRIPTION
## 개요

#160 해당 PR에서 반영한 변경 사항에서 원서 조회시 개별 교과성적 환산점수 dto를 주입해주는 부분을 누락하여 수정하였습니다.