### PR TITLE
[oneseo] 성적 계산 싱글톤 필드 동시성 문제 ThreadLocal 사용으로 개선

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
@@ -141,6 +141,8 @@ public class CalculateGradeService {
                     .score3_2(assignIndividualArtsPhysicalScore(freeSemesterKey, "3-2", graduationType, score_1, score_2, score_3, score_4))
                     .build();
 
+            clearThreadLocalValues();
+
             return CalculatedScoreResDto.builder()
                     .generalSubjectsScore(generalSubjectsScore)
                     .artsPhysicalSubjectsScore(artsPhysicalSubjectsScore)
@@ -151,6 +153,8 @@ public class CalculateGradeService {
                     .artsPhysicalSubjectsScoreDetail(artsPhysicalSubjectsScoreDetailResDto)
                     .build();
         }
+
+        clearThreadLocalValues();
 
         return CalculatedScoreResDto.builder()
                 .generalSubjectsScore(generalSubjectsScore)
@@ -455,5 +459,12 @@ public class CalculateGradeService {
     private void validateVolunteerScore(List<BigDecimal> convertedVolunteerHours) {
         if (convertedVolunteerHours.size() != 3)
             throw new ExpectedException("봉사일수 개수가 유효하지 않습니다.", HttpStatus.BAD_REQUEST);
+    }
+
+    private void clearThreadLocalValues() {
+        score2_1.remove();
+        score2_2.remove();
+        score3_1.remove();
+        score3_2.remove();
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGradeService.java
@@ -28,16 +28,13 @@ public class CalculateGradeService {
     private final EntranceTestResultRepository entranceTestResultRepository;
     private final EntranceTestFactorsDetailRepository entranceTestFactorsDetailRepository;
 
-    private BigDecimal score1_2 = BigDecimal.ZERO;
-    private BigDecimal score2_1 = BigDecimal.ZERO;
-    private BigDecimal score2_2 = BigDecimal.ZERO;
-    private BigDecimal score3_1 = BigDecimal.ZERO;
-    private BigDecimal score3_2 = BigDecimal.ZERO;
+    private ThreadLocal<BigDecimal> score1_2 = ThreadLocal.withInitial(() -> BigDecimal.ZERO);
+    private ThreadLocal<BigDecimal> score2_1 = ThreadLocal.withInitial(() -> BigDecimal.ZERO);
+    private ThreadLocal<BigDecimal> score2_2 = ThreadLocal.withInitial(() -> BigDecimal.ZERO);
+    private ThreadLocal<BigDecimal> score3_1 = ThreadLocal.withInitial(() -> BigDecimal.ZERO);
+    private ThreadLocal<BigDecimal> score3_2 = ThreadLocal.withInitial(() -> BigDecimal.ZERO);
 
     public CalculatedScoreResDto execute(MiddleSchoolAchievementReqDto dto, Oneseo oneseo, GraduationType graduationType) {
-
-        // 교과 성적 필드 초기화
-        initScore();
 
         validGraduationType(graduationType);
         validFreeSemester(dto.liberalSystem(), dto.freeSemester());
@@ -89,11 +86,11 @@ public class CalculateGradeService {
                         .attendanceScore(attendanceScore)
                         .volunteerScore(volunteerScore)
                         .totalNonSubjectsScore(totalNonSubjectsScore)
-                        .score1_2(score1_2)
-                        .score2_1(score2_1)
-                        .score2_2(score2_2)
-                        .score3_1(score3_1)
-                        .score3_2(score3_2)
+                        .score1_2(score1_2.get())
+                        .score2_1(score2_1.get())
+                        .score2_2(score2_2.get())
+                        .score3_1(score3_1.get())
+                        .score3_2(score3_2.get())
                         .build();
 
                 EntranceTestResult entranceTestResult = new EntranceTestResult(oneseo, entranceTestFactorsDetail, totalScore);
@@ -106,7 +103,7 @@ public class CalculateGradeService {
                 findEntranceTestFactorsDetail.updateGradeEntranceTestFactorsDetail(
                         generalSubjectsScore, artsPhysicalSubjectsScore, totalSubjectsScore,
                         attendanceScore, volunteerScore, totalNonSubjectsScore,
-                        score1_2, score2_1, score2_2, score3_1, score3_2
+                        score1_2.get(), score2_1.get(), score2_2.get(), score3_1.get(), score3_2.get()
                 );
 
                 findEntranceTestResult.modifyDocumentEvaluationScore(totalScore);
@@ -117,11 +114,11 @@ public class CalculateGradeService {
             }
 
             GeneralSubjectsScoreDetailResDto generalSubjectsScoreDetailResDto = GeneralSubjectsScoreDetailResDto.builder()
-                    .score1_2(score1_2)
-                    .score2_1(score2_1)
-                    .score2_2(score2_2)
-                    .score3_1(score3_1)
-                    .score3_2(score3_2)
+                    .score1_2(score1_2.get())
+                    .score2_1(score2_1.get())
+                    .score2_2(score2_2.get())
+                    .score3_1(score3_1.get())
+                    .score3_2(score3_2.get())
                     .build();
 
             validateArtPhysicalAchievement(graduationType, dto.artsPhysicalAchievement());
@@ -252,55 +249,55 @@ public class CalculateGradeService {
 
         switch (graduationType) {
             case CANDIDATE -> {
-                score1_2 = calcGeneralSubjectsScore(
+                score1_2.set(calcGeneralSubjectsScore(
                         dto.achievement1_2(), BigDecimal.valueOf(
                                 (liberalSystem.equals("자유학년제") || freeSemester.equals("1-2") || freeSemester.equals("1-1")) ? 0 : 54)
-                );
-                score2_1 = calcGeneralSubjectsScore(
+                ));
+                score2_1.set(calcGeneralSubjectsScore(
                         dto.achievement2_1(), BigDecimal.valueOf(
                                 freeSemester.equals("2-1") ? 0 : 54)
-                );
-                score2_2 = calcGeneralSubjectsScore(
+                ));
+                score2_2.set(calcGeneralSubjectsScore(
                         dto.achievement2_2(), BigDecimal.valueOf(
                                 freeSemester.equals("2-2") ? 0 :
                                         (freeSemester.equals("3-1") ? 72 : 54))
-                );
-                score3_1 = calcGeneralSubjectsScore(
+                ));
+                score3_1.set(calcGeneralSubjectsScore(
                         dto.achievement3_1(), BigDecimal.valueOf(
                                 (freeSemester.equals("3-1") ? 0 : 72))
-                );
+                ));
             }
             case GRADUATE -> {
-                score1_2 = calcGeneralSubjectsScore(
+                score1_2.set(calcGeneralSubjectsScore(
                         dto.achievement1_2(), BigDecimal.valueOf(
                                 (liberalSystem.equals("자유학년제") || freeSemester.equals("1-2")) ? 0 : 36)
-                );
-                score2_1 = calcGeneralSubjectsScore(
+                ));
+                score2_1.set(calcGeneralSubjectsScore(
                         dto.achievement2_1(), BigDecimal.valueOf(
                                 freeSemester.equals("2-1") ? 0 : 36)
-                );
-                score2_2 = calcGeneralSubjectsScore(
+                ));
+                score2_2.set(calcGeneralSubjectsScore(
                         dto.achievement2_2(), BigDecimal.valueOf(
                                 freeSemester.equals("2-2") ? 0 :
                                         (freeSemester.equals("3-1") || freeSemester.equals("3-2")) || freeSemester.equals("1-1") ? 54 : 36)
-                );
-                score3_1 = calcGeneralSubjectsScore(
+                ));
+                score3_1.set(calcGeneralSubjectsScore(
                         dto.achievement3_1(), BigDecimal.valueOf(
                                 freeSemester.equals("3-1") ? 0 : 54)
-                );
-                score3_2 = calcGeneralSubjectsScore(
+                ));
+                score3_2.set(calcGeneralSubjectsScore(
                         dto.achievement3_2(), BigDecimal.valueOf(
                                 (freeSemester.equals("3-2") ||  freeSemester.equals("1-1")) ? 0 : 54)
-                );
+                ));
             }
         }
 
         return Stream.of(
-                        score1_2,
-                        score2_1,
-                        score2_2,
-                        score3_1,
-                        score3_2)
+                        score1_2.get(),
+                        score2_1.get(),
+                        score2_2.get(),
+                        score3_1.get(),
+                        score3_2.get())
                 .reduce(BigDecimal.ZERO, BigDecimal::add)
                 .setScale(3, RoundingMode.HALF_UP);
     }
@@ -458,13 +455,5 @@ public class CalculateGradeService {
     private void validateVolunteerScore(List<BigDecimal> convertedVolunteerHours) {
         if (convertedVolunteerHours.size() != 3)
             throw new ExpectedException("봉사일수 개수가 유효하지 않습니다.", HttpStatus.BAD_REQUEST);
-    }
-
-    private void initScore() {
-        score1_2 = BigDecimal.ZERO;
-        score2_1 = BigDecimal.ZERO;
-        score2_2 = BigDecimal.ZERO;
-        score3_1 = BigDecimal.ZERO;
-        score3_2 = BigDecimal.ZERO;
     }
 }


### PR DESCRIPTION
## 개요

성적 계산 클래스(CalculateGradeService) 싱글톤 클래스 필드 동시성 문제를 ThreadLocal을 사용하여 개선하였습니다.

## 본문

성적 계산시 개별학기 환산점은 계산 메서드 여러 곳에서 사용되기 때문에 필드로 빼서 구현하게 되었습니다.
하지만 이러한 구조로 인해 싱글톤으로 관리되는 빈 특성상 여러 스레드가 필드를 공유하게 되고, 동시성 문제가 발생하였습니다.
https://github.com/themoment-team/hellogsm-server-24/pull/187 이러한 문제는 계산 메서드 시작 전에 필드를 초기화 하는 방식으로 해결한 작업이 반영되었습니다.

하지만 이러한 대처는 비슷한 방식의 동시성 문제를 야기할 수 있을 것이라 생각되어 불안전한 방식입니다.

그래서 현재 구조를 크게 변경하지 않으면서 안정성을 보장할 수 있는 방법인 ThreadLocal을 도입하여 문제를 개선해보았습니다.
ThreadLocal은 여러 스레드가 공유하는 필드를 각각의 스레드의 저장공간에 저장하여 해당 필드를 ThreadSafe하게 보장해주는 기능입니다.

기존 코드 구조를 크게 변경하지 않고 적용할 수 있어서 괜찮은 방식이라 생각하였습니다.