### PR TITLE
[ci/cd] 컨테이너가 실행중이지 않을경우 발생하던 CI/CD 에러 해결

### DIFF
--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -4,12 +4,12 @@ IMAGE_NAME=hellogsm-stage-server-img
 CONTAINER_NAME=hellogsm-stage-server
 DOCKERFILE_NAME=DockerfileStage
 
-CURRENT_CONTAINER_ID=$(docker ps -q -f name=$CONTAINER_NAME)
+EXISTING_CONTAINER_ID=$(docker ps -a -q -f name=$CONTAINER_NAME)
 
-if [ ! -z "$CURRENT_CONTAINER_ID" ]
+if [ ! -z "$EXISTING_CONTAINER_ID" ]
 then
-  echo "현재 구동 중인 컨테이너가 있습니다. 중지하고 삭제합니다."
-  docker stop $CONTAINER_NAME
+  echo "현재 이전버전의 컨테이너가 있습니다. 중지하고 삭제합니다."
+  docker stop $CONTAINER_NAME || true
   docker rm $CONTAINER_NAME
 fi
 

--- a/scripts/prod-deploy.sh
+++ b/scripts/prod-deploy.sh
@@ -5,15 +5,23 @@ CONTAINER_NAME=hellogsm-prod-server
 DOCKERFILE_NAME=DockerfileProd
 
 echo "> 현재 실행 중인 Docker 컨테이너 ID 확인" >> /home/ec2-user/deploy.log
-CURRENT_CONTAINER_ID=$(docker ps -q -f name=$CONTAINER_NAME)
+RUNNING_CONTAINER_ID=$(docker ps -q -f name=$CONTAINER_NAME)
+EXISTING_CONTAINER_ID=$(docker ps -a -q -f name=$CONTAINER_NAME)
 
-if [ -z $CURRENT_CONTAINER_ID ]
+if [ -z $RUNNING_CONTAINER_ID ]
 then
   echo "> 현재 구동중인 Docker 컨테이너가 없으므로 종료하지 않습니다." >> /home/ec2-user/deploy.log
 else
-  echo "> sudo docker stop $CURRENT_CONTAINER_ID"
-  sudo docker stop $CURRENT_CONTAINER_ID
-  sudo docker rm $CURRENT_CONTAINER_ID
+  echo "> sudo docker stop $RUNNING_CONTAINER_ID"
+  sudo docker stop $RUNNING_CONTAINER_ID
+fi
+
+if [ -z $EXISTING_CONTAINER_ID ]
+then
+  echo "> 현재 존재하는 Docker 컨테이너가 없으므로 삭제하지 않습니다." >> /home/ec2-user/deploy.log
+else
+  echo "> sudo docker rm $EXISTING_CONTAINER_ID"
+  sudo docker rm $EXISTING_CONTAINER_ID
 fi
 
 cd /home/ec2-user/builds/


### PR DESCRIPTION
## 개요
컨테이너가 실행중이지 않을경우 발생하던 CI/CD 잠재적인 에러를 방지했습니다.

## 본문
docker ps는 실행중인 컨테이너만 반환하므로, 이전버전의 컨테이너가 실행중이지 않다면 걸러낼 수 없었습니다. 그 상태로 `%CONTAINER_NAME을 사용하여 같은 이름의 컨테이너를 docker run을 통해 만드려고 할 경우, 에러가 발생하게 됩니다. 따라서 -a 파라미터로 실행중이지 않은 컨테이너까지 검색하도록 하였습니다.

### 변경 - optional
dev-deploy의 경우 컨테이너가 존재한다면  [(중지 or 무시) -> 삭제]
prod-deploy의 경우 [실행중인 컨테이너 중지 -> 존재하는 컨테이너 삭제]
하도록 변경되었습니다.

### 피드백 - optional

prod-deploy도 dev-deploy처럼 짧게 만들수 있었는데, `docker stop $CONTAINER_NAME || true`가 발생하는 에러를 무시하기 때문에 문제가 생길수도 있다고 생각해서 if문 두개로 처리하도록 하였는데 코드가 좀 더러워 보여서 피드백 가능한 부분이 있다면 받고싶습니다.

그런데 또 if문 없이 그냥 이렇게 하시는분들도 있긴하더라구요..
```shell
docker stop $CONTAINER_NAME || true
docker rm$CONTAINER_NAME || true
```


### 기타 - optional
![image](https://github.com/user-attachments/assets/6dc565eb-f46b-43a9-9634-d4c26f43c4ff)
백엔드 과제 하던중 실제로 겪어본 문제입니다.. ㅜㅜ
