### PR TITLE
[test-result] 결과 조회 기능 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/controller/TestResultController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/controller/TestResultController.java
@@ -34,8 +34,8 @@ public class TestResultController {
             @AuthRequest Long memberId,
             @RequestBody @Valid GenerateCodeReqDto reqDto
     ) {
-        String code = generateTestResultCodeService.execute(memberId, reqDto);
-        return CommonApiResponse.success("전송되었습니다." + code);
+        generateTestResultCodeService.execute(memberId, reqDto);
+        return CommonApiResponse.success("전송되었습니다.");
     }
 
     @Operation(summary = "인증코드 인증", description = "인증코드를 요청받아 인증을 진행합니다.")

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/controller/TestResultController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/controller/TestResultController.java
@@ -1,0 +1,73 @@
+package team.themoment.hellogsmv3.domain.common.testResult.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import team.themoment.hellogsmv3.domain.common.testResult.dto.request.FoundTestResultReqDto;
+import team.themoment.hellogsmv3.domain.common.testResult.dto.response.FoundTestResultResDto;
+import team.themoment.hellogsmv3.domain.common.testResult.service.QueryTestResultService;
+import team.themoment.hellogsmv3.domain.common.testResult.service.impl.GenerateTestResultCodeServiceImpl;
+import team.themoment.hellogsmv3.domain.member.dto.request.AuthenticateCodeReqDto;
+import team.themoment.hellogsmv3.domain.member.dto.request.GenerateCodeReqDto;
+import team.themoment.hellogsmv3.domain.member.service.AuthenticateCodeService;
+import team.themoment.hellogsmv3.global.common.handler.annotation.AuthRequest;
+import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
+
+import static team.themoment.hellogsmv3.domain.common.testResult.type.TestType.*;
+import static team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType.TEST_RESULT;
+
+@RestController
+@RequestMapping("/test-result/v3")
+@RequiredArgsConstructor
+public class TestResultController {
+
+    private final QueryTestResultService queryTestResultService;
+    private final AuthenticateCodeService authenticateCodeService;
+    private final GenerateTestResultCodeServiceImpl generateTestResultCodeService;
+
+    @Operation(summary = "인증코드 전송", description = "전화번호를 요청받아 인증코드를 전송합니다.")
+    @PostMapping("/send-code")
+    public CommonApiResponse sendCode(
+            @AuthRequest Long memberId,
+            @RequestBody @Valid GenerateCodeReqDto reqDto
+    ) {
+        String code = generateTestResultCodeService.execute(memberId, reqDto);
+        return CommonApiResponse.success("전송되었습니다." + code);
+    }
+
+    @Operation(summary = "인증코드 인증", description = "인증코드를 요청받아 인증을 진행합니다.")
+    @PostMapping("/auth-code")
+    public CommonApiResponse authCode(
+            @AuthRequest Long memberId,
+            @RequestBody @Valid AuthenticateCodeReqDto reqDto
+    ) {
+        authenticateCodeService.execute(memberId, reqDto, TEST_RESULT);
+        return CommonApiResponse.success("인증되었습니다.");
+    }
+
+    @Operation(summary = "1차 전형 결과 조회", description = "학부모 or 부모님의 전화번호와 접수번호의 조합으로 1차 전형의 결과를 조회합니다.")
+    @GetMapping("/first-test")
+    public FoundTestResultResDto foundFirstTestResult(
+            @AuthRequest Long memberId,
+            @RequestParam("phoneNumber") @NotNull String phoneNumber,
+            @RequestParam("code") @NotNull String code,
+            @RequestParam("submitCode") @NotNull String submitCode
+    ) {
+        return queryTestResultService.execute(memberId, code, phoneNumber, submitCode, FIRST);
+    }
+
+    @Operation(summary = "2차 전형 결과 조회", description = "학부모 or 부모님의 전화번호와 수험번호의 조합으로 2차 전형의 결과를 조회합니다.")
+    @GetMapping("/second-test")
+    public FoundTestResultResDto foundSecondTestResult(
+            @AuthRequest Long memberId,
+            @RequestParam("phoneNumber") @NotNull String phoneNumber,
+            @RequestParam("code") @NotNull String code,
+            @RequestParam("examinationNumber") @NotNull String examinationNumber
+    ) {
+        return queryTestResultService.execute(memberId, code, phoneNumber, examinationNumber, SECOND);
+    }
+
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/dto/request/FoundTestResultReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/dto/request/FoundTestResultReqDto.java
@@ -1,0 +1,12 @@
+package team.themoment.hellogsmv3.domain.common.testResult.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record FoundTestResultReqDto(
+        @Pattern(regexp = "^0(?:\\d|\\d{2})(?:\\d{3}|\\d{4})\\d{4}$")
+        @NotNull String phoneNumber,
+        @NotNull String code,
+        @NotNull String submitCode
+) {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/dto/request/FoundTestResultReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/dto/request/FoundTestResultReqDto.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
 public record FoundTestResultReqDto(
-
         @NotNull String phoneNumber,
         @NotNull String code,
         @NotNull String submitCode

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/dto/request/FoundTestResultReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/dto/request/FoundTestResultReqDto.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
 public record FoundTestResultReqDto(
-        @Pattern(regexp = "^0(?:\\d|\\d{2})(?:\\d{3}|\\d{4})\\d{4}$")
+
         @NotNull String phoneNumber,
         @NotNull String code,
         @NotNull String submitCode

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/dto/response/FoundTestResultResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/dto/response/FoundTestResultResDto.java
@@ -1,0 +1,18 @@
+package team.themoment.hellogsmv3.domain.common.testResult.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.*;
+
+@Builder
+@JsonInclude(NON_NULL)
+public record FoundTestResultResDto(
+        String name,
+        YesNo firstTestPassYn,
+        YesNo secondTestPassYn,
+        Major decidedMajor
+) {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/service/QueryTestResultService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/service/QueryTestResultService.java
@@ -1,0 +1,56 @@
+package team.themoment.hellogsmv3.domain.common.testResult.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import team.themoment.hellogsmv3.domain.common.testResult.dto.request.FoundTestResultReqDto;
+import team.themoment.hellogsmv3.domain.common.testResult.dto.response.FoundTestResultResDto;
+import team.themoment.hellogsmv3.domain.common.testResult.type.TestType;
+import team.themoment.hellogsmv3.domain.member.service.CommonCodeService;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+import static team.themoment.hellogsmv3.domain.common.testResult.type.TestType.*;
+import static team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType.TEST_RESULT;
+
+@Service
+@RequiredArgsConstructor
+public class QueryTestResultService {
+
+    private final OneseoRepository oneseoRepository;
+    private final CommonCodeService commonCodeService;
+
+    protected FoundTestResultResDto execute(FoundTestResultReqDto reqDto, TestType testType) {
+        commonCodeService.validateAndDelete(reqDto.code(), reqDto.phoneNumber(), TEST_RESULT);
+
+        validateSubmitCodeIsNotNull(reqDto.submitCode());
+        Oneseo findOneseo = findOneseo(reqDto);
+
+        return getResDto(findOneseo, testType);
+    }
+
+    private FoundTestResultResDto getResDto(Oneseo findOneseo, TestType testType) {
+        return testType.equals(FIRST)
+                ? FoundTestResultResDto.builder()
+                    .name(findOneseo.getMember().getName())
+                    .firstTestPassYn(findOneseo.getEntranceTestResult().getFirstTestPassYn())
+                    .build()
+                : FoundTestResultResDto.builder()
+                    .name(findOneseo.getMember().getName())
+                    .secondTestPassYn(findOneseo.getEntranceTestResult().getSecondTestPassYn())
+                    .decidedMajor(findOneseo.getDecidedMajor())
+                    .build();
+    }
+
+    private void validateSubmitCodeIsNotNull(String submitCode) {
+        if (submitCode == null) {
+            throw new ExpectedException("접수번호를 입력해주세요.", HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private Oneseo findOneseo(FoundTestResultReqDto reqDto) {
+        return oneseoRepository.findByGuardianOrTeacherPhoneNumberAndSubmitCode(reqDto.phoneNumber(), reqDto.submitCode())
+                .orElseThrow(() -> new ExpectedException("해당 전화번호, 접수번호로 작성된 원서를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST));
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/service/QueryTestResultService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/service/QueryTestResultService.java
@@ -3,12 +3,12 @@ package team.themoment.hellogsmv3.domain.common.testResult.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import team.themoment.hellogsmv3.domain.common.testResult.dto.request.FoundTestResultReqDto;
 import team.themoment.hellogsmv3.domain.common.testResult.dto.response.FoundTestResultResDto;
 import team.themoment.hellogsmv3.domain.common.testResult.type.TestType;
 import team.themoment.hellogsmv3.domain.member.service.CommonCodeService;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.hellogsmv3.domain.oneseo.service.OneseoService;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import static team.themoment.hellogsmv3.domain.common.testResult.type.TestType.*;
@@ -18,39 +18,59 @@ import static team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType.T
 @RequiredArgsConstructor
 public class QueryTestResultService {
 
+    private final OneseoService oneseoService;
     private final OneseoRepository oneseoRepository;
     private final CommonCodeService commonCodeService;
 
-    protected FoundTestResultResDto execute(FoundTestResultReqDto reqDto, TestType testType) {
-        commonCodeService.validateAndDelete(reqDto.code(), reqDto.phoneNumber(), TEST_RESULT);
+    public FoundTestResultResDto execute(Long memberId, String code, String phoneNumber, String oneseoCode, TestType testType) {
+        validateTesResultAnnouncement(testType);
 
-        validateSubmitCodeIsNotNull(reqDto.submitCode());
-        Oneseo findOneseo = findOneseo(reqDto);
+        Oneseo findOneseo = findOneseo(phoneNumber, oneseoCode, testType);
+        commonCodeService.validateAndDelete(memberId, code, phoneNumber, TEST_RESULT);
 
         return getResDto(findOneseo, testType);
     }
 
-    private FoundTestResultResDto getResDto(Oneseo findOneseo, TestType testType) {
-        return testType.equals(FIRST)
-                ? FoundTestResultResDto.builder()
-                    .name(findOneseo.getMember().getName())
-                    .firstTestPassYn(findOneseo.getEntranceTestResult().getFirstTestPassYn())
-                    .build()
-                : FoundTestResultResDto.builder()
-                    .name(findOneseo.getMember().getName())
-                    .secondTestPassYn(findOneseo.getEntranceTestResult().getSecondTestPassYn())
-                    .decidedMajor(findOneseo.getDecidedMajor())
-                    .build();
-    }
-
-    private void validateSubmitCodeIsNotNull(String submitCode) {
-        if (submitCode == null) {
-            throw new ExpectedException("접수번호를 입력해주세요.", HttpStatus.BAD_REQUEST);
+    private void validateTesResultAnnouncement(TestType testType) {
+        if (testType.equals(FIRST)) {
+            if (oneseoService.validateFirstTestResultAnnouncement()) {
+                throw new ExpectedException("1차 전형 결과 발표 전 입니다.", HttpStatus.BAD_REQUEST);
+            }
+        } else {
+            if (oneseoService.validateSecondTestResultAnnouncement()) {
+                throw new ExpectedException("2차 전형 결과 발표 전 입니다.", HttpStatus.BAD_REQUEST);
+            }
         }
     }
 
-    private Oneseo findOneseo(FoundTestResultReqDto reqDto) {
-        return oneseoRepository.findByGuardianOrTeacherPhoneNumberAndSubmitCode(reqDto.phoneNumber(), reqDto.submitCode())
-                .orElseThrow(() -> new ExpectedException("해당 전화번호, 접수번호로 작성된 원서를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST));
+    private Oneseo findOneseo(String phoneNumber, String oneseoCode, TestType testType) {
+        // 1차 전형 결과 조회에는 접수번호, 2차 전형 결과 조회에는 수험번호로 조회
+
+        return testType.equals(FIRST)
+        ? oneseoRepository.findByGuardianOrTeacherPhoneNumberAndSubmitCode(phoneNumber, oneseoCode)
+                .orElseThrow(() -> new ExpectedException("해당 전화번호, 접수번호로 작성된 원서를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST))
+        : oneseoRepository.findByGuardianOrTeacherPhoneNumberAndExaminationNumber(phoneNumber, oneseoCode)
+                .orElseThrow(() -> new ExpectedException("해당 전화번호, 수험번호로 작성된 원서를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST));
+    }
+
+    private FoundTestResultResDto getResDto(Oneseo findOneseo, TestType testType) {
+        return testType.equals(FIRST)
+                ? buildFirstTestResultResDto(findOneseo)
+                : buildSecondTestResultResDto(findOneseo);
+    }
+
+    private FoundTestResultResDto buildFirstTestResultResDto(Oneseo findOneseo) {
+        return FoundTestResultResDto.builder()
+                .name(findOneseo.getMember().getName())
+                .firstTestPassYn(findOneseo.getEntranceTestResult().getFirstTestPassYn())
+                .build();
+    }
+
+    private FoundTestResultResDto buildSecondTestResultResDto(Oneseo findOneseo) {
+        return FoundTestResultResDto.builder()
+                .name(findOneseo.getMember().getName())
+                .secondTestPassYn(findOneseo.getEntranceTestResult().getSecondTestPassYn())
+                .decidedMajor(findOneseo.getDecidedMajor())
+                .build();
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/service/impl/GenerateTestResultCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/service/impl/GenerateTestResultCodeServiceImpl.java
@@ -44,7 +44,7 @@ public class GenerateTestResultCodeServiceImpl extends GenerateCodeService {
                 TEST_RESULT,
                 false));
 
-//        sendCodeNotificationService.execute(phoneNumber, code);
+        sendCodeNotificationService.execute(phoneNumber, code);
 
         return code;
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/service/impl/GenerateTestResultCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/service/impl/GenerateTestResultCodeServiceImpl.java
@@ -1,4 +1,4 @@
-package team.themoment.hellogsmv3.domain.member.service.impl;
+package team.themoment.hellogsmv3.domain.common.testResult.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -12,20 +12,20 @@ import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.util.Random;
 
-import static team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType.*;
+import static team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType.TEST_RESULT;
 
 @Service
 @RequiredArgsConstructor
-public class GenerateCodeServiceImpl extends GenerateCodeService {
+public class GenerateTestResultCodeServiceImpl extends GenerateCodeService {
 
     private final CodeRepository codeRepository;
     private final SendCodeNotificationService sendCodeNotificationService;
     private static final Random RANDOM = new Random();
 
     @Override
-    public String execute(Long memberId, GenerateCodeReqDto reqDto) {
+    protected String execute(Long memberId, GenerateCodeReqDto reqDto) {
 
-        AuthenticationCode authenticationCode = codeRepository.findByMemberId(memberId)
+        AuthenticationCode authenticationCode = codeRepository.findByMemberIdAndAuthCodeType(memberId, TEST_RESULT)
                 .orElse(null);
 
         if (isLimitedRequest(authenticationCode))
@@ -42,7 +42,7 @@ public class GenerateCodeServiceImpl extends GenerateCodeService {
                 memberId,
                 code,
                 phoneNumber,
-                SIGNUP,
+                TEST_RESULT,
                 false));
 
         sendCodeNotificationService.execute(phoneNumber, code);

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/service/impl/GenerateTestResultCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/service/impl/GenerateTestResultCodeServiceImpl.java
@@ -23,7 +23,7 @@ public class GenerateTestResultCodeServiceImpl extends GenerateCodeService {
     private static final Random RANDOM = new Random();
 
     @Override
-    protected String execute(Long memberId, GenerateCodeReqDto reqDto) {
+    public String execute(Long memberId, GenerateCodeReqDto reqDto) {
 
         AuthenticationCode authenticationCode = codeRepository.findByMemberIdAndAuthCodeType(memberId, TEST_RESULT)
                 .orElse(null);
@@ -34,7 +34,6 @@ public class GenerateTestResultCodeServiceImpl extends GenerateCodeService {
                     LIMIT_COUNT_CODE_REQUEST), HttpStatus.BAD_REQUEST);
 
         String phoneNumber = reqDto.phoneNumber();
-
         final String code = generateUniqueCode(RANDOM, codeRepository);
 
         codeRepository.save(createAuthenticationCode(
@@ -45,7 +44,7 @@ public class GenerateTestResultCodeServiceImpl extends GenerateCodeService {
                 TEST_RESULT,
                 false));
 
-        sendCodeNotificationService.execute(phoneNumber, code);
+//        sendCodeNotificationService.execute(phoneNumber, code);
 
         return code;
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/type/TestType.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/testResult/type/TestType.java
@@ -1,0 +1,6 @@
+package team.themoment.hellogsmv3.domain.common.testResult.type;
+
+public enum TestType {
+    FIRST,
+    SECOND
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/controller/MemberController.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import team.themoment.hellogsmv3.domain.member.dto.request.CreateMemberReqDto;
 import team.themoment.hellogsmv3.domain.member.dto.response.*;
@@ -21,6 +20,8 @@ import team.themoment.hellogsmv3.domain.member.service.impl.GenerateTestCodeServ
 import team.themoment.hellogsmv3.global.common.handler.annotation.AuthRequest;
 import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 import team.themoment.hellogsmv3.global.security.auth.AuthenticatedUserManager;
+
+import static team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType.*;
 
 @Tag(name = "Member API", description = "맴버 관련 API입니다.")
 @RestController
@@ -35,8 +36,8 @@ public class MemberController {
     private final QueryMemberByIdService queryMemberByIdService;
     private final CreateMemberService createMemberService;
     private final QueryMemberAuthInfoByIdService queryMemberAuthInfoByIdService;
-    private final QueryFirstTestResultService queryFirstTestResultService;
-    private final QuerySecondTestResultService querySecondTestResultService;
+    private final QueryMyFirstTestResultService queryMyFirstTestResultService;
+    private final QueryMySecondTestResultService queryMySecondTestResultService;
     private final QueryCheckDuplicateMemberService queryCheckDuplicateMemberService;
 
     @Operation(summary = "인증코드 전송", description = "전화번호를 요청받아 인증코드를 전송합니다.")
@@ -65,7 +66,7 @@ public class MemberController {
             @AuthRequest Long memberId,
             @RequestBody @Valid AuthenticateCodeReqDto reqDto
     ) {
-        authenticateCodeService.execute(memberId, reqDto);
+        authenticateCodeService.execute(memberId, reqDto, SIGNUP);
         return CommonApiResponse.success("인증되었습니다.");
     }
 
@@ -122,7 +123,7 @@ public class MemberController {
     public FoundMemberFirstTestResDto firstTestResult(
             @AuthRequest Long memberId
     ) {
-        return queryFirstTestResultService.execute(memberId);
+        return queryMyFirstTestResultService.execute(memberId);
     }
 
     @Operation(summary = "2차 전형 결과 조회", description = "본인의 2차 전형 결과를 조회합니다.")
@@ -134,7 +135,7 @@ public class MemberController {
     public FoundMemberSecondTestResDto secondTestResult(
             @AuthRequest Long memberId
     ) {
-        return querySecondTestResultService.execute(memberId);
+        return queryMySecondTestResultService.execute(memberId);
     }
 
     @Operation(summary = "중복 회원가입 여부 확인", description = "중복 회원가입을 막기 위해 가입된 지원자의 전화번호인지 확인합니다.")

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/dto/request/AuthenticateCodeReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/dto/request/AuthenticateCodeReqDto.java
@@ -2,7 +2,8 @@ package team.themoment.hellogsmv3.domain.member.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record AuthenticateCodeReqDto(
+public record
+AuthenticateCodeReqDto(
         @NotBlank String code
 ) {
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/entity/AuthenticationCode.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/entity/AuthenticationCode.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.index.Indexed;
+import team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType;
 
 import java.time.LocalDateTime;
 
@@ -16,12 +17,15 @@ public class AuthenticationCode {
     @Id
     @Indexed
     private Long memberId;
+    @Id
+    @Indexed
+    private String phoneNumber;
     @Indexed
     private String code;
     private Boolean authenticated;
-    private String phoneNumber;
     private LocalDateTime createdAt;
     private int count;
+    private AuthCodeType authCodeType;
 
     public AuthenticationCode updatedCode(String code, LocalDateTime createdAt, boolean isTest) {
         this.code = code;
@@ -30,12 +34,13 @@ public class AuthenticationCode {
         return this;
     }
 
-    public AuthenticationCode(Long memberId, String code, String phoneNumber, LocalDateTime createdAt, boolean isTest) {
+    public AuthenticationCode(Long memberId, String code, String phoneNumber, LocalDateTime createdAt, AuthCodeType authCodeType, boolean isTest) {
         this.memberId = memberId;
         this.code = code;
         this.authenticated = false;
         this.phoneNumber = phoneNumber;
         this.createdAt = createdAt;
+        this.authCodeType = authCodeType;
         this.count = !isTest ? 1 : 0;
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/entity/AuthenticationCode.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/entity/AuthenticationCode.java
@@ -3,6 +3,7 @@ package team.themoment.hellogsmv3.domain.member.entity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.UniqueElements;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.index.Indexed;
@@ -17,15 +18,14 @@ public class AuthenticationCode {
     @Id
     @Indexed
     private Long memberId;
-    @Id
-    @Indexed
-    private String phoneNumber;
     @Indexed
     private String code;
+    @Indexed
+    private AuthCodeType authCodeType;
+    private String phoneNumber;
     private Boolean authenticated;
     private LocalDateTime createdAt;
     private int count;
-    private AuthCodeType authCodeType;
 
     public AuthenticationCode updatedCode(String code, LocalDateTime createdAt, boolean isTest) {
         this.code = code;

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/entity/type/AuthCodeType.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/entity/type/AuthCodeType.java
@@ -1,0 +1,6 @@
+package team.themoment.hellogsmv3.domain.member.entity.type;
+
+public enum AuthCodeType {
+    SIGNUP, // 회원가입 용도
+    TEST_RESULT // 결과확인 용도
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/repo/CodeRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/repo/CodeRepository.java
@@ -7,7 +7,6 @@ import team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType;
 import java.util.Optional;
 
 public interface CodeRepository extends CrudRepository<AuthenticationCode, String> {
-    Optional<AuthenticationCode> findByMemberId(Long memberId);
-    Optional<AuthenticationCode> findByPhoneNumberAndAuthCodeType(String phoneNumber, AuthCodeType authCodeType);
+    Optional<AuthenticationCode> findByMemberIdAndAuthCodeType(Long memberId, AuthCodeType authCodeType);
     Optional<AuthenticationCode> findByCode(String code);
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/repo/CodeRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/repo/CodeRepository.java
@@ -2,10 +2,12 @@ package team.themoment.hellogsmv3.domain.member.repo;
 
 import org.springframework.data.repository.CrudRepository;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType;
 
 import java.util.Optional;
 
 public interface CodeRepository extends CrudRepository<AuthenticationCode, String> {
     Optional<AuthenticationCode> findByMemberId(Long memberId);
+    Optional<AuthenticationCode> findByPhoneNumberAndAuthCodeType(String phoneNumber, AuthCodeType authCodeType);
     Optional<AuthenticationCode> findByCode(String code);
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/AuthenticateCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/AuthenticateCodeService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.member.dto.request.AuthenticateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType;
 import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
@@ -16,7 +17,7 @@ public class AuthenticateCodeService {
     private final CodeRepository codeRepository;
 
     @Transactional
-    public void execute(Long memberId, AuthenticateCodeReqDto reqDto) {
+    public void execute(Long memberId, AuthenticateCodeReqDto reqDto, AuthCodeType authCodeType) {
 
         AuthenticationCode code = codeRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new ExpectedException("사용자의 code가 존재하지 않습니다. member ID : " + memberId, HttpStatus.NOT_FOUND));

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/AuthenticateCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/AuthenticateCodeService.java
@@ -18,8 +18,7 @@ public class AuthenticateCodeService {
 
     @Transactional
     public void execute(Long memberId, AuthenticateCodeReqDto reqDto, AuthCodeType authCodeType) {
-
-        AuthenticationCode code = codeRepository.findByMemberId(memberId)
+        AuthenticationCode code = codeRepository.findByMemberIdAndAuthCodeType(memberId, authCodeType)
                 .orElseThrow(() -> new ExpectedException("사용자의 code가 존재하지 않습니다. member ID : " + memberId, HttpStatus.NOT_FOUND));
 
         if (!code.getCode().equals(reqDto.code()))

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeService.java
@@ -14,28 +14,9 @@ public class CommonCodeService {
 
     private final CodeRepository codeRepository;
 
-    public void validateAndDelete(Long memberId, String inputCode, String inputPhoneNumber) {
-        AuthenticationCode code = codeRepository.findByMemberId(memberId)
+    public void validateAndDelete(Long memberId, String inputCode, String inputPhoneNumber, AuthCodeType authCodeType) {
+        AuthenticationCode code = codeRepository.findByMemberIdAndAuthCodeType(memberId, authCodeType)
                 .orElseThrow(() -> new ExpectedException("사용자의 code가 존재하지 않습니다. 사용자의 ID : " + memberId, HttpStatus.BAD_REQUEST));
-
-        if (!code.getAuthenticated()) {
-            throw new ExpectedException("유효하지 않은 요청입니다. 인증받지 않은 code입니다.", HttpStatus.BAD_REQUEST);
-        }
-
-        if (!code.getCode().equals(inputCode)) {
-            throw new ExpectedException("유효하지 않은 요청입니다. 이전 혹은 잘못된 형식의 code입니다.", HttpStatus.BAD_REQUEST);
-        }
-
-        if (!code.getPhoneNumber().equals(inputPhoneNumber)) {
-            throw new ExpectedException("유효하지 않은 요청입니다. code인증에 사용되었던 전화번호와 요청에 사용한 전화번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
-        }
-
-        codeRepository.delete(code);
-    }
-
-    public void validateAndDelete(String inputCode, String inputPhoneNumber, AuthCodeType authCodeType) {
-        AuthenticationCode code = codeRepository.findByPhoneNumberAndAuthCodeType(inputPhoneNumber, authCodeType)
-                .orElseThrow(() -> new ExpectedException("사용자의 code가 존재하지 않습니다. 사용자의 전화번호 : " + inputPhoneNumber, HttpStatus.BAD_REQUEST));
 
         if (!code.getAuthenticated()) {
             throw new ExpectedException("유효하지 않은 요청입니다. 인증받지 않은 code입니다.", HttpStatus.BAD_REQUEST);

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType;
 import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
@@ -16,6 +17,25 @@ public class CommonCodeService {
     public void validateAndDelete(Long memberId, String inputCode, String inputPhoneNumber) {
         AuthenticationCode code = codeRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new ExpectedException("사용자의 code가 존재하지 않습니다. 사용자의 ID : " + memberId, HttpStatus.BAD_REQUEST));
+
+        if (!code.getAuthenticated()) {
+            throw new ExpectedException("유효하지 않은 요청입니다. 인증받지 않은 code입니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        if (!code.getCode().equals(inputCode)) {
+            throw new ExpectedException("유효하지 않은 요청입니다. 이전 혹은 잘못된 형식의 code입니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        if (!code.getPhoneNumber().equals(inputPhoneNumber)) {
+            throw new ExpectedException("유효하지 않은 요청입니다. code인증에 사용되었던 전화번호와 요청에 사용한 전화번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        codeRepository.delete(code);
+    }
+
+    public void validateAndDelete(String inputCode, String inputPhoneNumber, AuthCodeType authCodeType) {
+        AuthenticationCode code = codeRepository.findByPhoneNumberAndAuthCodeType(inputPhoneNumber, authCodeType)
+                .orElseThrow(() -> new ExpectedException("사용자의 code가 존재하지 않습니다. 사용자의 전화번호 : " + inputPhoneNumber, HttpStatus.BAD_REQUEST));
 
         if (!code.getAuthenticated()) {
             throw new ExpectedException("유효하지 않은 요청입니다. 인증받지 않은 code입니다.", HttpStatus.BAD_REQUEST);

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberService.java
@@ -15,6 +15,7 @@ import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
 
 import java.time.LocalDateTime;
 
+import static team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType.*;
 import static team.themoment.hellogsmv3.domain.member.entity.type.Role.*;
 
 @Service
@@ -33,7 +34,7 @@ public class CreateMemberService {
     @Transactional
     public Role execute(CreateMemberReqDto reqDto, Long memberId) {
 
-        commonCodeService.validateAndDelete(memberId, reqDto.code(), reqDto.phoneNumber());
+        commonCodeService.validateAndDelete(memberId, reqDto.code(), reqDto.phoneNumber(), SIGNUP);
 
         Member member = memberService.findByIdOrThrow(memberId);
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/GenerateCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/GenerateCodeService.java
@@ -2,6 +2,7 @@ package team.themoment.hellogsmv3.domain.member.service;
 
 import team.themoment.hellogsmv3.domain.member.dto.request.GenerateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType;
 import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
 
 import java.time.LocalDateTime;
@@ -19,10 +20,11 @@ public abstract class GenerateCodeService {
             Long memberId,
             String code,
             String phoneNumber,
+            AuthCodeType authCodeType,
             boolean isTest) {
 
         return authCode == null ?
-                new AuthenticationCode(memberId, code, phoneNumber, LocalDateTime.now(), isTest) :
+                new AuthenticationCode(memberId, code, phoneNumber, LocalDateTime.now(), authCodeType, isTest) :
                 authCode.updatedCode(code, LocalDateTime.now(), isTest);
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMyFirstTestResultService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMyFirstTestResultService.java
@@ -2,19 +2,11 @@ package team.themoment.hellogsmv3.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
-import team.themoment.hellogsmv3.domain.common.operation.repo.OperationTestResultRepository;
 import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberFirstTestResDto;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
-import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
 import team.themoment.hellogsmv3.domain.oneseo.service.OneseoService;
-import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
-
-import java.time.LocalDateTime;
-
-import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.*;
 
 @Service
 @RequiredArgsConstructor
@@ -22,26 +14,17 @@ public class QueryMyFirstTestResultService {
 
     private final MemberService memberService;
     private final OneseoService oneseoService;
-    private final ScheduleEnvironment scheduleEnv;
-    private final EntranceTestResultRepository entranceTestResultRepository;
-    private final OperationTestResultRepository operationTestResultRepository;
 
     public FoundMemberFirstTestResDto execute(Long memberId) {
         Member member = memberService.findByIdOrThrow(memberId);
         Oneseo oneseo = oneseoService.findByMemberOrThrow(member);
 
         // no content response status
-        if (validateFirstTestResultAnnouncement()) return null;
+        if (oneseoService.validateFirstTestResultAnnouncement()) return null;
 
         EntranceTestResult entranceTestResult = oneseo.getEntranceTestResult();
         return new FoundMemberFirstTestResDto(entranceTestResult.getFirstTestPassYn());
     }
 
-    private boolean validateFirstTestResultAnnouncement() {
-        OperationTestResult testResult = operationTestResultRepository.findTestResult();
 
-        return testResult.getFirstTestResultAnnouncementYn().equals(NO) ||
-                LocalDateTime.now().isBefore(scheduleEnv.firstResultsAnnouncement()) ||
-                entranceTestResultRepository.existsByFirstTestPassYnIsNull();
-    }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMyFirstTestResultService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMyFirstTestResultService.java
@@ -18,7 +18,7 @@ import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.*;
 
 @Service
 @RequiredArgsConstructor
-public class QueryFirstTestResultService {
+public class QueryMyFirstTestResultService {
 
     private final MemberService memberService;
     private final OneseoService oneseoService;

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMySecondTestResultService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMySecondTestResultService.java
@@ -18,7 +18,7 @@ import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.NO;
 
 @Service
 @RequiredArgsConstructor
-public class QuerySecondTestResultService {
+public class QueryMySecondTestResultService {
 
     private final MemberService memberService;
     private final OneseoService oneseoService;

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMySecondTestResultService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMySecondTestResultService.java
@@ -2,19 +2,11 @@ package team.themoment.hellogsmv3.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
-import team.themoment.hellogsmv3.domain.common.operation.repo.OperationTestResultRepository;
 import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberSecondTestResDto;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
-import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
 import team.themoment.hellogsmv3.domain.oneseo.service.OneseoService;
-import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
-
-import java.time.LocalDateTime;
-
-import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.NO;
 
 @Service
 @RequiredArgsConstructor
@@ -22,29 +14,18 @@ public class QueryMySecondTestResultService {
 
     private final MemberService memberService;
     private final OneseoService oneseoService;
-    private final ScheduleEnvironment scheduleEnv;
-    private final EntranceTestResultRepository entranceTestResultRepository;
-    private final OperationTestResultRepository operationTestResultRepository;
 
     public FoundMemberSecondTestResDto execute(Long memberId) {
         Member member = memberService.findByIdOrThrow(memberId);
         Oneseo oneseo = oneseoService.findByMemberOrThrow(member);
 
         // no content response status
-        if (validateSecondTestResultAnnouncement()) return null;
+        if (oneseoService.validateSecondTestResultAnnouncement()) return null;
 
         EntranceTestResult entranceTestResult = oneseo.getEntranceTestResult();
         return new FoundMemberSecondTestResDto(
                 entranceTestResult.getSecondTestPassYn(),
                 oneseo.getDecidedMajor()
         );
-    }
-
-    private boolean validateSecondTestResultAnnouncement() {
-        OperationTestResult testResult = operationTestResultRepository.findTestResult();
-
-        return testResult.getSecondTestResultAnnouncementYn().equals(NO) ||
-                LocalDateTime.now().isBefore(scheduleEnv.firstResultsAnnouncement()) ||
-                entranceTestResultRepository.existsByFirstTestPassYnIsNull();
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImpl.java
@@ -25,7 +25,7 @@ public class GenerateCodeServiceImpl extends GenerateCodeService {
     @Override
     public String execute(Long memberId, GenerateCodeReqDto reqDto) {
 
-        AuthenticationCode authenticationCode = codeRepository.findByMemberId(memberId)
+        AuthenticationCode authenticationCode = codeRepository.findByMemberIdAndAuthCodeType(memberId, SIGNUP)
                 .orElse(null);
 
         if (isLimitedRequest(authenticationCode))

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImpl.java
@@ -22,7 +22,7 @@ public class GenerateTestCodeServiceImpl extends GenerateCodeService {
     public String execute(Long memberId, GenerateCodeReqDto reqDto) {
         final String code = generateUniqueCode(RANDOM, codeRepository);
 
-        AuthenticationCode authenticationCode = codeRepository.findByMemberId(memberId)
+        AuthenticationCode authenticationCode = codeRepository.findByMemberIdAndAuthCodeType(memberId, SIGNUP)
                 .orElse(null);
 
         codeRepository.save(createAuthenticationCode(

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImpl.java
@@ -9,6 +9,8 @@ import team.themoment.hellogsmv3.domain.member.service.GenerateCodeService;
 
 import java.util.Random;
 
+import static team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType.*;
+
 @Service
 @RequiredArgsConstructor
 public class GenerateTestCodeServiceImpl extends GenerateCodeService {
@@ -28,6 +30,7 @@ public class GenerateTestCodeServiceImpl extends GenerateCodeService {
                 memberId,
                 code,
                 reqDto.phoneNumber(),
+                SIGNUP,
                 true));
 
         return code;

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
@@ -30,5 +30,6 @@ public interface CustomOneseoRepository {
     List<Oneseo> findAllByScreeningDynamic(Screening screening);
 
     Optional<Oneseo> findByGuardianOrTeacherPhoneNumberAndSubmitCode(String phoneNumber, String submitCode);
+    Optional<Oneseo> findByGuardianOrTeacherPhoneNumberAndExaminationNumber(String phoneNumber, String examinationNumber);
 
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
@@ -11,6 +11,7 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.AdmissionTicketsResDto;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CustomOneseoRepository {
 
@@ -27,4 +28,7 @@ public interface CustomOneseoRepository {
     List<AdmissionTicketsResDto> findAdmissionTickets();
 
     List<Oneseo> findAllByScreeningDynamic(Screening screening);
+
+    Optional<Oneseo> findByGuardianOrTeacherPhoneNumberAndSubmitCode(String phoneNumber, String submitCode);
+
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
@@ -29,6 +29,7 @@ import static team.themoment.hellogsmv3.domain.oneseo.entity.QOneseoPrivacyDetai
 import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.*;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -74,6 +75,19 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
                         : oneseo.wantedScreening.eq(screening))
                 .orderBy(entranceTestResult.documentEvaluationScore.desc())
                 .fetch();
+    }
+
+    @Override
+    public Optional<Oneseo> findByGuardianOrTeacherPhoneNumberAndSubmitCode(String phoneNumber, String submitCode) {
+         return Optional.ofNullable(
+                 queryFactory.selectFrom(oneseo)
+                    .join(oneseo.oneseoPrivacyDetail, oneseoPrivacyDetail)
+                    .where(
+                            oneseoPrivacyDetail.guardianPhoneNumber.eq(phoneNumber)
+                                    .or(oneseoPrivacyDetail.schoolTeacherPhoneNumber.eq(phoneNumber))
+                                    .and(oneseo.oneseoSubmitCode.eq(submitCode))
+                    ).fetchOne()
+         );
     }
 
     @Override

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
@@ -79,13 +79,26 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
 
     @Override
     public Optional<Oneseo> findByGuardianOrTeacherPhoneNumberAndSubmitCode(String phoneNumber, String submitCode) {
+        return Optional.ofNullable(
+                queryFactory.selectFrom(oneseo)
+                        .join(oneseo.oneseoPrivacyDetail, oneseoPrivacyDetail)
+                        .where(
+                                oneseoPrivacyDetail.guardianPhoneNumber.eq(phoneNumber)
+                                        .or(oneseoPrivacyDetail.schoolTeacherPhoneNumber.eq(phoneNumber))
+                                        .and(oneseo.oneseoSubmitCode.eq(submitCode))
+                        ).fetchOne()
+        );
+    }
+
+    @Override
+    public Optional<Oneseo> findByGuardianOrTeacherPhoneNumberAndExaminationNumber(String phoneNumber, String examinationNumber) {
          return Optional.ofNullable(
                  queryFactory.selectFrom(oneseo)
                     .join(oneseo.oneseoPrivacyDetail, oneseoPrivacyDetail)
                     .where(
                             oneseoPrivacyDetail.guardianPhoneNumber.eq(phoneNumber)
                                     .or(oneseoPrivacyDetail.schoolTeacherPhoneNumber.eq(phoneNumber))
-                                    .and(oneseo.oneseoSubmitCode.eq(submitCode))
+                                    .and(oneseo.examinationNumber.eq(examinationNumber))
                     ).fetchOne()
          );
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
@@ -3,6 +3,8 @@ package team.themoment.hellogsmv3.domain.oneseo.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
+import team.themoment.hellogsmv3.domain.common.operation.repo.OperationTestResultRepository;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.OneseoReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
@@ -10,20 +12,27 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.ScreeningCategory;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
+import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static team.themoment.hellogsmv3.domain.oneseo.entity.type.GraduationType.CANDIDATE;
+import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.NO;
 
 @Service
 @RequiredArgsConstructor
 public class OneseoService {
 
     public static final String ONESEO_CACHE_VALUE = "oneseo";
+    private final ScheduleEnvironment scheduleEnv;
     private final OneseoRepository oneseoRepository;
+    private final OperationTestResultRepository operationTestResultRepository;
+    private final EntranceTestResultRepository entranceTestResultRepository;
 
     public void assignSubmitCode(Oneseo oneseo, Screening originalScreening) {
         if (oneseo.getWantedScreening() != originalScreening) {
@@ -64,6 +73,22 @@ public class OneseoService {
         if (yn != null) {
             throw new ExpectedException("2차 전형 결과 산출 이후에는 작업을 진행할 수 없습니다.", HttpStatus.FORBIDDEN);
         }
+    }
+
+    public boolean validateFirstTestResultAnnouncement() {
+        OperationTestResult testResult = operationTestResultRepository.findTestResult();
+
+        return testResult.getFirstTestResultAnnouncementYn().equals(NO) ||
+                LocalDateTime.now().isBefore(scheduleEnv.firstResultsAnnouncement()) ||
+                entranceTestResultRepository.existsByFirstTestPassYnIsNull();
+    }
+
+    public boolean validateSecondTestResultAnnouncement() {
+        OperationTestResult testResult = operationTestResultRepository.findTestResult();
+
+        return testResult.getSecondTestResultAnnouncementYn().equals(NO) ||
+                LocalDateTime.now().isBefore(scheduleEnv.firstResultsAnnouncement()) ||
+                entranceTestResultRepository.existsByFirstTestPassYnIsNull();
     }
 
     public static void isValidMiddleSchoolInfo(OneseoReqDto reqDto) {

--- a/src/main/java/team/themoment/hellogsmv3/global/config/SwaggerConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/config/SwaggerConfig.java
@@ -32,7 +32,7 @@ public class SwaggerConfig {
     public GroupedOpenApi api(OperationCustomizer operationCustomizer) {
         return GroupedOpenApi.builder()
                 .group("Hello, GSM 2024 API")
-                .pathsToMatch("/member/**", "/oneseo/**", "/auth/**", "/date", "/operation/**")
+                .pathsToMatch("/member/**", "/oneseo/**", "/auth/**", "/date", "/operation/**", "/test-result/**")
                 .addOperationCustomizer(operationCustomizer)
                 .build();
     }

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -213,12 +213,18 @@ public class SecurityConfig {
                         Role.ADMIN.name()
                 )
 
-                // operation test result
+                // operation test result api
                 .requestMatchers("/operation/**").hasAnyAuthority(
                         Role.ADMIN.name()
                 )
 
-                // mock score calculate
+                // test result api
+                .requestMatchers("/test-result/v3/**").hasAnyAuthority(
+                        Role.UNAUTHENTICATED.name(),
+                        Role.APPLICANT.name()
+                )
+
+                // mock score calculate api
                 .requestMatchers(HttpMethod.POST, "/oneseo/v3/calculate-mock-score").permitAll()
 
                 // common / get date api

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,7 +27,7 @@ spring:
   jpa:
     database-platform: ${DB_PLATFORM}
     hibernate:
-      ddl-auto: ${HIBERNATE_DDL_AUTO}
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,7 +27,7 @@ spring:
   jpa:
     database-platform: ${DB_PLATFORM}
     hibernate:
-      ddl-auto: none
+      ddl-auto: ${HIBERNATE_DDL_AUTO}
     show-sql: true
     properties:
       hibernate:

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/AuthenticateCodeServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/AuthenticateCodeServiceTest.java
@@ -11,6 +11,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.member.dto.request.AuthenticateCodeReqDto;
 import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType;
 import team.themoment.hellogsmv3.domain.member.repo.CodeRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
@@ -21,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType.*;
 
 @DisplayName("AuthenticateCodeService 클래스의")
 public class AuthenticateCodeServiceTest {
@@ -52,14 +54,14 @@ public class AuthenticateCodeServiceTest {
 
             @BeforeEach
             void setUp() {
-                authenticationCode = new AuthenticationCode(memberId, validCode, "01000000000", LocalDateTime.now(), false);
-                given(codeRepository.findByMemberId(memberId)).willReturn(Optional.of(authenticationCode));
+                authenticationCode = new AuthenticationCode(memberId, validCode, "01000000000", LocalDateTime.now(), SIGNUP, false);
+                given(codeRepository.findByMemberIdAndAuthCodeType(memberId, SIGNUP)).willReturn(Optional.of(authenticationCode));
             }
 
             @Test
             @DisplayName("인증 코드를 인증 상태로 변경하고 저장한다.")
             void it_authenticates_code_and_saves() {
-                authenticateCodeService.execute(memberId, reqDto);
+                authenticateCodeService.execute(memberId, reqDto, SIGNUP);
 
                 ArgumentCaptor<AuthenticationCode> codeCaptor = ArgumentCaptor.forClass(AuthenticationCode.class);
                 verify(codeRepository).save(codeCaptor.capture());
@@ -75,14 +77,14 @@ public class AuthenticateCodeServiceTest {
 
             @BeforeEach
             void setUp() {
-                given(codeRepository.findByMemberId(memberId)).willReturn(Optional.empty());
+                given(codeRepository.findByMemberIdAndAuthCodeType(memberId, SIGNUP)).willReturn(Optional.empty());
             }
 
             @Test
             @DisplayName("ExpectedException을 던진다.")
             void it_throws_expected_exception() {
                 ExpectedException exception = assertThrows(ExpectedException.class, () ->
-                        authenticateCodeService.execute(memberId, reqDto)
+                        authenticateCodeService.execute(memberId, reqDto, SIGNUP)
                 );
 
                 assertEquals("사용자의 code가 존재하지 않습니다. member ID : " + memberId, exception.getMessage());
@@ -96,8 +98,8 @@ public class AuthenticateCodeServiceTest {
 
             @BeforeEach
             void setUp() {
-                authenticationCode = new AuthenticationCode(memberId, validCode, "01000000000", LocalDateTime.now(), false);
-                given(codeRepository.findByMemberId(memberId)).willReturn(Optional.of(authenticationCode));
+                authenticationCode = new AuthenticationCode(memberId, validCode, "01000000000", LocalDateTime.now(), SIGNUP, false);
+                given(codeRepository.findByMemberIdAndAuthCodeType(memberId, SIGNUP)).willReturn(Optional.of(authenticationCode));
             }
 
             @Test
@@ -106,7 +108,7 @@ public class AuthenticateCodeServiceTest {
                 AuthenticateCodeReqDto invalidReqDto = new AuthenticateCodeReqDto(invalidCode);
 
                 ExpectedException exception = assertThrows(ExpectedException.class, () ->
-                        authenticateCodeService.execute(memberId, invalidReqDto)
+                        authenticateCodeService.execute(memberId, invalidReqDto, SIGNUP)
                 );
 
                 assertEquals("유효하지 않은 code 이거나 이전 혹은 잘못된 code 입니다.", exception.getMessage());

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/CommonCodeServiceTest.java
@@ -18,8 +18,10 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType.*;
 
 @DisplayName("CommonCodeService 클래스의")
 class CommonCodeServiceTest {
@@ -53,6 +55,7 @@ class CommonCodeServiceTest {
                     validCode,
                     validPhoneNumber,
                     LocalDateTime.now(),
+                    SIGNUP,
                     false
             );
         }
@@ -64,13 +67,13 @@ class CommonCodeServiceTest {
             @BeforeEach
             void setUp() {
                 authenticationCode.authenticatedAuthenticationCode();
-                given(codeRepository.findByMemberId(memberId)).willReturn(Optional.of(authenticationCode));
+                given(codeRepository.findByMemberIdAndAuthCodeType(memberId, SIGNUP)).willReturn(Optional.of(authenticationCode));
             }
 
             @Test
             @DisplayName("코드를 삭제한다")
             void it_deletes_the_code() {
-                commonCodeService.validateAndDelete(memberId, validCode, validPhoneNumber);
+                commonCodeService.validateAndDelete(memberId, validCode, validPhoneNumber, SIGNUP);
 
                 verify(codeRepository).delete(authenticationCode);
             }
@@ -82,14 +85,14 @@ class CommonCodeServiceTest {
 
             @BeforeEach
             void setUp() {
-                given(codeRepository.findByMemberId(anyLong())).willReturn(Optional.empty());
+                given(codeRepository.findByMemberIdAndAuthCodeType(anyLong(), eq(SIGNUP))).willReturn(Optional.empty());
             }
 
             @Test
             @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception() {
                 ExpectedException exception = assertThrows(ExpectedException.class, () -> {
-                    commonCodeService.validateAndDelete(memberId, validCode, validPhoneNumber);
+                    commonCodeService.validateAndDelete(memberId, validCode, validPhoneNumber, SIGNUP);
                 });
 
                 assertEquals("사용자의 code가 존재하지 않습니다. 사용자의 ID : " + memberId, exception.getMessage());
@@ -103,14 +106,14 @@ class CommonCodeServiceTest {
 
             @BeforeEach
             void setUp() {
-                given(codeRepository.findByMemberId(memberId)).willReturn(Optional.of(authenticationCode));
+                given(codeRepository.findByMemberIdAndAuthCodeType(memberId, SIGNUP)).willReturn(Optional.of(authenticationCode));
             }
 
             @Test
             @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception_when_code_is_not_authenticated() {
                 ExpectedException exception = assertThrows(ExpectedException.class, () -> {
-                    commonCodeService.validateAndDelete(memberId, validCode, validPhoneNumber);
+                    commonCodeService.validateAndDelete(memberId, validCode, validPhoneNumber, SIGNUP);
                 });
 
                 assertEquals("유효하지 않은 요청입니다. 인증받지 않은 code입니다.", exception.getMessage());
@@ -125,14 +128,14 @@ class CommonCodeServiceTest {
             @BeforeEach
             void setUp() {
                 authenticationCode.authenticatedAuthenticationCode();
-                given(codeRepository.findByMemberId(memberId)).willReturn(Optional.of(authenticationCode));
+                given(codeRepository.findByMemberIdAndAuthCodeType(memberId, SIGNUP)).willReturn(Optional.of(authenticationCode));
             }
 
             @Test
             @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception_when_code_is_invalid() {
                 ExpectedException exception = assertThrows(ExpectedException.class, () -> {
-                    commonCodeService.validateAndDelete(memberId, invalidCode, validPhoneNumber);
+                    commonCodeService.validateAndDelete(memberId, invalidCode, validPhoneNumber, SIGNUP);
                 });
 
                 assertEquals("유효하지 않은 요청입니다. 이전 혹은 잘못된 형식의 code입니다.", exception.getMessage());
@@ -147,14 +150,14 @@ class CommonCodeServiceTest {
             @BeforeEach
             void setUp() {
                 authenticationCode.authenticatedAuthenticationCode();
-                given(codeRepository.findByMemberId(memberId)).willReturn(Optional.of(authenticationCode));
+                given(codeRepository.findByMemberIdAndAuthCodeType(memberId, SIGNUP)).willReturn(Optional.of(authenticationCode));
             }
 
             @Test
             @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception() {
                 ExpectedException exception = assertThrows(ExpectedException.class, () -> {
-                    commonCodeService.validateAndDelete(memberId, validCode, invalidPhoneNumber);
+                    commonCodeService.validateAndDelete(memberId, validCode, invalidPhoneNumber, SIGNUP);
                 });
 
                 assertEquals("유효하지 않은 요청입니다. code인증에 사용되었던 전화번호와 요청에 사용한 전화번호가 일치하지 않습니다.", exception.getMessage());

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/CreateMemberServiceTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.*;
+import static team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType.*;
 
 @DisplayName("CreateMemberService 클래스의")
 class CreateMemberServiceTest {
@@ -85,7 +86,7 @@ class CreateMemberServiceTest {
                 given(scheduleEnvironment.oneseoSubmissionEnd()).willReturn(LocalDateTime.of(9999, Month.OCTOBER, 10, 10, 10));
                 given(memberRepository.findByPhoneNumber(reqDto.phoneNumber())).willReturn(Optional.empty());
                 given(entranceTestResultRepository.existsByFirstTestPassYnIsNotNull()).willReturn(false);
-                willDoNothing().given(commonCodeService).validateAndDelete(memberId, reqDto.code(), reqDto.phoneNumber());
+                willDoNothing().given(commonCodeService).validateAndDelete(memberId, reqDto.code(), reqDto.phoneNumber(), SIGNUP);
             }
 
             @Test
@@ -115,7 +116,7 @@ class CreateMemberServiceTest {
             void setUp() {
                 when(memberService.findByIdOrThrow(memberId))
                         .thenThrow(new ExpectedException("존재하지 않는 지원자입니다. member ID: " + memberId, HttpStatus.NOT_FOUND));
-                willDoNothing().given(commonCodeService).validateAndDelete(memberId, reqDto.code(), reqDto.phoneNumber());
+                willDoNothing().given(commonCodeService).validateAndDelete(memberId, reqDto.code(), reqDto.phoneNumber(), SIGNUP);
             }
 
             @Test

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImplTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImplTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
-@DisplayName("GenerateCodeServiceImpl 클래스의")
+@DisplayName("GenerateTestResultCodeServiceImpl 클래스의")
 class GenerateCodeServiceImplTest {
 
     @Mock

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImplTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateCodeServiceImplTest.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
+import static team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType.*;
 
 @DisplayName("GenerateTestResultCodeServiceImpl 클래스의")
 class GenerateCodeServiceImplTest {
@@ -48,7 +49,7 @@ class GenerateCodeServiceImplTest {
 
             @BeforeEach
             void setUp() {
-                given(codeRepository.findByMemberId(memberId)).willReturn(Optional.empty());
+                given(codeRepository.findByMemberIdAndAuthCodeType(memberId, SIGNUP)).willReturn(Optional.empty());
                 given(codeRepository.findByCode(anyString())).willReturn(Optional.empty());
             }
 
@@ -83,7 +84,7 @@ class GenerateCodeServiceImplTest {
             @BeforeEach
             void setUp() {
                 existingCode = mock(AuthenticationCode.class);
-                given(codeRepository.findByMemberId(memberId)).willReturn(Optional.of(existingCode));
+                given(codeRepository.findByMemberIdAndAuthCodeType(memberId, SIGNUP)).willReturn(Optional.of(existingCode));
                 given(existingCode.getCount()).willReturn(5);
             }
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImplTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/impl/GenerateTestCodeServiceImplTest.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
+import static team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType.*;
 
 @DisplayName("GenerateTestCodeServiceImpl 클래스의")
 class GenerateTestCodeServiceImplTest {
@@ -42,7 +43,7 @@ class GenerateTestCodeServiceImplTest {
 
             @BeforeEach
             void setUp() {
-                given(codeRepository.findByMemberId(memberId)).willReturn(Optional.empty());
+                given(codeRepository.findByMemberIdAndAuthCodeType(memberId, SIGNUP)).willReturn(Optional.empty());
                 given(codeRepository.findByCode(anyString())).willReturn(Optional.empty());
             }
 


### PR DESCRIPTION
## 개요

지원자가 직접 로그인하여 모달을 통해 결과를 확인하는 것이 아닌 부모님이나 선생님이 지원자 학생의 결과를 조회할 수 있는 기능을 추가하였습니다.

## 작업 내용

결과 조회는 조회하려는 원서에 작성된 부모님 or 선생님의 전화번호와 (**1차 전형: 접수번호, 2차전형: 수험번호**)의 조합으로 조회가 가능합니다.

회원가입시 사용되는 인증코드 redis hash에 `testType` 인덱스 필드를 추가하여 회원가입용 코드, 결과확인용 코드로 구분하였습니다.

인증코드 인증 후에 결과 확인 기간이 지났는지, 전화번호, 접수번호 or 수험번호의 조합인 원서가 존재하는지 확인 후 결과를 반환합니다.

## 추가 사항

구조 변경과 테스트코드 수정으로 인해 file changes가 많아졌습니다. 리뷰어 분들께 죄송합니다.
AuthenticationCode의 변경된 구조와 common.testResult 부분의 로직을 중심적으로 확인해주시면 감사하겠습니다.