### PR TITLE
[member] 중복 확인 API res dto 필드 스네이크 케이스로 변경

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/member/dto/response/FoundDuplicateMemberResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/dto/response/FoundDuplicateMemberResDto.java
@@ -3,6 +3,6 @@ package team.themoment.hellogsmv3.domain.member.dto.response;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 
 public record FoundDuplicateMemberResDto(
-        YesNo DuplicateMemberYn
+        YesNo duplicateMemberYn
 ) {
 }

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryCheckDuplicateMemberServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryCheckDuplicateMemberServiceTest.java
@@ -43,7 +43,7 @@ class QueryCheckDuplicateMemberServiceTest {
                 // when
                 FoundDuplicateMemberResDto resDto = queryCheckDuplicateMemberService.execute(phoneNumber);
                 // then
-                assertEquals(YES, resDto.DuplicateMemberYn());
+                assertEquals(YES, resDto.duplicateMemberYn());
             }
 
             @Test
@@ -54,7 +54,7 @@ class QueryCheckDuplicateMemberServiceTest {
                 // when
                 FoundDuplicateMemberResDto resDto = queryCheckDuplicateMemberService.execute(phoneNumber);
                 // then
-                assertEquals(NO, resDto.DuplicateMemberYn());
+                assertEquals(NO, resDto.duplicateMemberYn());
             }
 
         }


### PR DESCRIPTION
## 개요

기존 파스칼케이스로 작성되었던 중복회원확인 API res dto 필드명을 스네이크케이스로 변경하였습니다.