### PR TITLE
fix: gradlew 실행권한 중복부여 코드 삭제

### DIFF
--- a/.github/workflows/hellogsm-prod-cd.yml
+++ b/.github/workflows/hellogsm-prod-cd.yml
@@ -33,9 +33,6 @@ jobs:
           echo "${{ secrets.PROD_WEB_YML }}" > ./src/main/resources/application-prod.yml
 
         shell: bash
-        
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
 
       - name: Build with Gradle
         run: ./gradlew build


### PR DESCRIPTION
## 개요

cd script에서 중복으로 실행하던 코드를 삭제했습니다.

## 본문

hellogsm-prod-cd.yml에서 gradlew에 중복으로 실행권한을 부여하던 부분을 삭제했습니다.

Before
```yml
      - name : Setup Gradle's permission
        run : chmod +x gradlew

      - name: Make yml file
        run: touch ./src/main/resources/application-prod.yml
          
          echo "${{ secrets.PROD_WEB_YML }}" > ./src/main/resources/application-prod.yml

        shell: bash
        
      - name: Grant execute permission for gradlew
        run: chmod +x gradlew
```
After
```yml
      - name : Setup Gradle's permission
        run : chmod +x gradlew

      - name: Make yml file
        run: touch ./src/main/resources/application-prod.yml
          
          echo "${{ secrets.PROD_WEB_YML }}" > ./src/main/resources/application-prod.yml

        shell: bash
```
