### PR TITLE
[oneseo] 원서 수정시에도 접수번호가 변경된 전형에 따라 수정되도록 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -54,6 +54,8 @@ public class ModifyOneseoService {
         saveHistoryIfWantedScreeningChange(reqDto.screening(), oneseo);
 
         Oneseo modifiedOneseo = buildOneseo(reqDto, oneseo, currentMember);
+        oneseoService.assignSubmitCode(modifiedOneseo);
+
         OneseoPrivacyDetail modifiedOneseoPrivacyDetail = buildOneseoPrivacyDetail(reqDto, oneseoPrivacyDetail, oneseo);
         MiddleSchoolAchievement modifiedMiddleSchoolAchievement = buildMiddleSchoolAchievement(reqDto, middleSchoolAchievement, oneseo);
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
@@ -3,6 +3,7 @@ package team.themoment.hellogsmv3.domain.oneseo.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import team.themoment.hellogsmv3.domain.application.type.ScreeningCategory;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
@@ -19,6 +20,22 @@ public class OneseoService {
 
     public static final String ONESEO_CACHE_VALUE = "oneseo";
     private final OneseoRepository oneseoRepository;
+
+    public void assignSubmitCode(Oneseo oneseo) {
+        Integer maxSubmitCodeNumber = oneseoRepository.findMaxSubmitCodeByScreening(oneseo.getWantedScreening());
+        int newSubmitCodeNumber = (maxSubmitCodeNumber != null ? maxSubmitCodeNumber : 0) + 1;
+
+        String submitCode;
+        ScreeningCategory screeningCategory = oneseo.getWantedScreening().getScreeningCategory();
+        switch (screeningCategory) {
+            case GENERAL -> submitCode = "A-" + newSubmitCodeNumber;
+            case SPECIAL -> submitCode = "B-" + newSubmitCodeNumber;
+            case EXTRA -> submitCode = "C-" + newSubmitCodeNumber;
+            default -> throw new IllegalArgumentException("Unexpected value: " + screeningCategory);
+        }
+
+        oneseo.setOneseoSubmitCode(submitCode);
+    }
 
     public static Integer calcAbsentDaysCount(List<Integer> absentDays, List<Integer> attendanceDays) {
         if (absentDays == null || attendanceDays == null) {


### PR DESCRIPTION
## 개요

원서 수정시에 접수번호(submitCode)를 새로 할당하지 않아서 submitCode 필드가 NULL이 되는 문제가 있어 접수번호 할당 메서드를 oneseo 관련 공통 로직 서비스인 OneseoService로 빼서 원서 생성, 수정시 변경되는 전형에 따라 submitCode를 할당하여 저장하도록 변경하였습니다.