### PR TITLE
[CI] ci script gradle 명령어 수정

### DIFF
--- a/.github/workflows/hellogsm-prod-ci.yml
+++ b/.github/workflows/hellogsm-prod-ci.yml
@@ -37,9 +37,8 @@ jobs:
 
         shell: bash
 
-      # Run build and tests without packaging
-      - name: Run Build and Tests
-        run: ./gradlew clean assemble
+      - name: Build with Gradle
+        run: ./gradlew clean build
 
       - name: CI Success Notification
         uses: sarisia/actions-status-discord@v1

--- a/.github/workflows/hellogsm-stage-ci.yml
+++ b/.github/workflows/hellogsm-stage-ci.yml
@@ -37,9 +37,8 @@ jobs:
 
         shell: bash
 
-      # Run build and tests without packaging
-      - name: Run Build and Tests
-        run: ./gradlew clean assemble
+      - name: Build with Gradle
+        run: ./gradlew clean build
 
       - name: CI Success Notification
         uses: sarisia/actions-status-discord@v1


### PR DESCRIPTION
## 본문

- 기존에 CI script에 `gradlew assemble`을 사용하였습니다만, 이는 컴파일만 하고 테스트는 포함되지 않았습니다. 
- `assemble`+ `test` + 부가작업 이 포함된 `build`명령어로 수정하였습니다.
