### PR TITLE
[oneseo] 원서 검색 enum 타입 파라미터 검증 로직 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -1,6 +1,7 @@
 package team.themoment.hellogsmv3.domain.oneseo.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -102,8 +103,11 @@ public class OneseoController {
     public SearchOneseosResDto search(
             @RequestParam("page") Integer page,
             @RequestParam("size") Integer size,
+            @Schema(description = "합격, 불합격 여부", defaultValue = "ALL", allowableValues = {"ALL", "FIRST_PASS", "FINAL_PASS", "FALL"})
             @RequestParam(name = "testResultTag") String testResultParam,
+            @Schema(description = "지원 전형", defaultValue = "GENERAL", allowableValues = {"GENERAL", "SPECIAL", "EXTRA"})
             @RequestParam(name = "screeningTag", required = false) String screeningParam,
+            @Schema(description = "서류 제출 여부", defaultValue = "YES", allowableValues = {"YES", "NO"})
             @RequestParam(name = "isSubmitted", required = false) String isSubmittedParam,
             @RequestParam(name = "keyword", required = false) String keyword
     ) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -102,14 +102,24 @@ public class OneseoController {
     public SearchOneseosResDto search(
             @RequestParam("page") Integer page,
             @RequestParam("size") Integer size,
-            @RequestParam(name = "testResultTag") TestResultTag testResultTag,
-            @RequestParam(name = "screeningTag", required = false) ScreeningCategory screeningTag,
-            @RequestParam(name = "isSubmitted", required = false) YesNo isSubmitted,
+            @RequestParam(name = "testResultTag") String testResultParam,
+            @RequestParam(name = "screeningTag", required = false) String screeningParam,
+            @RequestParam(name = "isSubmitted", required = false) String isSubmittedParam,
             @RequestParam(name = "keyword", required = false) String keyword
     ) {
-        if (page < 0 || size < 0)
+        if (page < 0 || size < 0) {
             throw new ExpectedException("page, size는 0 이상만 가능합니다", HttpStatus.BAD_REQUEST);
-        return searchOneseoService.execute(page, size, testResultTag, screeningTag, isSubmitted, keyword);
+        }
+
+        try {
+            TestResultTag tag = TestResultTag.valueOf(testResultParam);
+            ScreeningCategory screeningCategory = (screeningParam != null) ? ScreeningCategory.valueOf(screeningParam) : null;
+            YesNo isSubmitted = (isSubmittedParam != null) ? YesNo.valueOf(isSubmittedParam) : null;
+
+            return searchOneseoService.execute(page, size, tag, screeningCategory, isSubmitted, keyword);
+        } catch (IllegalArgumentException e) {
+            throw new ExpectedException("유효하지 않은 매개변수 값입니다.", HttpStatus.BAD_REQUEST);
+        }
     }
 
     @Operation(summary = "내 원서 조회", description = "내 원서 정보를 조회합니다. 임시 저장된 원서가 있다면 임시 저장된 원서를 조회합니다.")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
   jpa:
     database-platform: ${DB_PLATFORM}
     hibernate:
-      ddl-auto: ${HIBERNATE_DDL_AUTO}
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
   jpa:
     database-platform: ${DB_PLATFORM}
     hibernate:
-      ddl-auto: none
+      ddl-auto: ${HIBERNATE_DDL_AUTO}
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 개요

원서 검색 API에서 파라미터로 Enum 타입을 받고 있어 잘못된 값을 넘기면 `IllegalArgumentException`이 발생하여 
API 파라미터에서는 String 타입으로 받고 Enum 타입으로 변환하는 검증 로직을 추가하였습니다.