### PR TITLE
[oneseo] 성적 계산시 자유학기제 학기가 공백일 시 1-1학기로 계산하도록 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
@@ -195,7 +195,7 @@ public class CalculateGradeService {
 
     private void validSemester(String freeSemester) {
         // "" 공백은 1-1학기로 계산
-        List<String> validSemesterList = List.of("", "1-2", "2-2", "3-1", "3-2");
+        List<String> validSemesterList = List.of("", "1-2", "2-1", "2-2", "3-1", "3-2");
         if (validSemesterList.stream().noneMatch(s -> s.equals(freeSemester)))
             throw new ExpectedException(String.format("%s(은)는 유효한 학기가 아닙니다.", freeSemester), HttpStatus.BAD_REQUEST);
     }


### PR DESCRIPTION
## 개요

성적계산시 자유학기제에 공백을 입력시 요청으로 보낸 모든 학기의 환산값을 더해 교과점수 만점을 초과하는 상황이 발생하여 수정하였습니다.

## 본문
- fe에서 만약 1-1학기가 자유학기제라면 liberalSystem = 자유학기제, freeSemester를 공백으로 요청하기 때문에 이를 수정하였습니다.
- 추가로 유효하지 않은 학기를 요청할 시 예외를 발생시키도록 validSemester 메서드를 추가하였습니다.