### PR TITLE
[global] date response api 구현

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/common/date/controller/DateController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/date/controller/DateController.java
@@ -1,0 +1,21 @@
+package team.themoment.hellogsmv3.domain.common.date.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import team.themoment.hellogsmv3.domain.common.date.dto.DateResDto;
+import team.themoment.hellogsmv3.domain.common.date.service.QueryDateService;
+
+@RestController
+@RequiredArgsConstructor
+public class DateController {
+
+    private final QueryDateService queryDateService;
+
+    @Operation(summary = "일정 조회", description = "FE에서 페이지 트리거가 되는 date를 반환합니다.")
+    @GetMapping("/date")
+    public DateResDto getDate() {
+        return queryDateService.execute();
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/date/dto/DateResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/date/dto/DateResDto.java
@@ -1,0 +1,29 @@
+package team.themoment.hellogsmv3.domain.common.date.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record DateResDto(
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime oneseoSubmissionStart,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime oneseoSubmissionEnd,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime firstResultsAnnouncement,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime jobFitAssessment,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime inDepthInterview,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime finalResultsAnnouncement
+) {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/date/service/QueryDateService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/date/service/QueryDateService.java
@@ -16,8 +16,8 @@ public class QueryDateService {
                 .oneseoSubmissionStart(scheduleEnv.oneseoSubmissionStart())
                 .oneseoSubmissionEnd(scheduleEnv.oneseoSubmissionEnd())
                 .firstResultsAnnouncement(scheduleEnv.firstResultsAnnouncement())
-                .jobFitAssessment(scheduleEnv.jobFitAssessment())
-                .inDepthInterview(scheduleEnv.inDepthInterview())
+                .jobFitAssessment(scheduleEnv.aptitudeEvaluation())
+                .inDepthInterview(scheduleEnv.interview())
                 .finalResultsAnnouncement(scheduleEnv.finalResultsAnnouncement())
                 .build();
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/date/service/QueryDateService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/date/service/QueryDateService.java
@@ -1,0 +1,24 @@
+package team.themoment.hellogsmv3.domain.common.date.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.themoment.hellogsmv3.domain.common.date.dto.DateResDto;
+import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
+
+@Service
+@RequiredArgsConstructor
+public class QueryDateService {
+
+    private final ScheduleEnvironment scheduleEnv;
+
+    public DateResDto execute() {
+        return DateResDto.builder()
+                .oneseoSubmissionStart(scheduleEnv.oneseoSubmissionStart())
+                .oneseoSubmissionEnd(scheduleEnv.oneseoSubmissionEnd())
+                .firstResultsAnnouncement(scheduleEnv.firstResultsAnnouncement())
+                .jobFitAssessment(scheduleEnv.jobFitAssessment())
+                .inDepthInterview(scheduleEnv.inDepthInterview())
+                .finalResultsAnnouncement(scheduleEnv.finalResultsAnnouncement())
+                .build();
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -37,15 +37,15 @@ public class SecurityConfig {
 
     @Bean
     public Filter timeBasedFilter() {
-        LocalDateTime startReception = scheduleEnv.startReceptionDate();
-        LocalDateTime endReception = scheduleEnv.endReceptionDate();
+        LocalDateTime oneseoSubmissionStart = scheduleEnv.oneseoSubmissionStart();
+        LocalDateTime oneseoSubmissionEnd = scheduleEnv.oneseoSubmissionEnd();
 
         return new TimeBasedFilter()
-                .addFilter(HttpMethod.POST, "/oneseo/v3/temp-storage", startReception, endReception)
-                .addFilter(HttpMethod.POST, "/oneseo/v3/oneseo/me", startReception, endReception)
-                .addFilter(HttpMethod.PUT, "/oneseo/v3/oneseo/{memberId}", startReception, endReception)
-                .addFilter(HttpMethod.GET, "/oneseo/v3/oneseo/me", startReception, endReception)
-                .addFilter(HttpMethod.POST, "/oneseo/v3/image", startReception, endReception);
+                .addFilter(HttpMethod.POST, "/oneseo/v3/temp-storage", oneseoSubmissionStart, oneseoSubmissionEnd)
+                .addFilter(HttpMethod.POST, "/oneseo/v3/oneseo/me", oneseoSubmissionStart, oneseoSubmissionEnd)
+                .addFilter(HttpMethod.PUT, "/oneseo/v3/oneseo/{memberId}", oneseoSubmissionStart, oneseoSubmissionEnd)
+                .addFilter(HttpMethod.GET, "/oneseo/v3/oneseo/me", oneseoSubmissionStart, oneseoSubmissionEnd)
+                .addFilter(HttpMethod.POST, "/oneseo/v3/image", oneseoSubmissionStart, oneseoSubmissionEnd);
     }
 
     @Configuration

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -283,9 +283,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST, "/oneseo/v3/calculate-mock-score").permitAll()
 
                 // common / get date api
-                .requestMatchers(HttpMethod.GET, "/date").hasAnyAuthority(
-                        Role.ADMIN.name()
-                )
+                .requestMatchers(HttpMethod.GET, "/date").permitAll()
 
                 .anyRequest().permitAll()
         );

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -281,6 +281,12 @@ public class SecurityConfig {
 
                 // mock score calculate
                 .requestMatchers(HttpMethod.POST, "/oneseo/v3/calculate-mock-score").permitAll()
+
+                // common / get date api
+                .requestMatchers(HttpMethod.GET, "/date").hasAnyAuthority(
+                        Role.ADMIN.name()
+                )
+
                 .anyRequest().permitAll()
         );
     }

--- a/src/main/java/team/themoment/hellogsmv3/global/security/data/ScheduleEnvironment.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/data/ScheduleEnvironment.java
@@ -9,8 +9,8 @@ public record ScheduleEnvironment(
     LocalDateTime oneseoSubmissionStart,
     LocalDateTime oneseoSubmissionEnd,
     LocalDateTime firstResultsAnnouncement,
-    LocalDateTime jobFitAssessment,
-    LocalDateTime inDepthInterview,
+    LocalDateTime aptitudeEvaluation,
+    LocalDateTime interview,
     LocalDateTime finalResultsAnnouncement
 ) {
 }

--- a/src/main/java/team/themoment/hellogsmv3/global/security/data/ScheduleEnvironment.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/data/ScheduleEnvironment.java
@@ -7,6 +7,10 @@ import java.time.LocalDateTime;
 @ConfigurationProperties(prefix = "schedule")
 public record ScheduleEnvironment(
     LocalDateTime oneseoSubmissionStart,
-    LocalDateTime oneseoSubmissionEnd
+    LocalDateTime oneseoSubmissionEnd,
+    LocalDateTime firstResultsAnnouncement,
+    LocalDateTime jobFitAssessment,
+    LocalDateTime inDepthInterview,
+    LocalDateTime finalResultsAnnouncement
 ) {
 }

--- a/src/main/java/team/themoment/hellogsmv3/global/security/data/ScheduleEnvironment.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/data/ScheduleEnvironment.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 
 @ConfigurationProperties(prefix = "schedule")
 public record ScheduleEnvironment(
-    LocalDateTime startReceptionDate,
-    LocalDateTime endReceptionDate
+    LocalDateTime oneseoSubmissionStart,
+    LocalDateTime oneseoSubmissionEnd
 ) {
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -97,8 +97,8 @@ schedule:
   oneseoSubmissionStart: ${ONESEO_SUBMISSION_START}
   oneseoSubmissionEnd: ${ONESEO_SUBMISSION_END}
   firstResultsAnnouncement: ${FIRST_RESULTS_ANNOUNCEMENT}
-  jobFitAssessment: ${JOB_FIT_ASSESSMENT}
-  inDepthInterview: ${IN_DEPTH_INTERVIEW}
+  aptitudeEvaluation: ${APTITUDE_EVALUATION}
+  interview: ${INTERVIEW}
   finalResultsAnnouncement: ${FINAL_RESULTS_ANNOUNCEMENT}
 
 springdoc:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -96,6 +96,10 @@ auth:
 schedule:
   oneseoSubmissionStart: ${ONESEO_SUBMISSION_START}
   oneseoSubmissionEnd: ${ONESEO_SUBMISSION_END}
+  firstResultsAnnouncement: ${FIRST_RESULTS_ANNOUNCEMENT}
+  jobFitAssessment: ${JOB_FIT_ASSESSMENT}
+  inDepthInterview: ${IN_DEPTH_INTERVIEW}
+  finalResultsAnnouncement: ${FINAL_RESULTS_ANNOUNCEMENT}
 
 springdoc:
   api-docs:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -94,8 +94,8 @@ auth:
       - '*'
 
 schedule:
-  startReceptionDate: ${START_RECEPTION_DATE}
-  endReceptionDate: ${END_RECEPTION_DATE}
+  oneseoSubmissionStart: ${ONESEO_SUBMISSION_START}
+  oneseoSubmissionEnd: ${ONESEO_SUBMISSION_END}
 
 springdoc:
   api-docs:


### PR DESCRIPTION
## 개요

FE에서 버튼or페이지의 트리거가 되는 date response api 구현하였습니다.

## 본문

- `GET /date` 요청을 통해 아래 date를 반환해줍니다.
  - 원서접수 (시작&끝)
  - 1차전형결과발표
  - 최종결과발표
  - 직무적성평가
  - 심층면접

- 기존 원서접수기간을 나타내는 변수 이름을 변경하였습니다. (`ReceptionDate` -> `oneseoSubmission`)
- 기존 패키지에 date를 처리할 적절한 도메인이 없다고 판단하여, common->date 패키지를 생성 후 사용하였습니다.
