### PR TITLE
[oneseo] 원서 생성 테스트코드 수정 및 불변객체 모킹 라이브러리 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 
     /** test **/
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mockito:mockito-inline:4.9.0'
 
     /** validation **/
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
@@ -50,6 +51,8 @@ class CreateOneseoServiceTest {
     private MemberService memberService;
     @Mock
     private OneseoService oneseoService;
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
     @Mock
     private CalculateGradeService calculateGradeService;
     @Mock


### PR DESCRIPTION
## 개요

- #192 해당 PR 변경사항에 대한 테스트코드를 수정하였습니다.
- 불변객체(record)는 mockito에서 기본적으로 모킹할 수 없어 mockito-inlin 라이브러리를 추가하였습니다.