### PR TITLE
[oneseo] 원서 작성 동시성 제어 방식 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,6 @@ dependencies {
     /** persistence **/
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    implementation 'org.springframework.retry:spring-retry'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     /** queryDsl **/

--- a/src/main/java/team/themoment/hellogsmv3/HelloGsmV3Application.java
+++ b/src/main/java/team/themoment/hellogsmv3/HelloGsmV3Application.java
@@ -3,11 +3,9 @@ package team.themoment.hellogsmv3;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
-@EnableRetry
 @EnableAsync
 @EnableJpaAuditing
 @SpringBootApplication

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/repo/MemberRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/repo/MemberRepository.java
@@ -1,6 +1,8 @@
 package team.themoment.hellogsmv3.domain.member.repo;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
@@ -16,4 +18,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("DELETE FROM Member m WHERE m = :member")
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     void deleteDuplicate(Member member);
+
+    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
+    Optional<Member> findById(Long memberId);
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -3,10 +3,7 @@ package team.themoment.hellogsmv3.domain.oneseo.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.http.HttpStatus;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
@@ -27,7 +24,6 @@ import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.util.List;
 
-import static org.springframework.transaction.annotation.Isolation.*;
 import static team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo.*;
 import static team.themoment.hellogsmv3.domain.oneseo.service.OneseoService.isValidMiddleSchoolInfo;
 
@@ -44,11 +40,7 @@ public class CreateOneseoService {
     private final OneseoService oneseoService;
     private final ApplicationEventPublisher applicationEventPublisher;
 
-    @Retryable(
-            value = {CannotAcquireLockException.class},
-            maxAttempts = 2,
-            backoff = @Backoff(delay = 1000))
-    @Transactional(isolation = SERIALIZABLE)
+    @Transactional
     @CachePut(value = OneseoService.ONESEO_CACHE_VALUE, key = "#memberId")
     public FoundOneseoResDto execute(OneseoReqDto reqDto, Long memberId) {
 


### PR DESCRIPTION
## 본문

기존
- valid자원에는 s lock, 쓰기 자원에 대해서만 x lock을 걸어 insert에서 lock을 얻지 못하도록 함.
- 불필요한 쿼리가 그대로 나간다는 점에서 이상적이지 않다고 생각하였습니다.
 
개선
- valid자원에 for update구문을 통한 x lock을 걸어 처음 락을 획득한 스레드가 작업을 마치기 전까지 다른 스레드는 대기하도록 함.
- 최소한의 쿼리만으로 동시성 제어.

