### PR TITLE
[oneseo] 원서 생성 트랜잭션 고립도 SERIALIZABLE로 설정하여 동시성 문제 방지

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/member/entity/Member.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/entity/Member.java
@@ -26,7 +26,7 @@ public class Member {
     @Column(name = "member_id")
     private Long id;
 
-    @Column(name = "email", unique = true, nullable = false)
+    @Column(name = "email", nullable = false)
     private String email;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/Oneseo.java
@@ -45,6 +45,7 @@ public class Oneseo {
     @OneToOne(mappedBy = "oneseo", cascade = CascadeType.ALL, orphanRemoval = true)
     private MiddleSchoolAchievement middleSchoolAchievement;
 
+    @Builder.Default
     @OneToMany(mappedBy = "oneseo", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<WantedScreeningChangeHistory> wantedScreeningChangeHistory = new ArrayList<>();
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -16,7 +16,6 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.OneseoPrivacyDetail;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.DesiredMajors;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType;
-import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import team.themoment.hellogsmv3.domain.oneseo.event.OneseoApplyEvent;
 import team.themoment.hellogsmv3.domain.oneseo.repository.MiddleSchoolAchievementRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoPrivacyDetailRepository;
@@ -25,6 +24,7 @@ import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.util.List;
 
+import static org.springframework.transaction.annotation.Isolation.*;
 import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.*;
 import static team.themoment.hellogsmv3.domain.oneseo.service.OneseoService.isValidMiddleSchoolInfo;
 
@@ -41,7 +41,7 @@ public class CreateOneseoService {
     private final OneseoService oneseoService;
     private final ApplicationEventPublisher applicationEventPublisher;
 
-    @Transactional
+    @Transactional(isolation = SERIALIZABLE)
     @CachePut(value = OneseoService.ONESEO_CACHE_VALUE, key = "#memberId")
     public FoundOneseoResDto execute(OneseoReqDto reqDto, Long memberId) {
 


### PR DESCRIPTION
## 개요

원서 생성 로직 트랜잭션의 고립도를 4단계(SERIALIZABLE)로 설정하여 동시성 문제가 발생하지 못하도록 막았습니다.
- 원서 생성은 자주 발생하는 작업이 아니기 때문에 데드락이 발생할 수 있어도 안정성을 위해 고수준의 고립도를 설정하여 동시성 문제를 방지하였습니다.

## 변경사항
- 원서 엔티티에 1:N 매핑 관계인 필드의 기본값을 설정하기 위해 @Builder.Default 어노테이션을 설정하였습니다.
- 지원자의 email은 겹칠 수 있기 때문에 JPA 매핑 설정 정보에서 유니크 조건을 제거하였습니다.