### PR TITLE
[member] findById 쿼리 분리

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/member/repo/MemberRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/repo/MemberRepository.java
@@ -20,5 +20,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     void deleteDuplicate(Member member);
 
     @Lock(value = LockModeType.PESSIMISTIC_WRITE)
-    Optional<Member> findById(Long memberId);
+    @Query("SELECT m FROM Member m WHERE m.id = :memberId")
+    Optional<Member> findByIdForUpdate(Long memberId);
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/MemberService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/MemberService.java
@@ -17,4 +17,9 @@ public class MemberService {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new ExpectedException("존재하지 않는 지원자입니다. member ID: " + memberId, HttpStatus.NOT_FOUND));
     }
+
+    public Member findByIdForUpdateOrThrow(Long memberId) {
+        return memberRepository.findByIdForUpdate(memberId)
+                .orElseThrow(() -> new ExpectedException("존재하지 않는 지원자입니다. member ID: " + memberId, HttpStatus.NOT_FOUND));
+    }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CreateOneseoService.java
@@ -46,7 +46,7 @@ public class CreateOneseoService {
 
         isValidMiddleSchoolInfo(reqDto);
 
-        Member currentMember = memberService.findByIdOrThrow(memberId);
+        Member currentMember = memberService.findByIdForUpdateOrThrow(memberId);
 
         isExistOneseo(currentMember);
 


### PR DESCRIPTION
## 본문

findById 메서드의 불필요한 Lock 제거를 위해 쿼리를 분리하였습니다.

락을 적용할 메서드에 JPQL을 사용해 쿼리를 정의하고 ForUpdate라는 접미사를 붙여주었습니다.
쿼리 - `SELECT m FROM Member m WHERE m.id = :memberId`