### PR TITLE
[oneseo] 원서 작성시 디스코드 알림 전송 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,19 @@ dependencies {
 
     /** logging **/
     implementation group: 'ca.pjer', name: 'logback-awslogs-appender', version: '1.6.0'
+
+    /** open feign **/
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+}
+
+ext {
+    set('springCloudVersion', "2021.0.1")
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 def querydslSrcDir = "$projectDir/build/generated"

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ dependencies {
 }
 
 ext {
-    set('springCloudVersion', "2021.0.1")
+    set('springCloudVersion', "2022.0.3")
 }
 
 dependencyManagement {

--- a/src/main/java/team/themoment/hellogsmv3/HelloGsmV3Application.java
+++ b/src/main/java/team/themoment/hellogsmv3/HelloGsmV3Application.java
@@ -3,7 +3,9 @@ package team.themoment.hellogsmv3;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @EnableJpaAuditing
 @SpringBootApplication
 public class HelloGsmV3Application {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/event/OneseoApplyEvent.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/event/OneseoApplyEvent.java
@@ -1,0 +1,19 @@
+package team.themoment.hellogsmv3.domain.oneseo.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class OneseoApplyEvent {
+    private String name;
+    private String summitCode;
+    private GraduationType graduationType;
+    private Screening screening;
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/event/handler/OneseoApplyEventHandler.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/event/handler/OneseoApplyEventHandler.java
@@ -1,0 +1,87 @@
+package team.themoment.hellogsmv3.domain.oneseo.event.handler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
+import team.themoment.hellogsmv3.domain.oneseo.event.OneseoApplyEvent;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.request.DiscordAlarmReqDto;
+import team.themoment.hellogsmv3.global.thirdParty.feign.client.type.Env;
+import team.themoment.hellogsmv3.global.thirdParty.feign.service.DiscordAlarmFeignClientService;
+
+import static team.themoment.hellogsmv3.global.thirdParty.feign.client.type.Env.prod;
+import static team.themoment.hellogsmv3.global.thirdParty.feign.client.type.Env.dev;
+import static team.themoment.hellogsmv3.global.thirdParty.feign.client.type.NoticeLevel.*;
+
+@Component
+@RequiredArgsConstructor
+public class OneseoApplyEventHandler {
+
+    private final OneseoRepository oneseoRepository;
+    private final DiscordAlarmFeignClientService discordAlarmFeignClientService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void sendDiscordAlarm(OneseoApplyEvent oneseoApplyEvent) {
+
+        String title = makeTitle(oneseoApplyEvent);
+        String content = makeContent(oneseoApplyEvent);
+        Env env = getEnv();
+
+        DiscordAlarmReqDto reqDto = buildReqDto(title, content, env);
+
+        discordAlarmFeignClientService.send(reqDto);
+    }
+
+    private DiscordAlarmReqDto buildReqDto(String title, String content, Env env) {
+        return DiscordAlarmReqDto.builder()
+                .title(title)
+                .content(content)
+                .noticeLevel(info)
+                .env(env)
+                .build();
+    }
+
+    private String makeTitle(OneseoApplyEvent oneseoApplyEvent) {
+        String summitCode = oneseoApplyEvent.getSummitCode();
+
+        return String.format(
+                "원서가 작성되었습니다! [%s]",
+                summitCode
+        );
+    }
+
+    private String makeContent(OneseoApplyEvent oneseoApplyEvent) {
+        long count = oneseoRepository.count();
+
+        String name = oneseoApplyEvent.getName().substring(0, 1);
+        String masking = "#".repeat(oneseoApplyEvent.getName().substring(1).length());
+
+        String graduationType = switch (oneseoApplyEvent.getGraduationType()) {
+            case CANDIDATE -> "졸업예정자";
+            case GRADUATE -> "졸업자";
+            case GED -> "검정고시 응시자";
+        };
+
+        String screening = switch (oneseoApplyEvent.getScreening()) {
+            case GENERAL -> "일반전형";
+            case SPECIAL -> "특별전형";
+            case EXTRA_ADMISSION, EXTRA_VETERANS -> "정원 외 특별전형";
+        };
+
+        return String.format(
+                "### 이름 \n%s%s \n### 졸업상태 \n%s \n### 전형 \n%s \n### 현재 작성된 원서 수 \n%s개",
+                name, masking, graduationType, screening, count
+        );
+    }
+
+    private Env getEnv() {
+        String profile = System.getProperty("spring.profiles.active");
+        Env env = profile.equals("prod") ? prod : dev;
+        return env;
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/event/handler/OneseoApplyEventHandler.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/event/handler/OneseoApplyEventHandler.java
@@ -5,8 +5,6 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
-import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
-import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import team.themoment.hellogsmv3.domain.oneseo.event.OneseoApplyEvent;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.request.DiscordAlarmReqDto;

--- a/src/main/java/team/themoment/hellogsmv3/global/security/data/HeaderConstant.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/data/HeaderConstant.java
@@ -1,12 +1,6 @@
 package team.themoment.hellogsmv3.global.security.data;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
-public enum HeaderConstant {
-    X_HG_ENV("X-HG-ENV");
-
-    private final String content;
+public interface HeaderConstant {
+    String X_HG_ENV = "X-HG-ENV";
+    String X_HG_API_KEY = "x-hg-api-key";
 }

--- a/src/main/java/team/themoment/hellogsmv3/global/security/handler/CustomUrlAuthenticationSuccessHandler.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/handler/CustomUrlAuthenticationSuccessHandler.java
@@ -30,7 +30,7 @@ public class CustomUrlAuthenticationSuccessHandler implements AuthenticationSucc
         boolean isAdmin = authentication.getAuthorities().stream()
                 .anyMatch(authority -> Role.ADMIN.name().equals(authority.getAuthority()));
 
-        String dryrun = request.getHeader(X_HG_ENV.getContent());
+        String dryrun = request.getHeader(X_HG_ENV);
         boolean isDryrun = Boolean.parseBoolean(dryrun != null ? dryrun : "false");
 
         String redirectUrlWithParameter = UriComponentsBuilder

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/client/DiscordAlarmClient.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/client/DiscordAlarmClient.java
@@ -1,0 +1,13 @@
+package team.themoment.hellogsmv3.global.thirdParty.feign.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "discord-alarm-client", url = "${discord-alarm.url}")
+public interface DiscordAlarmClient {
+    @PostMapping
+    void sendAlarm(
+            @RequestBody DiscordAlarmClient reqDto
+    );
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/client/DiscordAlarmClient.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/client/DiscordAlarmClient.java
@@ -3,11 +3,12 @@ package team.themoment.hellogsmv3.global.thirdParty.feign.client;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.request.DiscordAlarmReqDto;
 
 @FeignClient(name = "discord-alarm-client", url = "${discord-alarm.url}")
 public interface DiscordAlarmClient {
-    @PostMapping
+    @PostMapping("/notice")
     void sendAlarm(
-            @RequestBody DiscordAlarmClient reqDto
+            @RequestBody DiscordAlarmReqDto reqDto
     );
 }

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/client/DiscordAlarmClient.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/client/DiscordAlarmClient.java
@@ -3,12 +3,16 @@ package team.themoment.hellogsmv3.global.thirdParty.feign.client;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.request.DiscordAlarmReqDto;
+
+import static team.themoment.hellogsmv3.global.security.data.HeaderConstant.*;
 
 @FeignClient(name = "discord-alarm-client", url = "${discord-alarm.url}")
 public interface DiscordAlarmClient {
     @PostMapping("/notice")
     void sendAlarm(
-            @RequestBody DiscordAlarmReqDto reqDto
+            @RequestBody DiscordAlarmReqDto reqDto,
+            @RequestHeader(X_HG_API_KEY) String apiKey
     );
 }

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/client/dto/request/DiscordAlarmReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/client/dto/request/DiscordAlarmReqDto.java
@@ -1,0 +1,15 @@
+package team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import team.themoment.hellogsmv3.global.thirdParty.feign.client.type.Env;
+import team.themoment.hellogsmv3.global.thirdParty.feign.client.type.NoticeLevel;
+
+@Getter
+@AllArgsConstructor
+public class DiscordAlarmReqDto {
+    private String title;
+    private String content;
+    private NoticeLevel noticeLevel;
+    private Env env;
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/client/dto/request/DiscordAlarmReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/client/dto/request/DiscordAlarmReqDto.java
@@ -1,11 +1,13 @@
 package team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.request;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.type.Env;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.type.NoticeLevel;
 
 @Getter
+@Builder
 @AllArgsConstructor
 public class DiscordAlarmReqDto {
     private String title;

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/client/type/Env.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/client/type/Env.java
@@ -6,8 +6,6 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Env {
-    DEV("dev"),
-    PROD("prod");
-
-    private final String content;
+    dev,
+    prod
 }

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/client/type/Env.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/client/type/Env.java
@@ -1,0 +1,13 @@
+package team.themoment.hellogsmv3.global.thirdParty.feign.client.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Env {
+    DEV("dev"),
+    PROD("prod");
+
+    private final String content;
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/client/type/NoticeLevel.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/client/type/NoticeLevel.java
@@ -1,0 +1,14 @@
+package team.themoment.hellogsmv3.global.thirdParty.feign.client.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NoticeLevel {
+    INFO("info"),
+    WARN("warn"),
+    ERROR("error");
+
+    private final String content;
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/client/type/NoticeLevel.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/client/type/NoticeLevel.java
@@ -6,9 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum NoticeLevel {
-    INFO("info"),
-    WARN("warn"),
-    ERROR("error");
-
-    private final String content;
+    info,
+    dev,
+    prod
 }

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/config/FeignConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/config/FeignConfig.java
@@ -1,0 +1,14 @@
+package team.themoment.hellogsmv3.global.thirdParty.feign.config;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@EnableFeignClients(basePackages = "team.themoment.hellogsmv3")
+@Configuration
+public class FeignConfig {
+    @Bean
+    public FeignErrorDecoder feignErrorDecoder() {
+        return new FeignErrorDecoder();
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/config/FeignErrorDecoder.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/config/FeignErrorDecoder.java
@@ -5,6 +5,7 @@ import feign.Response;
 import feign.codec.ErrorDecoder;
 import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+import team.themoment.hellogsmv3.global.security.data.HeaderConstant;
 
 public class FeignErrorDecoder implements ErrorDecoder {
     @Override
@@ -13,6 +14,7 @@ public class FeignErrorDecoder implements ErrorDecoder {
         if (status >= 400) {
             switch (status) {
                 case 400 -> throw new ExpectedException(response.reason(), HttpStatus.BAD_REQUEST);
+                case 401 -> throw new ExpectedException(response.reason(), HttpStatus.UNAUTHORIZED);
                 default -> throw new ExpectedException(response.reason(), HttpStatus.INTERNAL_SERVER_ERROR);
             }
         }

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/config/FeignErrorDecoder.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/config/FeignErrorDecoder.java
@@ -1,0 +1,21 @@
+package team.themoment.hellogsmv3.global.thirdParty.feign.config;
+
+import feign.FeignException;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import org.springframework.http.HttpStatus;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+public class FeignErrorDecoder implements ErrorDecoder {
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        int status = response.status();
+        if (status >= 400) {
+            switch (status) {
+                case 400 -> throw new ExpectedException(response.reason(), HttpStatus.BAD_REQUEST);
+                default -> throw new ExpectedException(response.reason(), HttpStatus.INTERNAL_SERVER_ERROR);
+            }
+        }
+        return FeignException.errorStatus(methodKey, response);
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/service/DiscordAlarmFeignClientService.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/service/DiscordAlarmFeignClientService.java
@@ -1,6 +1,7 @@
 package team.themoment.hellogsmv3.global.thirdParty.feign.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.DiscordAlarmClient;
 import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.request.DiscordAlarmReqDto;
@@ -11,7 +12,10 @@ public class DiscordAlarmFeignClientService {
 
     private final DiscordAlarmClient discordAlarmClient;
 
+    @Value("${discord-alarm.api-key}")
+    private String apiKey;
+
     public void send(DiscordAlarmReqDto reqDto) {
-        discordAlarmClient.sendAlarm(reqDto);
+        discordAlarmClient.sendAlarm(reqDto, apiKey);
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/service/DiscordAlarmFeignClientService.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/thirdParty/feign/service/DiscordAlarmFeignClientService.java
@@ -1,0 +1,17 @@
+package team.themoment.hellogsmv3.global.thirdParty.feign.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import team.themoment.hellogsmv3.global.thirdParty.feign.client.DiscordAlarmClient;
+import team.themoment.hellogsmv3.global.thirdParty.feign.client.dto.request.DiscordAlarmReqDto;
+
+@Component
+@RequiredArgsConstructor
+public class DiscordAlarmFeignClientService {
+
+    private final DiscordAlarmClient discordAlarmClient;
+
+    public void send(DiscordAlarmReqDto reqDto) {
+        discordAlarmClient.sendAlarm(reqDto);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -126,3 +126,4 @@ management:
 
 discord-alarm:
   url: ${DISCORD_RELAY_SERVER_URL}
+  api-key: ${DISCORD_RELAY_SERVER_API_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -123,3 +123,6 @@ management:
       exposure:
         include: health
       base-path: ${ACTUATOR_BASE_PATH}
+
+discord-alarm:
+  url: ${DISCORD_RELAY_SERVER_URL}


### PR DESCRIPTION
## 개요

원서 작성시 디스코드 알림을 전송하는 기능을 추가하였습니다.

## 본문

open feign client를 사용해서 디스코드 relay server API로 알림을 전송하도록 구현하였습니다.

원서 생성 서비스 클래스 원서 생성 이벤트 publish -> 원서 생성 이벤트 핸들러(원서 생성 커밋 후 실행)에서 비동기로 feign client 호출 -> 디스코드 알림 전송

<img width="294" alt="스크린샷 2024-10-10 오후 5 13 42" src="https://github.com/user-attachments/assets/73c810b0-83a5-4f78-b99c-2a71c81fc9b4">
