### PR TITLE
[onesoe] 테스트 중 발생한 원서 관련 트러블 슈팅

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberService.java
@@ -28,6 +28,7 @@ public class CreateMemberService {
     private final ScheduleEnvironment scheduleEnv;
 
     private final OneseoRepository oneseoRepository;
+    private final EntranceTestResultRepository entranceTestResultRepository;
 
     @Transactional
     public Role execute(CreateMemberReqDto reqDto, Long memberId) {
@@ -48,7 +49,7 @@ public class CreateMemberService {
     }
 
     private void ifDuplicateMemberDeleteMemberInfo(String phoneNumber) {
-        if (LocalDateTime.now().isAfter(scheduleEnv.oneseoSubmissionEnd()))
+        if (LocalDateTime.now().isAfter(scheduleEnv.oneseoSubmissionEnd()) || entranceTestResultRepository.existsByFirstTestPassYnIsNotNull())
             throw new ExpectedException("원서접수 기간 이후에는 기존 회원정보를 삭제하고 회원가입할 수 없습니다.", HttpStatus.BAD_REQUEST);
 
         memberRepository.findByPhoneNumber(phoneNumber).ifPresent(

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
@@ -168,7 +168,7 @@ public class CalculateGradeService {
         // 졸업예정자는 예체능 점수를 9개, 졸업자는 예체능 점수를 12개를 보내야 함
         int size = graduationType.equals(CANDIDATE) ? 9 : 12;
         if (achievementList.size() != size) {
-            throw new ExpectedException("achievementList의 size가 유효하지 않습니다. " + achievementList.size(), HttpStatus.BAD_REQUEST);
+            throw new ExpectedException("예체능 성취도 개수가 유효하지 않습니다. " + achievementList.size(), HttpStatus.BAD_REQUEST);
         }
     }
 
@@ -358,8 +358,20 @@ public class CalculateGradeService {
         // Integer 리스트를 BigDecimal 리스트로 변경
         List<BigDecimal> convertedAbsentDays = new ArrayList<>();
         List<BigDecimal> convertedAttendanceDays = new ArrayList<>();
-        absentDays.forEach(absentDay -> convertedAbsentDays.add(BigDecimal.valueOf(absentDay)));
-        attendanceDays.forEach(attendanceDay -> convertedAttendanceDays.add(BigDecimal.valueOf(attendanceDay)));
+        absentDays.forEach(absentDay -> {
+            if (absentDay < 0)  throw new ExpectedException("결석일수는 음수가 될 수 없습니다.", HttpStatus.BAD_REQUEST);
+            convertedAbsentDays.add(BigDecimal.valueOf(absentDay));
+        });
+        attendanceDays.forEach(attendanceDay -> {
+            if (attendanceDay < 0)  throw new ExpectedException("출결일수는 음수가 될 수 없습니다.", HttpStatus.BAD_REQUEST);
+            convertedAttendanceDays.add(BigDecimal.valueOf(attendanceDay));
+        });
+
+        if (convertedAbsentDays.size() != 3)
+            throw new ExpectedException("결석일수 개수가 유효하지 않습니다.", HttpStatus.BAD_REQUEST);
+
+        if (convertedAttendanceDays.size() != 9)
+            throw new ExpectedException("출결일수 개수가 유효하지 않습니다.", HttpStatus.BAD_REQUEST);
 
         // 결석 횟수를 더함
         BigDecimal absentDay = convertedAbsentDays.stream().reduce(BigDecimal.ZERO, BigDecimal::add);
@@ -382,7 +394,10 @@ public class CalculateGradeService {
     private BigDecimal calcVolunteerScore(List<Integer> volunteerHours) {
         // Integer 리스트를 BigDecimal 리스트로 변경
         List<BigDecimal> convertedVolunteerHours = new ArrayList<>();
-        volunteerHours.forEach(volunteerHour -> convertedVolunteerHours.add(BigDecimal.valueOf(volunteerHour)));
+        volunteerHours.forEach(volunteerHour -> {
+            if (volunteerHour < 0)  throw new ExpectedException("봉사일수는 음수가 될 수 없습니다.", HttpStatus.BAD_REQUEST);
+            convertedVolunteerHours.add(BigDecimal.valueOf(volunteerHour));
+        });
 
         return convertedVolunteerHours.stream().reduce(BigDecimal.valueOf(0), (current, hour) -> {
             // 연간 7시간 이상

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
@@ -232,15 +232,15 @@ public class CalculateGradeService {
                 .filter(achievement -> achievement != 0)
                 .count();
 
+        if (achievementCount == 0) {
+            return BigDecimal.ZERO;
+        }
+
         // 개별 학기별 예체능 점수 배점은 60 * (해당 학기의 성적이 있는 예체능 교과 수 / 성적이 있는 총 예체능 교과 수)으로 계산
         BigDecimal allocation = BigDecimal.valueOf(60)
                 .multiply(
                         BigDecimal.valueOf(achievementCount).divide(BigDecimal.valueOf(allAchievementCount), 10, RoundingMode.HALF_UP)
                 );
-
-        if (achievementCount == 0) {
-            return BigDecimal.ZERO;
-        }
 
         return BigDecimal.valueOf(sum)
                 .divide(BigDecimal.valueOf(achievementCount).multiply(BigDecimal.valueOf(5)), 10, RoundingMode.HALF_UP)

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelService.java
@@ -177,7 +177,15 @@ public class DownloadExcelService {
     }
 
     private BigDecimal calculateFinalScore(EntranceTestResult entranceTestResult) {
-        if (entranceTestResult.getSecondTestPassYn() == null) {
+
+        BigDecimal aptitudeEvaluationScore = entranceTestResult.getAptitudeEvaluationScore();
+        BigDecimal interviewScore = entranceTestResult.getInterviewScore();
+
+        if (
+                entranceTestResult.getSecondTestPassYn() == null
+                        || aptitudeEvaluationScore == null
+                        || interviewScore == null
+        ) {
             return null;
         }
 
@@ -185,8 +193,8 @@ public class DownloadExcelService {
                 .divide(BigDecimal.valueOf(3), 3, RoundingMode.HALF_UP);
 
         return documentEvaluationScore.multiply(BigDecimal.valueOf(0.5))
-                .add(entranceTestResult.getAptitudeEvaluationScore().multiply(BigDecimal.valueOf(0.3)))
-                .add(entranceTestResult.getInterviewScore().multiply(BigDecimal.valueOf(0.2)))
+                .add(aptitudeEvaluationScore.multiply(BigDecimal.valueOf(0.3)))
+                .add(interviewScore.multiply(BigDecimal.valueOf(0.2)))
                 .setScale(3, RoundingMode.HALF_UP);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
   jpa:
     database-platform: ${DB_PLATFORM}
     hibernate:
-      ddl-auto: ${HIBERNATE_DDL_AUTO}
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
   jpa:
     database-platform: ${DB_PLATFORM}
     hibernate:
-      ddl-auto: none
+      ddl-auto: ${HIBERNATE_DDL_AUTO}
     show-sql: true
     properties:
       hibernate:

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberServiceTest.java
@@ -14,6 +14,7 @@ import team.themoment.hellogsmv3.domain.member.entity.type.AuthReferrerType;
 import team.themoment.hellogsmv3.domain.member.entity.type.Role;
 import team.themoment.hellogsmv3.domain.member.entity.type.Sex;
 import team.themoment.hellogsmv3.domain.member.repo.MemberRepository;
+import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
@@ -40,6 +41,8 @@ class CreateMemberServiceTest {
     private ScheduleEnvironment scheduleEnvironment;
     @Mock
     private OneseoRepository oneseoRepository;
+    @Mock
+    private EntranceTestResultRepository entranceTestResultRepository;
     @Mock
     private CommonCodeService commonCodeService;
     @InjectMocks
@@ -81,6 +84,7 @@ class CreateMemberServiceTest {
                 given(memberService.findByIdOrThrow(memberId)).willReturn(existingMember);
                 given(scheduleEnvironment.oneseoSubmissionEnd()).willReturn(LocalDateTime.of(9999, Month.OCTOBER, 10, 10, 10));
                 given(memberRepository.findByPhoneNumber(reqDto.phoneNumber())).willReturn(Optional.empty());
+                given(entranceTestResultRepository.existsByFirstTestPassYnIsNotNull()).willReturn(false);
                 willDoNothing().given(commonCodeService).validateAndDelete(memberId, reqDto.code(), reqDto.phoneNumber());
             }
 


### PR DESCRIPTION
## 개요

fdfcbde24f27a50e940ae1f50e662362ddbcc36e
- 예체능 점수 모두 없음(0)으로 입력시 개별학기 환산점 계산로직에서 `0 / 0` 계산이 발생(500에러)하는 문제 해결

fe202193fd56ce859bc57ac90bdedc14e0e92469
- 원서 출력시 평가점수(인적성, 면접)가 null이라면 환산총점을 계산하지 않도록 수정

57260559698627c9d140f5836b6cbc3e59d49a3d
- 비교과 점수(출결, 봉사점수) 음수 입력 validate 메서드 추가

## 수정사항
fb37df6e6bef83beb3edc013db4b1f90daa1c427
- 접수기간 이후에는 회원정보 삭제되지 않도록 더 안전하게 조건식을 추가하였습니다.

2a96853d1284c8d464779740f74b64a95ba8d8da
- 성적 계산식에서 validate 하는 로직을 메서드로 분리하여 개선하였습니다.