### PR TITLE
[oneseo] 잘못된 1-1 자유학기 관련 성적계산 조건식 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
@@ -37,8 +37,8 @@ public class CalculateGradeService {
 
     public CalculatedScoreResDto execute(MiddleSchoolAchievementReqDto dto, Oneseo oneseo, GraduationType graduationType) {
 
-        if (!graduationType.equals(CANDIDATE) && !graduationType.equals(GRADUATE))
-            throw new IllegalArgumentException("올바르지 않은 graduationType입니다.");
+        validationGraduationType(graduationType);
+        validationFreeSemester(dto.liberalSystem(), dto.freeSemester());
 
         String liberalSystem = dto.liberalSystem();
         // freeSemester가 NULL이라면 "" 공백으로 변경, "" 공백이라면 "1-1"로 변경
@@ -138,6 +138,16 @@ public class CalculateGradeService {
                 .volunteerScore(volunteerScore)
                 .totalScore(totalScore)
                 .build();
+    }
+
+    private void validationGraduationType(GraduationType graduationType) {
+        if (!graduationType.equals(CANDIDATE) && !graduationType.equals(GRADUATE))
+            throw new IllegalArgumentException("올바르지 않은 graduationType입니다.");
+    }
+
+    private void validationFreeSemester(String liberalSystem, String freeSemester) {
+        if (liberalSystem.equals("자유학기제") && freeSemester == null)
+            throw new ExpectedException("자유학기가 적용된 학기를 입력해주세요.", HttpStatus.BAD_REQUEST);
     }
 
     private BigDecimal calcGeneralSubjectsScore(MiddleSchoolAchievementReqDto dto, GraduationType graduationType, String liberalSystem, String freeSemester) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
@@ -144,7 +144,7 @@ public class CalculateGradeService {
             case CANDIDATE -> {
                 score1_2 = calcGeneralSubjectsScore(
                         dto.achievement1_2(), BigDecimal.valueOf(
-                                (liberalSystem.equals("자유학년제") || freeSemester.equals("1-2")) ? 0 : 54)
+                                (liberalSystem.equals("자유학년제") || freeSemester.equals("1-2") || freeSemester.equals("1-1")) ? 0 : 54)
                 );
                 score2_1 = calcGeneralSubjectsScore(
                         dto.achievement2_1(), BigDecimal.valueOf(
@@ -153,11 +153,11 @@ public class CalculateGradeService {
                 score2_2 = calcGeneralSubjectsScore(
                         dto.achievement2_2(), BigDecimal.valueOf(
                                 freeSemester.equals("2-2") ? 0 :
-                                        (freeSemester.equals("3-1") || freeSemester.equals("1-1") ? 72 : 54))
+                                        (freeSemester.equals("3-1") ? 72 : 54))
                 );
                 score3_1 = calcGeneralSubjectsScore(
                         dto.achievement3_1(), BigDecimal.valueOf(
-                                (freeSemester.equals("3-1") || freeSemester.equals("1-1")) ? 0 : 72)
+                                (freeSemester.equals("3-1") ? 0 : 72))
                 );
             }
             case GRADUATE -> {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
@@ -156,7 +156,8 @@ public class CalculateGradeService {
                 );
                 score2_2 = calcGeneralSubjectsScore(
                         dto.achievement2_2(), BigDecimal.valueOf(
-                                freeSemester.equals("2-2") ? 0 : (freeSemester.equals("3-1") ? 72 : 54))
+                                freeSemester.equals("2-2") ? 0 :
+                                        (freeSemester.equals("3-1") || freeSemester.equals("1-1") ? 72 : 54))
                 );
                 score3_1 = calcGeneralSubjectsScore(
                         dto.achievement3_1(), BigDecimal.valueOf(

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
@@ -1,7 +1,6 @@
 package team.themoment.hellogsmv3.domain.oneseo.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.MiddleSchoolAchievementReqDto;
@@ -16,7 +15,6 @@ import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -37,8 +35,8 @@ public class CalculateGradeService {
 
     public CalculatedScoreResDto execute(MiddleSchoolAchievementReqDto dto, Oneseo oneseo, GraduationType graduationType) {
 
-        validationGraduationType(graduationType);
-        validationFreeSemester(dto.liberalSystem(), dto.freeSemester());
+        validGraduationType(graduationType);
+        validFreeSemester(dto.liberalSystem(), dto.freeSemester());
 
         String liberalSystem = dto.liberalSystem();
         // freeSemester가 NULL이라면 "" 공백으로 변경, "" 공백이라면 "1-1"로 변경
@@ -142,8 +140,6 @@ public class CalculateGradeService {
 
     private BigDecimal calcGeneralSubjectsScore(MiddleSchoolAchievementReqDto dto, GraduationType graduationType, String liberalSystem, String freeSemester) {
 
-        validSemester(freeSemester);
-
         switch (graduationType) {
             case CANDIDATE -> {
                 score1_2 = calcGeneralSubjectsScore(
@@ -197,12 +193,6 @@ public class CalculateGradeService {
                         score3_2)
                 .reduce(BigDecimal.ZERO, BigDecimal::add)
                 .setScale(3, RoundingMode.HALF_UP);
-    }
-
-    private void validSemester(String freeSemester) {
-        List<String> validSemesterList = List.of("", "1-1", "1-2", "2-1", "2-2", "3-1", "3-2");
-        if (validSemesterList.stream().noneMatch(s -> s.equals(freeSemester)))
-            throw new ExpectedException(String.format("%s(은)는 유효한 학기가 아닙니다.", freeSemester), HttpStatus.BAD_REQUEST);
     }
 
     private BigDecimal calcGeneralSubjectsScore(List<Integer> achievements, BigDecimal maxPoint) {
@@ -304,13 +294,20 @@ public class CalculateGradeService {
         });
     }
 
-    private void validationGraduationType(GraduationType graduationType) {
+    private void validGraduationType(GraduationType graduationType) {
         if (!graduationType.equals(CANDIDATE) && !graduationType.equals(GRADUATE))
             throw new IllegalArgumentException("올바르지 않은 graduationType입니다.");
     }
 
-    private void validationFreeSemester(String liberalSystem, String freeSemester) {
+    private void validFreeSemester(String liberalSystem, String freeSemester) {
+        List<String> validSemesterList = List.of("", "1-1", "1-2", "2-1", "2-2", "3-1", "3-2");
+
+        // 자유학기제 && 자유학기제가 적용된 학기를 입력하지 않았다면 예외 발생
         if (liberalSystem.equals("자유학기제") && freeSemester == null)
             throw new ExpectedException("자유학기가 적용된 학기를 입력해주세요.", HttpStatus.BAD_REQUEST);
+
+        // 자유학기제 && 올바른 학기를 입력하지 않았다면 예외 발생
+        if (liberalSystem.equals("자유학기제") && validSemesterList.stream().noneMatch(s -> s.equals(freeSemester)))
+            throw new ExpectedException(String.format("%s(은)는 유효한 학기가 아닙니다.", freeSemester), HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
@@ -140,16 +140,6 @@ public class CalculateGradeService {
                 .build();
     }
 
-    private void validationGraduationType(GraduationType graduationType) {
-        if (!graduationType.equals(CANDIDATE) && !graduationType.equals(GRADUATE))
-            throw new IllegalArgumentException("올바르지 않은 graduationType입니다.");
-    }
-
-    private void validationFreeSemester(String liberalSystem, String freeSemester) {
-        if (liberalSystem.equals("자유학기제") && freeSemester == null)
-            throw new ExpectedException("자유학기가 적용된 학기를 입력해주세요.", HttpStatus.BAD_REQUEST);
-    }
-
     private BigDecimal calcGeneralSubjectsScore(MiddleSchoolAchievementReqDto dto, GraduationType graduationType, String liberalSystem, String freeSemester) {
 
         validSemester(freeSemester);
@@ -314,4 +304,13 @@ public class CalculateGradeService {
         });
     }
 
+    private void validationGraduationType(GraduationType graduationType) {
+        if (!graduationType.equals(CANDIDATE) && !graduationType.equals(GRADUATE))
+            throw new IllegalArgumentException("올바르지 않은 graduationType입니다.");
+    }
+
+    private void validationFreeSemester(String liberalSystem, String freeSemester) {
+        if (liberalSystem.equals("자유학기제") && freeSemester == null)
+            throw new ExpectedException("자유학기가 적용된 학기를 입력해주세요.", HttpStatus.BAD_REQUEST);
+    }
 }


### PR DESCRIPTION
## 개요

1-1학기가 자유학기제인 졸업예정자의 학기별 환산값 조건식에 누락된 부분을 수정하였습니다.

## 본문

이해를 돕기 위해 아래 캡쳐를 참고해주시면 좋을것 같습니다.

<img width="508" alt="수정전" src="https://github.com/user-attachments/assets/23dc0c68-267a-4a33-bf78-cb94ceba4190">

> 수정전, 1-1학기가 자유학기라면 1-2, 2-1, 2-2 학기가 각각 54, 54, 72점이 만점으로 들어가야하지만 54, 54, 54로 잘못 계산되는 것을 확인할 수 있습니다.

<img width="508" alt="수정후" src="https://github.com/user-attachments/assets/076bb722-49ab-4159-ba4b-676e66e84430">

> 수정후, 2-2학기에 누락된 조건식을 추가하여 정상적으로 54, 54, 72로 계산되는것을 확인할 수 있습니다.

<br />

- 자유학기 관련 valid 메서드를 추가하여 비정상적인 상황을 방지하였습니다. 80b3383a0437f7643fcddbfcf9042439049ac68c