### PR TITLE
[oneseo] 졸업예정 지원자 3-2학기 점수가 할당되는 문제 해결

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
@@ -309,7 +309,7 @@ public class CalculateGradeService {
         // Integer 리스트를 BigDecimal 리스트로 변경 & 등급 유효성 검사
         List<BigDecimal> convertedAchievements = new ArrayList<>();
         achievements.forEach(achievement -> {
-            if (achievement > 5 || achievement < 0) throw new IllegalArgumentException("올바르지 않은 일반교과 등급이 입력되었습니다.");
+            if (achievement > 5 || achievement < 0) throw new ExpectedException("올바르지 않은 일반교과 등급이 입력되었습니다.", HttpStatus.BAD_REQUEST);
             convertedAchievements.add(BigDecimal.valueOf(achievement));
         });
 
@@ -327,8 +327,12 @@ public class CalculateGradeService {
     }
 
     private BigDecimal calcArtSportsScore(List<Integer> achievements) {
+        if (achievements == null || achievements.isEmpty()) {
+            throw new ExpectedException("예체능 등급을 입력해주세요", HttpStatus.BAD_REQUEST);
+        }
+
         achievements.forEach(achievement -> {
-            if (achievement != 0 && (achievement > 5 || achievement < 3)) throw new IllegalArgumentException("올바르지 않은 예체능 등급이 입력되었습니다.");
+            if (achievement != 0 && (achievement > 5 || achievement < 3)) throw new ExpectedException("올바르지 않은 예체능 등급이 입력되었습니다.", HttpStatus.BAD_REQUEST);
         });
 
         // 1. 각 등급별 갯수에 등급별 배점을 곱한 값을 더한다.
@@ -408,6 +412,10 @@ public class CalculateGradeService {
 
     private void validFreeSemester(String liberalSystem, String freeSemester) {
         List<String> validSemesterList = List.of("", "1-1", "1-2", "2-1", "2-2", "3-1", "3-2");
+
+        // liberalSystem가 null이거나 자유학기제 or 자유학년제가 아니라면 예외 발생
+        if (liberalSystem == null || (!liberalSystem.equals("자유학기제") && !liberalSystem.equals("자유학년제")))
+            throw new ExpectedException("올바른 liberalSystem을 입력해주세요.", HttpStatus.BAD_REQUEST);
 
         // 자유학기제 && 자유학기제가 적용된 학기를 입력하지 않았다면 예외 발생
         if (liberalSystem.equals("자유학기제") && freeSemester == null)

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
@@ -36,6 +36,9 @@ public class CalculateGradeService {
 
     public CalculatedScoreResDto execute(MiddleSchoolAchievementReqDto dto, Oneseo oneseo, GraduationType graduationType) {
 
+        // 교과 성적 필드 초기화
+        initScore();
+
         validGraduationType(graduationType);
         validFreeSemester(dto.liberalSystem(), dto.freeSemester());
 
@@ -424,5 +427,13 @@ public class CalculateGradeService {
         // 자유학기제 && 올바른 학기를 입력하지 않았다면 예외 발생
         if (liberalSystem.equals("자유학기제") && validSemesterList.stream().noneMatch(s -> s.equals(freeSemester)))
             throw new ExpectedException(String.format("%s(은)는 유효한 학기가 아닙니다.", freeSemester), HttpStatus.BAD_REQUEST);
+    }
+
+    private void initScore() {
+        score1_2 = BigDecimal.ZERO;
+        score2_1 = BigDecimal.ZERO;
+        score2_2 = BigDecimal.ZERO;
+        score3_1 = BigDecimal.ZERO;
+        score3_2 = BigDecimal.ZERO;
     }
 }


### PR DESCRIPTION
## 개요

졸업예정 지원자가 성적 계산시 3-2학기 환산점에 점수가 할당되는 문제를 해결하였습니다.

## 본문

<img width="498" alt="스크린샷 2024-10-09 오후 4 52 32" src="https://github.com/user-attachments/assets/8f4f3e40-a3f5-40cc-8a5e-6383e6545433">

### 문제 상황
성적계산시 총 환산점이 300점을 넘기는 문제가 발생하였습니다. 원인 분석 중 졸업예정자 원서에서만 발생하고 3-2학기 환산 점수가 할당되어 있다는 것을 확인하였습니다. (졸업예정 지원자는 3-2학기 점수를 받지 않기 때문에 환산점이 계산될 수 없습니다.)

### 원인 파악

<img width="298" alt="스크린샷 2024-10-09 오후 4 55 14" src="https://github.com/user-attachments/assets/7012667e-a00d-41c3-b4d7-20411f22e255">

성적계산 클래스는 위 사진처럼 필드로 학기별 교과성적 환산점을 관리하고 있습니다. 0점으로 초기화되어 있긴 하지만, 해당 클래스는 스프링 빈으로 싱글톤 패턴으로 스프링 컨텍스트에서 관리됩니다.

성적계산 로직에서는 필드를 수정하는 로직이 포함되어 있기 때문에 해당 로직이 끝난다고 해도 **싱글톤을 관리되는 객체이기 때문에 필드 값이 수정된대로 남아있게 되어 문제가 발생**한 것입니다.

### 문제 해결

성적계산 메서드 시작 부분에 필드를 초기화 해주는 작업을 추가하여 문제를 해결하였습니다.

## 수정사항
- 성적계산로직 관련 validate를 추가하였습니다. 07c6c6e29f1b85fbd9fd2d0d6e906ff6ca7edabe
