### PR TITLE
fix(member): 인증번호 유효기간 TTl 3분으로 수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/member/entity/AuthenticationCode.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/entity/AuthenticationCode.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@RedisHash(timeToLive = 3600L)
+@RedisHash(timeToLive = 180L)
 public class AuthenticationCode {
     @Id
     @Indexed


### PR DESCRIPTION
## 개요

인증번호 redis-hash의 TTL을 3분으로 수정하였습니다.