### PR TITLE
[oneseo] 예체능 개별학기 환산점 3-2 학기 필드 추가 (졸업자)

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/ArtsPhysicalSubjectsScoreDetailResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/ArtsPhysicalSubjectsScoreDetailResDto.java
@@ -13,6 +13,7 @@ public record ArtsPhysicalSubjectsScoreDetailResDto(
         BigDecimal score1_2,
         BigDecimal score2_1,
         BigDecimal score2_2,
-        BigDecimal score3_1
+        BigDecimal score3_1,
+        BigDecimal score3_2
 ) {
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
@@ -120,6 +120,8 @@ public class CalculateGradeService {
                     .score3_2(score3_2)
                     .build();
 
+            validateArtPhysicalAchievement(graduationType, dto.artsPhysicalAchievement());
+
             BigDecimal score_1 = calculateIndividualArtsPhysicalScore(dto.artsPhysicalAchievement(), 0, 3);
             BigDecimal score_2 = calculateIndividualArtsPhysicalScore(dto.artsPhysicalAchievement(), 3, 6);
             BigDecimal score_3 = calculateIndividualArtsPhysicalScore(dto.artsPhysicalAchievement(), 6, 9);
@@ -156,6 +158,14 @@ public class CalculateGradeService {
                 .volunteerScore(volunteerScore)
                 .totalScore(totalScore)
                 .build();
+    }
+
+    private static void validateArtPhysicalAchievement(GraduationType graduationType, List<Integer> achievementList) {
+        // 졸업예정자는 예체능 점수를 9개, 졸업자는 예체능 점수를 12개를 보내야 함
+        int size = graduationType.equals(CANDIDATE) ? 9 : 12;
+        if (achievementList.size() != size) {
+            throw new ExpectedException("achievementList의 size가 유효하지 않습니다. " + achievementList.size(), HttpStatus.BAD_REQUEST);
+        }
     }
 
     public static String getFreeSemesterKey(String liberalSystem, String freeSemester) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
@@ -120,21 +120,23 @@ public class CalculateGradeService {
                     .score3_2(score3_2)
                     .build();
 
-            ArtsPhysicalSubjectsScoreDetailResDto artsPhysicalSubjectsScoreDetailResDto = null;
-            if (graduationType.equals(CANDIDATE)) {
-                BigDecimal score_1 = calculateIndividualArtsPhysicalScore(dto.artsPhysicalAchievement(), 0, 3);
-                BigDecimal score_2 = calculateIndividualArtsPhysicalScore(dto.artsPhysicalAchievement(), 3, 6);
-                BigDecimal score_3 = calculateIndividualArtsPhysicalScore(dto.artsPhysicalAchievement(), 6, 9);
+            BigDecimal score_1 = calculateIndividualArtsPhysicalScore(dto.artsPhysicalAchievement(), 0, 3);
+            BigDecimal score_2 = calculateIndividualArtsPhysicalScore(dto.artsPhysicalAchievement(), 3, 6);
+            BigDecimal score_3 = calculateIndividualArtsPhysicalScore(dto.artsPhysicalAchievement(), 6, 9);
+            BigDecimal score_4 = BigDecimal.ZERO;
 
-                String freeSemesterKey = getFreeSemesterKey(liberalSystem, freeSemester);
+            if (graduationType.equals(GRADUATE))
+                score_4 = calculateIndividualArtsPhysicalScore(dto.artsPhysicalAchievement(), 9, 12);
 
-                artsPhysicalSubjectsScoreDetailResDto = ArtsPhysicalSubjectsScoreDetailResDto.builder()
-                        .score1_2(assignIndividualArtsPhysicalScore(freeSemesterKey, "1-2", score_1, score_2, score_3))
-                        .score2_1(assignIndividualArtsPhysicalScore(freeSemesterKey, "2-1", score_1, score_2, score_3))
-                        .score2_2(assignIndividualArtsPhysicalScore(freeSemesterKey, "2-2", score_1, score_2, score_3))
-                        .score3_1(assignIndividualArtsPhysicalScore(freeSemesterKey, "3-1", score_1, score_2, score_3))
-                        .build();
-            }
+            String freeSemesterKey = getFreeSemesterKey(liberalSystem, freeSemester);
+
+            ArtsPhysicalSubjectsScoreDetailResDto artsPhysicalSubjectsScoreDetailResDto = ArtsPhysicalSubjectsScoreDetailResDto.builder()
+                    .score1_2(assignIndividualArtsPhysicalScore(freeSemesterKey, "1-2", graduationType, score_1, score_2, score_3, score_4))
+                    .score2_1(assignIndividualArtsPhysicalScore(freeSemesterKey, "2-1", graduationType, score_1, score_2, score_3, score_4))
+                    .score2_2(assignIndividualArtsPhysicalScore(freeSemesterKey, "2-2", graduationType, score_1, score_2, score_3, score_4))
+                    .score3_1(assignIndividualArtsPhysicalScore(freeSemesterKey, "3-1", graduationType, score_1, score_2, score_3, score_4))
+                    .score3_2(assignIndividualArtsPhysicalScore(freeSemesterKey, "3-2", graduationType, score_1, score_2, score_3, score_4))
+                    .build();
 
             return CalculatedScoreResDto.builder()
                     .generalSubjectsScore(generalSubjectsScore)
@@ -164,29 +166,39 @@ public class CalculateGradeService {
     }
 
     public static BigDecimal assignIndividualArtsPhysicalScore(
-            String freeSemesterKey, String currentSemester,
-            BigDecimal score_1, BigDecimal score_2, BigDecimal score_3
+            String freeSemesterKey, String currentSemester, GraduationType graduationType,
+            BigDecimal score_1, BigDecimal score_2, BigDecimal score_3, BigDecimal score_4
     ) {
         switch (freeSemesterKey) {
             case "free", "1-1", "1-2" -> {
                 if (currentSemester.equals("2-1")) return score_1;
                 if (currentSemester.equals("2-2")) return score_2;
                 if (currentSemester.equals("3-1")) return score_3;
+                if (currentSemester.equals("3-2") && graduationType.equals(GRADUATE)) return score_4;
             }
             case "2-1" -> {
                 if (currentSemester.equals("1-2")) return score_1;
                 if (currentSemester.equals("2-2")) return score_2;
                 if (currentSemester.equals("3-1")) return score_3;
+                if (currentSemester.equals("3-2") && graduationType.equals(GRADUATE)) return score_4;
             }
             case "2-2" -> {
                 if (currentSemester.equals("1-2")) return score_1;
                 if (currentSemester.equals("2-1")) return score_2;
                 if (currentSemester.equals("3-1")) return score_3;
+                if (currentSemester.equals("3-2") && graduationType.equals(GRADUATE)) return score_4;
             }
             case "3-1" -> {
                 if (currentSemester.equals("1-2")) return score_1;
                 if (currentSemester.equals("2-1")) return score_2;
                 if (currentSemester.equals("2-2")) return score_3;
+                if (currentSemester.equals("3-2") && graduationType.equals(GRADUATE)) return score_4;
+            }
+            case "3-2" -> {
+                if (currentSemester.equals("1-2")) return score_1;
+                if (currentSemester.equals("2-1")) return score_2;
+                if (currentSemester.equals("2-2")) return score_3;
+                if (currentSemester.equals("3-1") && graduationType.equals(GRADUATE)) return score_4;
             }
         }
         return null;

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -186,6 +186,10 @@ public class ModifyOneseoService {
                         .secondDesiredMajor(reqDto.secondDesiredMajor())
                         .thirdDesiredMajor(reqDto.thirdDesiredMajor())
                         .build())
+                .wantedScreeningChangeHistory(oneseo.getWantedScreeningChangeHistory())
+                .oneseoPrivacyDetail(oneseo.getOneseoPrivacyDetail())
+                .middleSchoolAchievement(oneseo.getMiddleSchoolAchievement())
+                .entranceTestResult(oneseo.getEntranceTestResult())
                 .realOneseoArrivedYn(oneseo.getRealOneseoArrivedYn())
                 .wantedScreening(reqDto.screening())
                 .build();

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/QueryOneseoByIdService.java
@@ -15,6 +15,7 @@ import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRep
 import java.math.BigDecimal;
 import java.util.List;
 
+import static team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType.*;
 import static team.themoment.hellogsmv3.domain.oneseo.service.OneseoService.ONESEO_CACHE_VALUE;
 
 @Service
@@ -58,19 +59,24 @@ public class QueryOneseoByIdService {
                 .build();
 
         return switch (graduationType) {
-            case CANDIDATE -> {
+            case CANDIDATE, GRADUATE -> {
                 MiddleSchoolAchievement middleSchoolAchievement = oneseo.getMiddleSchoolAchievement();
                 BigDecimal score_1 = CalculateGradeService.calculateIndividualArtsPhysicalScore(middleSchoolAchievement.getArtsPhysicalAchievement(), 0, 3);
                 BigDecimal score_2 = CalculateGradeService.calculateIndividualArtsPhysicalScore(middleSchoolAchievement.getArtsPhysicalAchievement(), 3, 6);
                 BigDecimal score_3 = CalculateGradeService.calculateIndividualArtsPhysicalScore(middleSchoolAchievement.getArtsPhysicalAchievement(), 6, 9);
+                BigDecimal score_4 = BigDecimal.ZERO;
+
+                if (graduationType.equals(GRADUATE))
+                    score_4 = CalculateGradeService.calculateIndividualArtsPhysicalScore(middleSchoolAchievement.getArtsPhysicalAchievement(), 9, 12);
 
                 String freeSemesterKey = CalculateGradeService.getFreeSemesterKey(middleSchoolAchievement.getLiberalSystem(), middleSchoolAchievement.getFreeSemester());
 
                 ArtsPhysicalSubjectsScoreDetailResDto artsPhysicalSubjectsScoreDetailResDto = ArtsPhysicalSubjectsScoreDetailResDto.builder()
-                        .score1_2(CalculateGradeService.assignIndividualArtsPhysicalScore(freeSemesterKey, "1-2", score_1, score_2, score_3))
-                        .score2_1(CalculateGradeService.assignIndividualArtsPhysicalScore(freeSemesterKey, "2-1", score_1, score_2, score_3))
-                        .score2_2(CalculateGradeService.assignIndividualArtsPhysicalScore(freeSemesterKey, "2-2", score_1, score_2, score_3))
-                        .score3_1(CalculateGradeService.assignIndividualArtsPhysicalScore(freeSemesterKey, "3-1", score_1, score_2, score_3))
+                        .score1_2(CalculateGradeService.assignIndividualArtsPhysicalScore(freeSemesterKey, "1-2", graduationType, score_1, score_2, score_3, score_4))
+                        .score2_1(CalculateGradeService.assignIndividualArtsPhysicalScore(freeSemesterKey, "2-1", graduationType, score_1, score_2, score_3, score_4))
+                        .score2_2(CalculateGradeService.assignIndividualArtsPhysicalScore(freeSemesterKey, "2-2", graduationType, score_1, score_2, score_3, score_4))
+                        .score3_1(CalculateGradeService.assignIndividualArtsPhysicalScore(freeSemesterKey, "3-1", graduationType, score_1, score_2, score_3, score_4))
+                        .score3_2(CalculateGradeService.assignIndividualArtsPhysicalScore(freeSemesterKey, "3-2", graduationType, score_1, score_2, score_3, score_4))
                         .build();
 
                 yield CalculatedScoreResDto.builder()
@@ -83,15 +89,6 @@ public class QueryOneseoByIdService {
                         .artsPhysicalSubjectsScoreDetail(artsPhysicalSubjectsScoreDetailResDto)
                         .build();
             }
-            case GRADUATE ->
-                CalculatedScoreResDto.builder()
-                        .generalSubjectsScore(entranceTestFactorsDetail.getGeneralSubjectsScore())
-                        .artsPhysicalSubjectsScore(entranceTestFactorsDetail.getArtsPhysicalSubjectsScore())
-                        .attendanceScore(entranceTestFactorsDetail.getAttendanceScore())
-                        .volunteerScore(entranceTestFactorsDetail.getVolunteerScore())
-                        .totalScore(entranceTestResult.getDocumentEvaluationScore())
-                        .generalSubjectsScoreDetail(generalSubjectsScoreDetailResDto)
-                        .build();
             case GED ->
                 CalculatedScoreResDto.builder()
                         .totalSubjectsScore(entranceTestFactorsDetail.getTotalSubjectsScore())


### PR DESCRIPTION
## 개요

성적확인서를 졸업자도 출력해야한다는 요구사항이 생겨 예체능 개별학기 환산 필드에 3-2 학기를 추가하였습니다.

## 본문

기존 로직에 3-2 학기 필드를 추가하여 졸업 상태가 졸업자(GRADUATE)인 지원자라면 3-2 학기 환산점을 계산하도록 하였습니다.