### PR TITLE
[oneseo] 디스코드 알람 비동기 처리 스레드풀 정의

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/HelloGsmV3Application.java
+++ b/src/main/java/team/themoment/hellogsmv3/HelloGsmV3Application.java
@@ -3,11 +3,8 @@ package team.themoment.hellogsmv3;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.retry.annotation.EnableRetry;
-import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
-@EnableAsync
 @EnableJpaAuditing
 @SpringBootApplication
 @EnableRedisHttpSession

--- a/src/main/java/team/themoment/hellogsmv3/HelloGsmV3Application.java
+++ b/src/main/java/team/themoment/hellogsmv3/HelloGsmV3Application.java
@@ -7,7 +7,6 @@ import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
-@EnableRetry
 @EnableAsync
 @EnableJpaAuditing
 @SpringBootApplication

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/event/handler/OneseoApplyEventHandler.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/event/handler/OneseoApplyEventHandler.java
@@ -27,7 +27,7 @@ public class OneseoApplyEventHandler {
     @Value("${spring.profiles.active:default}")
     private String activeProfile;
 
-    @Async
+    @Async("discordTaskExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void sendDiscordAlarm(OneseoApplyEvent oneseoApplyEvent) {
 

--- a/src/main/java/team/themoment/hellogsmv3/global/config/AsyncConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package team.themoment.hellogsmv3.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    @Bean(name = "discordTaskExecutor")
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setThreadNamePrefix("Discord-Task");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/config/AsyncConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/config/AsyncConfig.java
@@ -1,16 +1,22 @@
 package team.themoment.hellogsmv3.global.config;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import team.themoment.hellogsmv3.global.exception.GlobalAsyncExceptionHandler;
 
 import java.util.concurrent.Executor;
 
 @EnableAsync
 @Configuration
+@RequiredArgsConstructor
 public class AsyncConfig implements AsyncConfigurer {
+
+    private final GlobalAsyncExceptionHandler globalAsyncExceptionHandler;
 
     @Override
     @Bean(name = "discordTaskExecutor")
@@ -19,5 +25,10 @@ public class AsyncConfig implements AsyncConfigurer {
         executor.setThreadNamePrefix("Discord-Task");
         executor.initialize();
         return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler(){
+        return globalAsyncExceptionHandler;
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/global/config/AsyncConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/config/AsyncConfig.java
@@ -22,6 +22,9 @@ public class AsyncConfig implements AsyncConfigurer {
     @Bean(name = "discordTaskExecutor")
     public Executor getAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setQueueCapacity(Integer.MAX_VALUE);
+        executor.setMaxPoolSize(Integer.MAX_VALUE);
         executor.setThreadNamePrefix("Discord-Task");
         executor.initialize();
         return executor;

--- a/src/main/java/team/themoment/hellogsmv3/global/exception/GlobalAsyncExceptionHandler.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/exception/GlobalAsyncExceptionHandler.java
@@ -1,0 +1,17 @@
+package team.themoment.hellogsmv3.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Slf4j
+@Component
+public class GlobalAsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+
+    @Override
+    public void handleUncaughtException(Throwable ex, Method method, Object... params) {
+        log.error("[ASYNC-DISCORD-ERROR] method: {}, exception: {}", method.getName(), ex);
+    }
+}


### PR DESCRIPTION
## 본문

기존 디스코드 알람 전송 비동기 처리는 따로 스레드풀 설정이 없어 SimpleAsyncTaskExecutor가 사용되었습니다.
이는 스레드를 관리하는 게 아니라 매번 새로 만들기 때문에 낭비로 이어질 수 있습니다. 
이를 방지하기 위해 ThreadPoolTaskExecutor를 사용해 스레드풀을 정의하였습니다.

corePoolSize=1, queueCapacity=unlimit, maxPoolSize=unlimit으로 설정하였습니다.
큐 용량에 제한을 두어 스레드를 늘리는게 오히려 성능 저하가 오는 테스트 자료를 보았습니다. (생성 리소스가 메모리에 대기시켜두는 거보다 느림)
또한 corePoolSize도 [자바 전문가가 제시하는 공식](https://blog.devops.dev/how-to-determine-java-thread-pool-size-a-comprehensive-guide-4f73a4758273)을 적용하여 1이 적당할 것이라고 판단하였습니다.

비동기 메서드에서 발생하는 예외를 처리하기 위해 AsyncUncaughtExceptionHandler를 구현하였습니다.
로그 내용은 발생 method와 exception 트레이스로 하였습니다.

궁금한점 혹은 이견 있으시면 편하게 말씀해주세요