### PR TITLE
[oneseo] 개별 학기별 예체능 환산점 계산식 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/ArtsPhysicalSubjectsScoreDetailResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/ArtsPhysicalSubjectsScoreDetailResDto.java
@@ -1,0 +1,13 @@
+package team.themoment.hellogsmv3.domain.oneseo.dto.response;
+
+import lombok.Builder;
+
+import java.math.BigDecimal;
+
+@Builder
+public record ArtsPhysicalSubjectsScoreDetailResDto(
+        BigDecimal score2_1,
+        BigDecimal score2_2,
+        BigDecimal score3_1
+) {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/ArtsPhysicalSubjectsScoreDetailResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/ArtsPhysicalSubjectsScoreDetailResDto.java
@@ -1,11 +1,16 @@
 package team.themoment.hellogsmv3.domain.oneseo.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
 import java.math.BigDecimal;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.*;
+
 @Builder
+@JsonInclude(NON_NULL)
 public record ArtsPhysicalSubjectsScoreDetailResDto(
+        BigDecimal score1_2,
         BigDecimal score2_1,
         BigDecimal score2_2,
         BigDecimal score3_1

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/CalculatedScoreResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/CalculatedScoreResDto.java
@@ -14,6 +14,8 @@ public record CalculatedScoreResDto(
 		@JsonInclude(JsonInclude.Include.NON_NULL)
 		BigDecimal artsPhysicalSubjectsScore,
 		@JsonInclude(JsonInclude.Include.NON_NULL)
+		ArtsPhysicalSubjectsScoreDetailResDto artsPhysicalSubjectsScoreDetail,
+		@JsonInclude(JsonInclude.Include.NON_NULL)
 		BigDecimal totalSubjectsScore,
 		BigDecimal attendanceScore,
 		BigDecimal volunteerScore,

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
@@ -156,14 +156,14 @@ public class CalculateGradeService {
                 .build();
     }
 
-    private String getFreeSemesterKey(String liberalSystem, String freeSemester) {
+    public static String getFreeSemesterKey(String liberalSystem, String freeSemester) {
         if (liberalSystem.equals("자유학년제") || freeSemester.equals("1-1") || freeSemester.equals("1-2")) {
             return "free";
         }
         return freeSemester;
     }
 
-    private BigDecimal assignIndividualArtsPhysicalScore(
+    public static BigDecimal assignIndividualArtsPhysicalScore(
             String freeSemesterKey, String currentSemester,
             BigDecimal score_1, BigDecimal score_2, BigDecimal score_3
     ) {
@@ -192,7 +192,7 @@ public class CalculateGradeService {
         return null;
     }
 
-    private BigDecimal calculateIndividualArtsPhysicalScore(List<Integer> achievementList, int start, int end) {
+    public static BigDecimal calculateIndividualArtsPhysicalScore(List<Integer> achievementList, int start, int end) {
         List<Integer> subList = achievementList.subList(start, end);
 
         int sum = subList.stream()

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
@@ -208,15 +208,16 @@ public class CalculateGradeService {
 
         // 개별 학기별 예체능 점수 배점은 60 * (해당 학기의 성적이 있는 예체능 교과 수 / 성적이 있는 총 예체능 교과 수)으로 계산
         BigDecimal allocation = BigDecimal.valueOf(60)
-                .multiply(BigDecimal.valueOf(achievementCount)
-                        .divide(BigDecimal.valueOf(allAchievementCount), 4, RoundingMode.HALF_UP));
+                .multiply(
+                        BigDecimal.valueOf(achievementCount).divide(BigDecimal.valueOf(allAchievementCount), 10, RoundingMode.HALF_UP)
+                );
 
         if (achievementCount == 0) {
             return BigDecimal.ZERO;
         }
 
         return BigDecimal.valueOf(sum)
-                .divide(BigDecimal.valueOf(achievementCount).multiply(BigDecimal.valueOf(5)), 4, RoundingMode.HALF_UP)
+                .divide(BigDecimal.valueOf(achievementCount).multiply(BigDecimal.valueOf(5)), 10, RoundingMode.HALF_UP)
                 .multiply(allocation)
                 .setScale(4, RoundingMode.HALF_UP);
     }
@@ -280,7 +281,7 @@ public class CalculateGradeService {
 
     private BigDecimal calcGeneralSubjectsScore(List<Integer> achievements, BigDecimal maxPoint) {
         // 해당 학기의 등급별 점수 배열이 비어있거나 해당 학기의 배점이 없다면 0.000을 반환
-        if (achievements == null || achievements.isEmpty() || maxPoint.equals(BigDecimal.ZERO)) return BigDecimal.valueOf(0).setScale(3, RoundingMode.HALF_UP);
+        if (achievements == null || achievements.isEmpty() || maxPoint.equals(BigDecimal.ZERO)) return BigDecimal.valueOf(0).setScale(4, RoundingMode.HALF_UP);
 
         // Integer 리스트를 BigDecimal 리스트로 변경 & 등급 유효성 검사
         List<BigDecimal> convertedAchievements = new ArrayList<>();
@@ -292,14 +293,14 @@ public class CalculateGradeService {
         // 해당 학기에 수강하지 않은 과목이 있다면 제거한 리스트를 반환 (점수가 0인 원소 제거)
         List<BigDecimal> noZeroAchievements = convertedAchievements.stream().filter(score -> score.compareTo(BigDecimal.ZERO) != 0).toList();
         // 위에서 구한 리스트가 비어있다면 0.000을 반환
-        if (noZeroAchievements.isEmpty()) return BigDecimal.valueOf(0).setScale(3, RoundingMode.HALF_UP);
+        if (noZeroAchievements.isEmpty()) return BigDecimal.valueOf(0).setScale(4, RoundingMode.HALF_UP);
 
         // 1. 점수로 환산된 등급을 모두 더한다.
         BigDecimal reduceResult = convertedAchievements.stream().reduce(BigDecimal.ZERO, BigDecimal::add);
         // 2. 더한값 / (과목 수 * 5) (소수점 6째자리에서 반올림)
-        BigDecimal divideResult = reduceResult.divide(BigDecimal.valueOf(noZeroAchievements.size() * 5L), 5, RoundingMode.HALF_UP);
+        BigDecimal divideResult = reduceResult.divide(BigDecimal.valueOf(noZeroAchievements.size() * 5L), 6, RoundingMode.HALF_UP);
         // 3. 각 학기당 배점 * 나눈값 (소수점 4째자리에서 반올림)
-        return divideResult.multiply(maxPoint).setScale(3, RoundingMode.HALF_UP);
+        return divideResult.multiply(maxPoint).setScale(4, RoundingMode.HALF_UP);
     }
 
     private BigDecimal calcArtSportsScore(List<Integer> achievements) {
@@ -316,7 +317,7 @@ public class CalculateGradeService {
 
         // 과목 수가 0일시 0점 반환
         if (achievementCount == 0) {
-            return BigDecimal.ZERO.setScale(3, RoundingMode.HALF_UP);
+            return BigDecimal.ZERO.setScale(4, RoundingMode.HALF_UP);
         }
 
         BigDecimal averageOfAchievementScale = BigDecimal.valueOf(totalScores).divide(BigDecimal.valueOf(maxScore), 4, RoundingMode.HALF_UP);

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
@@ -219,7 +219,7 @@ public class CalculateGradeService {
         return BigDecimal.valueOf(sum)
                 .divide(BigDecimal.valueOf(achievementCount).multiply(BigDecimal.valueOf(5)), 10, RoundingMode.HALF_UP)
                 .multiply(allocation)
-                .setScale(4, RoundingMode.HALF_UP);
+                .setScale(3, RoundingMode.HALF_UP);
     }
 
     private BigDecimal calcGeneralSubjectsScore(MiddleSchoolAchievementReqDto dto, GraduationType graduationType, String liberalSystem, String freeSemester) {
@@ -281,7 +281,7 @@ public class CalculateGradeService {
 
     private BigDecimal calcGeneralSubjectsScore(List<Integer> achievements, BigDecimal maxPoint) {
         // 해당 학기의 등급별 점수 배열이 비어있거나 해당 학기의 배점이 없다면 0.000을 반환
-        if (achievements == null || achievements.isEmpty() || maxPoint.equals(BigDecimal.ZERO)) return BigDecimal.valueOf(0).setScale(4, RoundingMode.HALF_UP);
+        if (achievements == null || achievements.isEmpty() || maxPoint.equals(BigDecimal.ZERO)) return BigDecimal.valueOf(0).setScale(3, RoundingMode.HALF_UP);
 
         // Integer 리스트를 BigDecimal 리스트로 변경 & 등급 유효성 검사
         List<BigDecimal> convertedAchievements = new ArrayList<>();
@@ -293,14 +293,14 @@ public class CalculateGradeService {
         // 해당 학기에 수강하지 않은 과목이 있다면 제거한 리스트를 반환 (점수가 0인 원소 제거)
         List<BigDecimal> noZeroAchievements = convertedAchievements.stream().filter(score -> score.compareTo(BigDecimal.ZERO) != 0).toList();
         // 위에서 구한 리스트가 비어있다면 0.000을 반환
-        if (noZeroAchievements.isEmpty()) return BigDecimal.valueOf(0).setScale(4, RoundingMode.HALF_UP);
+        if (noZeroAchievements.isEmpty()) return BigDecimal.valueOf(0).setScale(3, RoundingMode.HALF_UP);
 
         // 1. 점수로 환산된 등급을 모두 더한다.
         BigDecimal reduceResult = convertedAchievements.stream().reduce(BigDecimal.ZERO, BigDecimal::add);
         // 2. 더한값 / (과목 수 * 5) (소수점 6째자리에서 반올림)
-        BigDecimal divideResult = reduceResult.divide(BigDecimal.valueOf(noZeroAchievements.size() * 5L), 6, RoundingMode.HALF_UP);
+        BigDecimal divideResult = reduceResult.divide(BigDecimal.valueOf(noZeroAchievements.size() * 5L), 5, RoundingMode.HALF_UP);
         // 3. 각 학기당 배점 * 나눈값 (소수점 4째자리에서 반올림)
-        return divideResult.multiply(maxPoint).setScale(4, RoundingMode.HALF_UP);
+        return divideResult.multiply(maxPoint).setScale(3, RoundingMode.HALF_UP);
     }
 
     private BigDecimal calcArtSportsScore(List<Integer> achievements) {
@@ -317,11 +317,11 @@ public class CalculateGradeService {
 
         // 과목 수가 0일시 0점 반환
         if (achievementCount == 0) {
-            return BigDecimal.ZERO.setScale(4, RoundingMode.HALF_UP);
+            return BigDecimal.ZERO.setScale(3, RoundingMode.HALF_UP);
         }
 
-        BigDecimal averageOfAchievementScale = BigDecimal.valueOf(totalScores).divide(BigDecimal.valueOf(maxScore), 4, RoundingMode.HALF_UP);
-        return BigDecimal.valueOf(60).multiply(averageOfAchievementScale).setScale(4, RoundingMode.HALF_UP);
+        BigDecimal averageOfAchievementScale = BigDecimal.valueOf(totalScores).divide(BigDecimal.valueOf(maxScore), 3, RoundingMode.HALF_UP);
+        return BigDecimal.valueOf(60).multiply(averageOfAchievementScale).setScale(3, RoundingMode.HALF_UP);
     }
 
     private BigDecimal calcAttendanceScore(List<Integer> absentDays, List<Integer> attendanceDays) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
@@ -16,6 +16,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.List;
 
+import static team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType.CANDIDATE;
 import static team.themoment.hellogsmv3.domain.oneseo.service.OneseoService.ONESEO_CACHE_VALUE;
 
 @Service
@@ -61,10 +62,17 @@ public class QueryOneseoByIdService {
         return switch (graduationType) {
             case CANDIDATE -> {
                 MiddleSchoolAchievement middleSchoolAchievement = oneseo.getMiddleSchoolAchievement();
+                BigDecimal score_1 = calculateIndividualArtsPhysicalScore(middleSchoolAchievement.getArtsPhysicalAchievement(), 0, 3);
+                BigDecimal score_2 = calculateIndividualArtsPhysicalScore(middleSchoolAchievement.getArtsPhysicalAchievement(), 3, 6);
+                BigDecimal score_3 = calculateIndividualArtsPhysicalScore(middleSchoolAchievement.getArtsPhysicalAchievement(), 6, 9);
+
+                String freeSemesterKey = getFreeSemesterKey(middleSchoolAchievement.getLiberalSystem(), middleSchoolAchievement.getFreeSemester());
+
                 ArtsPhysicalSubjectsScoreDetailResDto artsPhysicalSubjectsScoreDetailResDto = ArtsPhysicalSubjectsScoreDetailResDto.builder()
-                        .score2_1(calculateIndividualArtsPhysicalScore(middleSchoolAchievement.getArtsPhysicalAchievement(), 0, 3))
-                        .score2_2(calculateIndividualArtsPhysicalScore(middleSchoolAchievement.getArtsPhysicalAchievement(), 3, 6))
-                        .score3_1(calculateIndividualArtsPhysicalScore(middleSchoolAchievement.getArtsPhysicalAchievement(), 6, 9))
+                        .score1_2(assignIndividualArtsPhysicalScore(freeSemesterKey, "1-2", score_1, score_2, score_3))
+                        .score2_1(assignIndividualArtsPhysicalScore(freeSemesterKey, "2-1", score_1, score_2, score_3))
+                        .score2_2(assignIndividualArtsPhysicalScore(freeSemesterKey, "2-2", score_1, score_2, score_3))
+                        .score3_1(assignIndividualArtsPhysicalScore(freeSemesterKey, "3-1", score_1, score_2, score_3))
                         .build();
 
                 yield CalculatedScoreResDto.builder()
@@ -96,6 +104,42 @@ public class QueryOneseoByIdService {
         };
     }
 
+    private String getFreeSemesterKey(String liberalSystem, String freeSemester) {
+        if (liberalSystem.equals("자유학년제") || freeSemester.equals("1-1") || freeSemester.equals("1-2")) {
+            return "free";
+        }
+        return freeSemester;
+    }
+
+    private BigDecimal assignIndividualArtsPhysicalScore(
+            String freeSemesterKey, String currentSemester,
+            BigDecimal score_1, BigDecimal score_2, BigDecimal score_3
+    ) {
+        switch (freeSemesterKey) {
+            case "free", "1-1", "1-2" -> {
+                if (currentSemester.equals("2-1")) return score_1;
+                if (currentSemester.equals("2-2")) return score_2;
+                if (currentSemester.equals("3-1")) return score_3;
+            }
+            case "2-1" -> {
+                if (currentSemester.equals("1-2")) return score_1;
+                if (currentSemester.equals("2-2")) return score_2;
+                if (currentSemester.equals("3-1")) return score_3;
+            }
+            case "2-2" -> {
+                if (currentSemester.equals("1-2")) return score_1;
+                if (currentSemester.equals("2-1")) return score_2;
+                if (currentSemester.equals("3-1")) return score_3;
+            }
+            case "3-1" -> {
+                if (currentSemester.equals("1-2")) return score_1;
+                if (currentSemester.equals("2-1")) return score_2;
+                if (currentSemester.equals("2-2")) return score_3;
+            }
+        }
+        return null;
+    }
+
     private BigDecimal calculateIndividualArtsPhysicalScore(List<Integer> achievementList, int start, int end) {
         List<Integer> subList = achievementList.subList(start, end);
 
@@ -106,13 +150,23 @@ public class QueryOneseoByIdService {
                 .filter(achievement -> achievement != 0)
                 .count();
 
+        int allAchievementCount = (int) achievementList.stream()
+                .filter(achievement -> achievement != 0)
+                .count();
+
+        // 개별 학기별 예체능 점수 배점은 60 * (해당 학기의 성적이 있는 예체능 교과 수 / 성적이 있는 총 예체능 교과 수)으로 계산
+        BigDecimal allocation = BigDecimal.valueOf(60)
+                .multiply(BigDecimal.valueOf(achievementCount)
+                        .divide(BigDecimal.valueOf(allAchievementCount), 4, RoundingMode.HALF_UP));
+
         if (achievementCount == 0) {
             return BigDecimal.ZERO;
         }
 
         return BigDecimal.valueOf(sum)
-                .divide(BigDecimal.valueOf(achievementCount).multiply(BigDecimal.valueOf(5)), 3, RoundingMode.HALF_UP)
-                .multiply(BigDecimal.valueOf(20));
+                .divide(BigDecimal.valueOf(achievementCount).multiply(BigDecimal.valueOf(5)), 4, RoundingMode.HALF_UP)
+                .multiply(allocation)
+                .setScale(4, RoundingMode.HALF_UP);
     }
 
     private OneseoPrivacyDetailResDto buildOneseoPrivacyDetailResDto(

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
@@ -13,10 +13,8 @@ import team.themoment.hellogsmv3.domain.oneseo.repository.MiddleSchoolAchievemen
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRepository;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.List;
 
-import static team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType.CANDIDATE;
 import static team.themoment.hellogsmv3.domain.oneseo.service.OneseoService.ONESEO_CACHE_VALUE;
 
 @Service

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
@@ -167,7 +167,7 @@ public class QueryOneseoByIdService {
         return BigDecimal.valueOf(sum)
                 .divide(BigDecimal.valueOf(achievementCount).multiply(BigDecimal.valueOf(5)), 10, RoundingMode.HALF_UP)
                 .multiply(allocation)
-                .setScale(4, RoundingMode.HALF_UP);
+                .setScale(3, RoundingMode.HALF_UP);
     }
 
     private OneseoPrivacyDetailResDto buildOneseoPrivacyDetailResDto(

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
@@ -156,15 +156,16 @@ public class QueryOneseoByIdService {
 
         // 개별 학기별 예체능 점수 배점은 60 * (해당 학기의 성적이 있는 예체능 교과 수 / 성적이 있는 총 예체능 교과 수)으로 계산
         BigDecimal allocation = BigDecimal.valueOf(60)
-                .multiply(BigDecimal.valueOf(achievementCount)
-                        .divide(BigDecimal.valueOf(allAchievementCount), 4, RoundingMode.HALF_UP));
+                .multiply(
+                        BigDecimal.valueOf(achievementCount).divide(BigDecimal.valueOf(allAchievementCount), 10, RoundingMode.HALF_UP)
+                );
 
         if (achievementCount == 0) {
             return BigDecimal.ZERO;
         }
 
         return BigDecimal.valueOf(sum)
-                .divide(BigDecimal.valueOf(achievementCount).multiply(BigDecimal.valueOf(5)), 4, RoundingMode.HALF_UP)
+                .divide(BigDecimal.valueOf(achievementCount).multiply(BigDecimal.valueOf(5)), 10, RoundingMode.HALF_UP)
                 .multiply(allocation)
                 .setScale(4, RoundingMode.HALF_UP);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
   jpa:
     database-platform: ${DB_PLATFORM}
     hibernate:
-      ddl-auto: ${HIBERNATE_DDL_AUTO}
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
   jpa:
     database-platform: ${DB_PLATFORM}
     hibernate:
-      ddl-auto: none
+      ddl-auto: ${HIBERNATE_DDL_AUTO}
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 개요

**졸업예정자**의 원서 조회시 개별 학기별 예체능 환산점 계산식을 추가하였습니다.

개별 학기별 예체능 환산점의 배점 계산식은 아래와 같습니다.
```
60 * (해당 학기의 성적이 있는 예체능 교과 수 / 성적이 있는 총 예체능 교과 수)
```

해당 배점 식으로 각 학기별 예체능 환산점을 구할 수 있습니다.

## 본문

<img width="306" alt="스크린샷 2024-10-05 오후 5 52 18" src="https://github.com/user-attachments/assets/0bfc3372-ccd6-4d65-bb0e-6cda48e26591">

위와 같이 `FoundOneseoResDto` dto 필드에 `artsPhysicalSubjectsScoreDetail` 필드를 추가하여 학기별 예체능 환산점을 반환합니다.

