### PR TITLE
[member] 전형 결과 조회 api 스펙에 배정 학과 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/member/dto/response/FoundMemberTestResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/dto/response/FoundMemberTestResDto.java
@@ -1,11 +1,13 @@
 package team.themoment.hellogsmv3.domain.member.dto.response;
 
 import lombok.Builder;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 
 @Builder
 public record FoundMemberTestResDto(
         YesNo firstTestPassYn,
-        YesNo secondTestPassYn
+        YesNo secondTestPassYn,
+        Major decidedMajor
 ) {
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryTestResultService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryTestResultService.java
@@ -23,7 +23,8 @@ public class QueryTestResultService {
 
         return new FoundMemberTestResDto(
                 entranceTestResult.getFirstTestPassYn(),
-                entranceTestResult.getSecondTestPassYn()
+                entranceTestResult.getSecondTestPassYn(),
+                oneseo.getDecidedMajor()
         );
     }
 }


### PR DESCRIPTION
## 개요

최종결과 발표 시 배정학과를 표시하기 위해 전형 결과 조회 api response 필드에 배정학과를 추가하였습니다.