### PR TITLE
[oneseo] String list 컨버터 null check 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/global/common/converter/StringListConverter.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/common/converter/StringListConverter.java
@@ -24,6 +24,7 @@ public class StringListConverter implements AttributeConverter<List<String>, Str
     @Override
     public List<String> convertToEntityAttribute(String data) {
         try {
+            if (data == null) return null;
             return mapper.readValue(data, List.class);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
## 개요

`tb_middle_school_achievement` 테이블의 컬럼과 엔티티의 매핑에 사용되는 컨버터에 null-check 처리가 되어있지 않아 null 값이 할당되어있는 검정고시 원서에서 NPE가 발생하여 null-check를 추가하였습니다.