### PR TITLE
[oneseo] 원서 생성 로직 실행중 데드락 발생시 retry 어노테이션 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     /** persistence **/
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.retry:spring-retry'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     /** queryDsl **/

--- a/src/main/java/team/themoment/hellogsmv3/HelloGsmV3Application.java
+++ b/src/main/java/team/themoment/hellogsmv3/HelloGsmV3Application.java
@@ -3,9 +3,11 @@ package team.themoment.hellogsmv3;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
+@EnableRetry
 @EnableAsync
 @EnableJpaAuditing
 @SpringBootApplication

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -3,7 +3,10 @@ package team.themoment.hellogsmv3.domain.oneseo.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.http.HttpStatus;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
@@ -41,6 +44,10 @@ public class CreateOneseoService {
     private final OneseoService oneseoService;
     private final ApplicationEventPublisher applicationEventPublisher;
 
+    @Retryable(
+            value = {CannotAcquireLockException.class},
+            maxAttempts = 2,
+            backoff = @Backoff(delay = 1000))
     @Transactional(isolation = SERIALIZABLE)
     @CachePut(value = OneseoService.ONESEO_CACHE_VALUE, key = "#memberId")
     public FoundOneseoResDto execute(OneseoReqDto reqDto, Long memberId) {


### PR DESCRIPTION
## 개요

원서 생성 트랜잭션의 고립도는 SERIALIZABLE로 가장 고수준으로 설정되어있습니다. 그렇기 때문에 동일한 트랜잭션 작업시 데드락이 발생할 수 있어 스프링 retry 라이브러리를 사용해서 데드락 발생시 트랜잭션을 재시도 하게 개선하였습니다.

<img width="593" alt="스크린샷 2024-10-15 오후 6 01 37" src="https://github.com/user-attachments/assets/3a53470a-120e-4dc8-b3dd-2b2095557bae">

> 재시도 기능 추가 전, 원서 생성을 빠르게 두번 했다면 데드락이 발생하여 한쪽에서 500에러 발생

<img width="593" alt="스크린샷 2024-10-15 오후 6 02 05" src="https://github.com/user-attachments/assets/2831d91c-04e6-4015-a75a-d60b63198f27">

> 재시도 기능 추가 후, 원서 생성을 빠르게 두번 해서 데드락 발생시 한쪽 트랜잭션이 1000ms를 기다리고 최대 2번 재시도를 진행해서 정상적으로 원서 생성 후 중복 원서 예외 발생
