### PR TITLE
[oneseo] 특정 시점 이후에는 동작하지 않아야 하는 작업 수정 및 평가 점수 검증 메서드 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyAptitudeEvaluationScoreService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyAptitudeEvaluationScoreService.java
@@ -1,6 +1,7 @@
 package team.themoment.hellogsmv3.domain.oneseo.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
@@ -8,6 +9,9 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.request.AptitudeEvaluationSco
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+import java.math.BigDecimal;
 
 @Service
 @RequiredArgsConstructor
@@ -24,7 +28,10 @@ public class ModifyAptitudeEvaluationScoreService {
         EntranceTestResult entranceTestResult = oneseo.getEntranceTestResult();
         OneseoService.isBeforeSecondTest(entranceTestResult.getSecondTestPassYn());
 
-        entranceTestResult.modifyAptitudeEvaluationScore(aptitudeEvaluationScoreReqDto.aptitudeEvaluationScore());
+        BigDecimal aptitudeEvaluationScore = aptitudeEvaluationScoreReqDto.aptitudeEvaluationScore();
+        OneseoService.validateEvaluationScore(aptitudeEvaluationScore);
+
+        entranceTestResult.modifyAptitudeEvaluationScore(aptitudeEvaluationScore);
 
         entranceTestResultRepository.save(entranceTestResult);
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyAptitudeEvaluationScoreService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyAptitudeEvaluationScoreService.java
@@ -1,7 +1,6 @@
 package team.themoment.hellogsmv3.domain.oneseo.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
@@ -9,10 +8,6 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.request.AptitudeEvaluationSco
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
-import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
-import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
-
-import java.math.BigDecimal;
 
 @Service
 @RequiredArgsConstructor
@@ -26,7 +21,8 @@ public class ModifyAptitudeEvaluationScoreService {
         Member member = memberService.findByIdOrThrow(memberId);
         Oneseo oneseo = oneseoService.findByMemberOrThrow(member);
 
-        EntranceTestResult entranceTestResult = entranceTestResultRepository.findByOneseo(oneseo);
+        EntranceTestResult entranceTestResult = oneseo.getEntranceTestResult();
+        OneseoService.isBeforeSecondTest(entranceTestResult.getSecondTestPassYn());
 
         entranceTestResult.modifyAptitudeEvaluationScore(aptitudeEvaluationScoreReqDto.aptitudeEvaluationScore());
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyAptitudeEvaluationScoreService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyAptitudeEvaluationScoreService.java
@@ -24,7 +24,6 @@ public class ModifyAptitudeEvaluationScoreService {
 
     public void execute(Long memberId, AptitudeEvaluationScoreReqDto aptitudeEvaluationScoreReqDto) {
         Member member = memberService.findByIdOrThrow(memberId);
-
         Oneseo oneseo = oneseoService.findByMemberOrThrow(member);
 
         EntranceTestResult entranceTestResult = entranceTestResultRepository.findByOneseo(oneseo);

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyInterviewScoreService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyInterviewScoreService.java
@@ -1,7 +1,6 @@
 package team.themoment.hellogsmv3.domain.oneseo.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
@@ -10,7 +9,6 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.request.InterviewScoreReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
-import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
 @RequiredArgsConstructor
@@ -25,7 +23,8 @@ public class ModifyInterviewScoreService {
         Member member = memberService.findByIdOrThrow(memberId);
         Oneseo oneseo = oneseoService.findByMemberOrThrow(member);
 
-        EntranceTestResult entranceTestResult = entranceTestResultRepository.findByOneseo(oneseo);
+        EntranceTestResult entranceTestResult = oneseo.getEntranceTestResult();
+        OneseoService.isBeforeSecondTest(entranceTestResult.getSecondTestPassYn());
 
         entranceTestResult.modifyInterviewScore(reqDto.interviewScore());
         entranceTestResultRepository.save(entranceTestResult);

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyInterviewScoreService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyInterviewScoreService.java
@@ -10,6 +10,8 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
 
+import java.math.BigDecimal;
+
 @Service
 @RequiredArgsConstructor
 public class ModifyInterviewScoreService {
@@ -26,7 +28,10 @@ public class ModifyInterviewScoreService {
         EntranceTestResult entranceTestResult = oneseo.getEntranceTestResult();
         OneseoService.isBeforeSecondTest(entranceTestResult.getSecondTestPassYn());
 
-        entranceTestResult.modifyInterviewScore(reqDto.interviewScore());
+        BigDecimal interviewScore = reqDto.interviewScore();
+        OneseoService.validateEvaluationScore(interviewScore);
+
+        entranceTestResult.modifyInterviewScore(interviewScore);
         entranceTestResultRepository.save(entranceTestResult);
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyInterviewScoreService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyInterviewScoreService.java
@@ -22,7 +22,6 @@ public class ModifyInterviewScoreService {
 
     @Transactional
     public void execute(Long memberId, InterviewScoreReqDto reqDto) {
-
         Member member = memberService.findByIdOrThrow(memberId);
         Oneseo oneseo = oneseoService.findByMemberOrThrow(member);
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyOneseoService.java
@@ -47,7 +47,8 @@ public class ModifyOneseoService {
         Member currentMember = memberService.findByIdOrThrow(memberId);
         Oneseo currentOneseo = oneseoService.findByMemberOrThrow(currentMember);
 
-        isBeforeFirstTest(currentOneseo);
+        EntranceTestResult entranceTestResult = currentOneseo.getEntranceTestResult();
+        OneseoService.isBeforeFirstTest(entranceTestResult.getFirstTestPassYn());
 
         OneseoPrivacyDetail oneseoPrivacyDetail = oneseoPrivacyDetailRepository.findByOneseo(currentOneseo);
         MiddleSchoolAchievement middleSchoolAchievement = middleSchoolAchievementRepository.findByOneseo(currentOneseo);
@@ -71,13 +72,6 @@ public class ModifyOneseoService {
                 middleSchoolAchievementResDto,
                 calculatedScoreResDto
         );
-    }
-
-    private void isBeforeFirstTest(Oneseo oneseo) {
-        EntranceTestResult entranceTestResult = oneseo.getEntranceTestResult();
-        if (entranceTestResult.getFirstTestPassYn() != null) {
-            throw new ExpectedException("1차 전형 결과 산출 이후에는 원서를 수정할 수 없습니다.", HttpStatus.FORBIDDEN);
-        }
     }
 
     private OneseoPrivacyDetailResDto buildOneseoPrivacyDetailResDto(

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.ArrivedStatusResDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 
@@ -20,8 +21,10 @@ public class ModifyRealOneseoArrivedYnService {
     @Transactional
     public ArrivedStatusResDto execute(Long memberId) {
         Member member = memberService.findByIdOrThrow(memberId);
-
         Oneseo oneseo = oneseoService.findByMemberOrThrow(member);
+
+        EntranceTestResult entranceTestResult = oneseo.getEntranceTestResult();
+        OneseoService.isBeforeFirstTest(entranceTestResult.getFirstTestPassYn());
 
         oneseo.switchRealOneseoArrivedYn();
         Oneseo modifiedOneseo = oneseoRepository.save(oneseo);

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
@@ -56,6 +56,12 @@ public class OneseoService {
         }
     }
 
+    public static void isBeforeSecondTest(YesNo yn) {
+        if (yn != null) {
+            throw new ExpectedException("2차 전형 결과 산출 이후에는 작업을 진행할 수 없습니다.", HttpStatus.FORBIDDEN);
+        }
+    }
+
     public static void isValidMiddleSchoolInfo(OneseoReqDto reqDto) {
         if (
                 reqDto.graduationType().equals(CANDIDATE) && (

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
@@ -5,8 +5,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.ScreeningCategory;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
@@ -46,6 +48,12 @@ public class OneseoService {
         int totalAttendanceDays = attendanceDays.stream().mapToInt(Integer::intValue).sum();
 
         return totalAbsentDays + (totalAttendanceDays / 3);
+    }
+
+    public static void isBeforeFirstTest(YesNo yn) {
+        if (yn != null) {
+            throw new ExpectedException("1차 전형 결과 산출 이후에는 작업을 진행할 수 없습니다.", HttpStatus.FORBIDDEN);
+        }
     }
 
     public static void isValidMiddleSchoolInfo(OneseoReqDto reqDto) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
@@ -12,6 +12,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import static team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType.CANDIDATE;
@@ -59,6 +60,14 @@ public class OneseoService {
     public static void isBeforeSecondTest(YesNo yn) {
         if (yn != null) {
             throw new ExpectedException("2차 전형 결과 산출 이후에는 작업을 진행할 수 없습니다.", HttpStatus.FORBIDDEN);
+        }
+    }
+
+    public static void validateEvaluationScore(BigDecimal aptitudeEvaluationScore) {
+        BigDecimal minValue = BigDecimal.ZERO;
+        BigDecimal maxValue = new BigDecimal(100);
+        if (aptitudeEvaluationScore.compareTo(minValue) < 0 || aptitudeEvaluationScore.compareTo(maxValue) > 0) {
+            throw new ExpectedException("0부터 100사이의 값만 할당할 수 있습니다.", HttpStatus.BAD_REQUEST);
         }
     }
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyAptitudeEvaluationScoreServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyAptitudeEvaluationScoreServiceTest.java
@@ -59,17 +59,18 @@ public class ModifyAptitudeEvaluationScoreServiceTest {
                         .id(memberId)
                         .build();
 
-                Oneseo oneseo = Oneseo.builder()
-                        .member(member)
-                        .build();
-
                 entranceTestResult = EntranceTestResult.builder()
                         .aptitudeEvaluationScore(BigDecimal.valueOf(70))
+                        .secondTestPassYn(null)
+                        .build();
+
+                Oneseo oneseo = Oneseo.builder()
+                        .member(member)
+                        .entranceTestResult(entranceTestResult)
                         .build();
 
                 given(memberService.findByIdOrThrow(memberId)).willReturn(member);
                 given(oneseoService.findByMemberOrThrow(member)).willReturn(oneseo);
-                given(entranceTestResultRepository.findByOneseo(oneseo)).willReturn(entranceTestResult);
             }
 
             @Test

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyInterviewScoreServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyInterviewScoreServiceTest.java
@@ -61,17 +61,18 @@ public class ModifyInterviewScoreServiceTest {
                         .id(memberId)
                         .build();
 
-                Oneseo oneseo = Oneseo.builder()
-                        .member(member)
-                        .build();
-
                 entranceTestResult = EntranceTestResult.builder()
                         .interviewScore(BigDecimal.valueOf(75))
+                        .firstTestPassYn(null)
+                        .build();
+
+                Oneseo oneseo = Oneseo.builder()
+                        .member(member)
+                        .entranceTestResult(entranceTestResult)
                         .build();
 
                 given(memberService.findByIdOrThrow(memberId)).willReturn(member);
                 given(oneseoService.findByMemberOrThrow(member)).willReturn(oneseo);
-                given(entranceTestResultRepository.findByOneseo(oneseo)).willReturn(entranceTestResult);
             }
 
             @Test

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnServiceTest.java
@@ -12,11 +12,14 @@ import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.AptitudeEvaluationScoreReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.ArrivedStatusResDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+import java.math.BigDecimal;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
@@ -59,10 +62,15 @@ public class ModifyRealOneseoArrivedYnServiceTest {
                         .id(memberId)
                         .build();
 
+                EntranceTestResult entranceTestResult = EntranceTestResult.builder()
+                        .firstTestPassYn(null)
+                        .build();
+
                 oneseo = Oneseo.builder()
                         .member(member)
                         .realOneseoArrivedYn(YesNo.NO)
                         .wantedScreening(Screening.GENERAL)
+                        .entranceTestResult(entranceTestResult)
                         .build();
 
                 given(memberService.findByIdOrThrow(memberId)).willReturn(member);


### PR DESCRIPTION
## 개요

특정 시험 이후에는 동작하지 않아야하는 작업에 대한 처리와 평가 점수 입력 범위에 대한 검증 로직을 추가하였습니다.

## 본문

- 특정 시점 이후에는 동작하지 않아야 하는 작업에 대한 validate를 추가하였습니다. (1차 평가 이후 불가능: 서류제출여부 수정, 2차 평가 이후 불가능: 평가점수 수정)
- 평가 점수 입력 범위에 대한 검증 메서드를 추가하였습니다. (인적성, 면접 점수 0점 ~ 100점 범위 제한)

