### PR TITLE
[global] prod docker file에 system time 서울 시간대로 설정하는 커멘드 추가

### DIFF
--- a/DockerfileProd
+++ b/DockerfileProd
@@ -6,4 +6,6 @@ ARG JAR_FILE=build/libs/*.jar
 
 COPY ${JAR_FILE} hellogsm-prod-server.jar
 
+RUN ln -snf /usr/share/zoneinfo/Asia/Seoul /etc/localtime
+
 ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=prod", "hellogsm-prod-server.jar"]


### PR DESCRIPTION
## 개요

prod docker file 컨테이너 실행시 system time 서울 시간대로 설정하는 커멘드를 추가하였습니다.