### PR TITLE
[oneseo] 직무적성 소양평가가 역량검사로 변경됨에 따른 명칭수정

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/common/date/dto/DateResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/date/dto/DateResDto.java
@@ -18,7 +18,7 @@ public record DateResDto(
         LocalDateTime firstResultsAnnouncement,
 
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
-        LocalDateTime jobFitAssessment,
+        LocalDateTime competencyEvaluation,
 
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime inDepthInterview,

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/date/service/QueryDateService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/date/service/QueryDateService.java
@@ -16,7 +16,7 @@ public class QueryDateService {
                 .oneseoSubmissionStart(scheduleEnv.oneseoSubmissionStart())
                 .oneseoSubmissionEnd(scheduleEnv.oneseoSubmissionEnd())
                 .firstResultsAnnouncement(scheduleEnv.firstResultsAnnouncement())
-                .jobFitAssessment(scheduleEnv.aptitudeEvaluation())
+                .jobFitAssessment(scheduleEnv.competencyEvaluation())
                 .inDepthInterview(scheduleEnv.interview())
                 .finalResultsAnnouncement(scheduleEnv.finalResultsAnnouncement())
                 .build();

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/date/service/QueryDateService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/date/service/QueryDateService.java
@@ -16,7 +16,7 @@ public class QueryDateService {
                 .oneseoSubmissionStart(scheduleEnv.oneseoSubmissionStart())
                 .oneseoSubmissionEnd(scheduleEnv.oneseoSubmissionEnd())
                 .firstResultsAnnouncement(scheduleEnv.firstResultsAnnouncement())
-                .jobFitAssessment(scheduleEnv.competencyEvaluation())
+                .competencyEvaluation(scheduleEnv.competencyEvaluation())
                 .inDepthInterview(scheduleEnv.interview())
                 .finalResultsAnnouncement(scheduleEnv.finalResultsAnnouncement())
                 .build();

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -39,7 +39,7 @@ public class OneseoController {
     private final CreateOneseoService createOneseoService;
     private final ModifyOneseoService modifyOneseoService;
     private final ModifyRealOneseoArrivedYnService modifyRealOneseoArrivedYnService;
-    private final ModifyAptitudeEvaluationScoreService modifyAptitudeEvaluationScoreService;
+    private final ModifyCompetencyEvaluationScoreService modifyCompetencyEvaluationScoreService;
     private final ModifyInterviewScoreService modifyInterviewScoreService;
     private final QueryAdmissionTicketsService queryAdmissionTicketsService;
     private final DownloadExcelService downloadExcelService;
@@ -78,13 +78,13 @@ public class OneseoController {
         return modifyRealOneseoArrivedYnService.execute(memberId);
     }
 
-    @Operation(summary = "적성 검사 점수 기입", description = "맴버 id로 원서의 적성 검사 점수를 기입합니다.")
-    @PatchMapping("/aptitude-score/{memberId}")
-    public CommonApiResponse modifyAptitudeScore(
+    @Operation(summary = "역량검사 점수 기입", description = "맴버 id로 원서의 역량검사 점수를 기입합니다.")
+    @PatchMapping("/competency-score/{memberId}")
+    public CommonApiResponse modifyCompetencyScore(
             @PathVariable Long memberId,
-            @RequestBody @Valid AptitudeEvaluationScoreReqDto aptitudeEvaluationScoreReqDto
+            @RequestBody @Valid CompetencyEvaluationScoreReqDto competencyEvaluationScoreReqDto
     ) {
-        modifyAptitudeEvaluationScoreService.execute(memberId, aptitudeEvaluationScoreReqDto);
+        modifyCompetencyEvaluationScoreService.execute(memberId, competencyEvaluationScoreReqDto);
         return CommonApiResponse.success("수정되었습니다.");
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/CompetencyEvaluationScoreReqDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/request/CompetencyEvaluationScoreReqDto.java
@@ -6,10 +6,10 @@ import jakarta.validation.constraints.NotNull;
 
 import java.math.BigDecimal;
 
-public record AptitudeEvaluationScoreReqDto(
+public record CompetencyEvaluationScoreReqDto(
         @NotNull
         @DecimalMin(value = "0.0", message = "0점 이상이여야 합니다.")
         @DecimalMax(value = "100.0", message = "100점 이하여야 합니다.")
-        BigDecimal aptitudeEvaluationScore
+        BigDecimal competencyEvaluationScore
 ) {
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/SearchOneseoResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/SearchOneseoResDto.java
@@ -19,7 +19,7 @@ public record SearchOneseoResDto(
         String guardianPhoneNumber,
         String schoolTeacherPhoneNumber,
         YesNo firstTestPassYn,
-        BigDecimal aptitudeEvaluationScore,
+        BigDecimal competencyEvaluationScore,
         BigDecimal interviewScore,
         YesNo secondTestPassYn,
         YesNo entranceIntentionYn

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestResult.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestResult.java
@@ -2,7 +2,6 @@ package team.themoment.hellogsmv3.domain.oneseo.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 
 import java.math.BigDecimal;
@@ -38,8 +37,8 @@ public class EntranceTestResult {
     @Column(name = "first_test_pass_yn")
     private YesNo firstTestPassYn;
 
-    @Column(name = "aptitude_evaluation_score")
-    private BigDecimal aptitudeEvaluationScore;
+    @Column(name = "competency_evaluation_score")
+    private BigDecimal competencyEvaluationScore;
 
     @Column(name = "interview_score")
     private BigDecimal interviewScore;
@@ -48,8 +47,8 @@ public class EntranceTestResult {
     @Column(name = "second_test_pass_yn")
     private YesNo secondTestPassYn;
 
-    public void modifyAptitudeEvaluationScore(BigDecimal aptitudeEvaluationScore) {
-        this.aptitudeEvaluationScore = aptitudeEvaluationScore;
+    public void modifyCompetencyEvaluationScore(BigDecimal competencyEvaluationScore) {
+        this.competencyEvaluationScore = competencyEvaluationScore;
     }
 
     public void modifyInterviewScore(BigDecimal interviewScore) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
@@ -142,7 +142,7 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
                         oneseo.oneseoPrivacyDetail.guardianPhoneNumber,
                         oneseo.oneseoPrivacyDetail.schoolTeacherPhoneNumber,
                         oneseo.entranceTestResult.firstTestPassYn,
-                        oneseo.entranceTestResult.aptitudeEvaluationScore,
+                        oneseo.entranceTestResult.competencyEvaluationScore,
                         oneseo.entranceTestResult.interviewScore,
                         oneseo.entranceTestResult.secondTestPassYn,
                         oneseo.entranceIntentionYn

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelService.java
@@ -35,7 +35,7 @@ public class DownloadExcelService {
     private static final List<String> HEADER_NAMES = List.of(
             "순번", "접수번호", "성명", "1지망", "2지망", "3지망", "생년월일", "성별", "상세주소", "출신학교",
             "학력", "초기전형", "적용되는 전형", "일반교과점수", "예체능점수", "출석점수", "봉사점수", "1차전형총점",
-            "직무적성소양평가점수", "심층면접점수", "최종점수", "최종학과", "지원자연락처", "보호자연락처", "담임연락처", "1차전형결과", "2차전형결과"
+            "역량평가점수", "심층면접점수", "최종점수", "최종학과", "지원자연락처", "보호자연락처", "담임연락처", "1차전형결과", "2차전형결과"
     );
 
     public Workbook execute() {
@@ -161,7 +161,7 @@ public class DownloadExcelService {
                     String.valueOf(entranceTestResult.getEntranceTestFactorsDetail().getAttendanceScore()),
                     String.valueOf(entranceTestResult.getEntranceTestFactorsDetail().getVolunteerScore()),
                     String.valueOf(entranceTestResult.getDocumentEvaluationScore()),
-                    String.valueOf(entranceTestResult.getAptitudeEvaluationScore()),
+                    String.valueOf(entranceTestResult.getCompetencyEvaluationScore()),
                     String.valueOf(entranceTestResult.getInterviewScore()),
                     String.valueOf(finalScore),
                     String.valueOf(oneseo.getDecidedMajor()),
@@ -208,12 +208,12 @@ public class DownloadExcelService {
 
     private BigDecimal calculateFinalScore(EntranceTestResult entranceTestResult) {
 
-        BigDecimal aptitudeEvaluationScore = entranceTestResult.getAptitudeEvaluationScore();
+        BigDecimal competencyEvaluationScore = entranceTestResult.getCompetencyEvaluationScore();
         BigDecimal interviewScore = entranceTestResult.getInterviewScore();
 
         if (
                 entranceTestResult.getSecondTestPassYn() == null
-                        || aptitudeEvaluationScore == null
+                        || competencyEvaluationScore == null
                         || interviewScore == null
         ) {
             return null;
@@ -223,7 +223,7 @@ public class DownloadExcelService {
                 .divide(BigDecimal.valueOf(3), 3, RoundingMode.HALF_UP);
 
         return documentEvaluationScore.multiply(BigDecimal.valueOf(0.5))
-                .add(aptitudeEvaluationScore.multiply(BigDecimal.valueOf(0.3)))
+                .add(competencyEvaluationScore.multiply(BigDecimal.valueOf(0.3)))
                 .add(interviewScore.multiply(BigDecimal.valueOf(0.2)))
                 .setScale(3, RoundingMode.HALF_UP);
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyCompetencyEvaluationScoreService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyCompetencyEvaluationScoreService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
-import team.themoment.hellogsmv3.domain.oneseo.dto.request.AptitudeEvaluationScoreReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.CompetencyEvaluationScoreReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
@@ -13,21 +13,21 @@ import java.math.BigDecimal;
 
 @Service
 @RequiredArgsConstructor
-public class ModifyAptitudeEvaluationScoreService {
+public class ModifyCompetencyEvaluationScoreService {
 
     private final MemberService memberService;
     private final OneseoService oneseoService;
     private final EntranceTestResultRepository entranceTestResultRepository;
 
-    public void execute(Long memberId, AptitudeEvaluationScoreReqDto aptitudeEvaluationScoreReqDto) {
+    public void execute(Long memberId, CompetencyEvaluationScoreReqDto competencyEvaluationScoreReqDto) {
         Member member = memberService.findByIdOrThrow(memberId);
         Oneseo oneseo = oneseoService.findByMemberOrThrow(member);
 
         EntranceTestResult entranceTestResult = oneseo.getEntranceTestResult();
         OneseoService.isBeforeSecondTest(entranceTestResult.getSecondTestPassYn());
 
-        BigDecimal aptitudeEvaluationScore = aptitudeEvaluationScoreReqDto.aptitudeEvaluationScore();
-        entranceTestResult.modifyAptitudeEvaluationScore(aptitudeEvaluationScore);
+        BigDecimal competencyEvaluationScore = competencyEvaluationScoreReqDto.competencyEvaluationScore();
+        entranceTestResult.modifyCompetencyEvaluationScore(competencyEvaluationScore);
 
         entranceTestResultRepository.save(entranceTestResult);
     }

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -181,7 +181,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.PATCH, "/oneseo/v3/arrived-status/{memberId}").hasAnyAuthority(
                         Role.ADMIN.name()
                 )
-                .requestMatchers(HttpMethod.PATCH, "/oneseo/v3/aptitude-score/{memberId}").hasAnyAuthority(
+                .requestMatchers(HttpMethod.PATCH, "/oneseo/v3/competency-score/{memberId}").hasAnyAuthority(
                         Role.ADMIN.name()
                 )
                 .requestMatchers(HttpMethod.PATCH, "/oneseo/v3/interview-score/{memberId}").hasAnyAuthority(

--- a/src/main/java/team/themoment/hellogsmv3/global/security/data/ScheduleEnvironment.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/data/ScheduleEnvironment.java
@@ -9,7 +9,7 @@ public record ScheduleEnvironment(
     LocalDateTime oneseoSubmissionStart,
     LocalDateTime oneseoSubmissionEnd,
     LocalDateTime firstResultsAnnouncement,
-    LocalDateTime aptitudeEvaluation,
+    LocalDateTime competencyEvaluation,
     LocalDateTime interview,
     LocalDateTime finalResultsAnnouncement
 ) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -104,7 +104,7 @@ schedule:
   oneseoSubmissionStart: ${ONESEO_SUBMISSION_START}
   oneseoSubmissionEnd: ${ONESEO_SUBMISSION_END}
   firstResultsAnnouncement: ${FIRST_RESULTS_ANNOUNCEMENT}
-  aptitudeEvaluation: ${APTITUDE_EVALUATION}
+  competencyEvaluation: ${COMPETENCY_EVALUATION}
   interview: ${INTERVIEW}
   finalResultsAnnouncement: ${FINAL_RESULTS_ANNOUNCEMENT}
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelServiceTest.java
@@ -122,7 +122,7 @@ public class DownloadExcelServiceTest {
             List<String> expectedHeader = List.of(
                     "순번", "접수번호", "성명", "1지망", "2지망", "3지망", "생년월일", "성별", "상세주소", "출신학교",
                     "학력", "초기전형", "적용되는 전형", "일반교과점수", "예체능점수", "출석점수", "봉사점수", "1차전형총점",
-                    "직무적성소양평가점수", "심층면접점수", "최종점수", "최종학과", "지원자연락처", "보호자연락처", "담임연락처", "1차전형결과", "2차전형결과"
+                    "역량평가점수", "심층면접점수", "최종점수", "최종학과", "지원자연락처", "보호자연락처", "담임연락처", "1차전형결과", "2차전형결과"
             );
 
             String wantedScreening = null;
@@ -153,7 +153,7 @@ public class DownloadExcelServiceTest {
                     String.valueOf(entranceTestResult.getEntranceTestFactorsDetail().getAttendanceScore()),
                     String.valueOf(entranceTestResult.getEntranceTestFactorsDetail().getVolunteerScore()),
                     String.valueOf(entranceTestResult.getDocumentEvaluationScore()),
-                    String.valueOf(entranceTestResult.getAptitudeEvaluationScore()),
+                    String.valueOf(entranceTestResult.getCompetencyEvaluationScore()),
                     String.valueOf(entranceTestResult.getInterviewScore()),
                     String.valueOf(46.334),
                     String.valueOf(oneseo.getDecidedMajor()),
@@ -230,7 +230,7 @@ public class DownloadExcelServiceTest {
                     .documentEvaluationScore(BigDecimal.valueOf(80))
                     .firstTestPassYn(yn)
                     .secondTestPassYn(yn)
-                    .aptitudeEvaluationScore(BigDecimal.valueOf(70))
+                    .competencyEvaluationScore(BigDecimal.valueOf(70))
                     .interviewScore(BigDecimal.valueOf(60))
                     .build();
         }

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyCompetencyEvaluationScoreServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyCompetencyEvaluationScoreServiceTest.java
@@ -10,22 +10,21 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
-import team.themoment.hellogsmv3.domain.oneseo.dto.request.AptitudeEvaluationScoreReqDto;
+import team.themoment.hellogsmv3.domain.oneseo.dto.request.CompetencyEvaluationScoreReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.math.BigDecimal;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
-@DisplayName("ModifyAptitudeEvaluationScoreService 클래스의")
-public class ModifyAptitudeEvaluationScoreServiceTest {
+@DisplayName("ModifyCompetencyEvaluationScoreService 클래스의")
+public class ModifyCompetencyEvaluationScoreServiceTest {
 
     @Mock
     private MemberService memberService;
@@ -35,7 +34,7 @@ public class ModifyAptitudeEvaluationScoreServiceTest {
     private EntranceTestResultRepository entranceTestResultRepository;
 
     @InjectMocks
-    private ModifyAptitudeEvaluationScoreService modifyAptitudeEvaluationScoreService;
+    private ModifyCompetencyEvaluationScoreService modifyCompetencyEvaluationScoreService;
 
     @BeforeEach
     void setUp() {
@@ -49,8 +48,8 @@ public class ModifyAptitudeEvaluationScoreServiceTest {
         private final BigDecimal newScore = BigDecimal.valueOf(85);
 
         @Nested
-        @DisplayName("존재하는 회원 ID와 적성 검사 점수가 주어지면")
-        class Context_with_existing_member_id_and_aptitude_evaluation_score {
+        @DisplayName("존재하는 회원 ID와 역량 검사 점수가 주어지면")
+        class Context_with_existing_member_id_and_competency_evaluation_score {
             EntranceTestResult entranceTestResult;
 
             @BeforeEach
@@ -60,7 +59,7 @@ public class ModifyAptitudeEvaluationScoreServiceTest {
                         .build();
 
                 entranceTestResult = EntranceTestResult.builder()
-                        .aptitudeEvaluationScore(BigDecimal.valueOf(70))
+                        .competencyEvaluationScore(BigDecimal.valueOf(70))
                         .secondTestPassYn(null)
                         .build();
 
@@ -74,13 +73,13 @@ public class ModifyAptitudeEvaluationScoreServiceTest {
             }
 
             @Test
-            @DisplayName("적성 검사 점수를 저장한다.")
-            void it_save_aptitude_evaluation_score() {
-                AptitudeEvaluationScoreReqDto aptitudeEvaluationScoreReqDto = new AptitudeEvaluationScoreReqDto(newScore);
+            @DisplayName("역량 검사 점수를 저장한다.")
+            void it_save_competency_evaluation_score() {
+                CompetencyEvaluationScoreReqDto competencyEvaluationScoreReqDto = new CompetencyEvaluationScoreReqDto(newScore);
 
-                modifyAptitudeEvaluationScoreService.execute(memberId, aptitudeEvaluationScoreReqDto);
+                modifyCompetencyEvaluationScoreService.execute(memberId, competencyEvaluationScoreReqDto);
 
-                assertEquals(newScore, entranceTestResult.getAptitudeEvaluationScore());
+                assertEquals(newScore, entranceTestResult.getCompetencyEvaluationScore());
                 verify(entranceTestResultRepository).save(entranceTestResult);
             }
         }
@@ -97,9 +96,9 @@ public class ModifyAptitudeEvaluationScoreServiceTest {
             @Test
             @DisplayName("ExpectedException을 던진다")
             void it_throws_expected_exception() {
-                AptitudeEvaluationScoreReqDto aptitudeEvaluationScoreReqDto = new AptitudeEvaluationScoreReqDto(newScore);
+                CompetencyEvaluationScoreReqDto competencyEvaluationScoreReqDto = new CompetencyEvaluationScoreReqDto(newScore);
 
-                ExpectedException exception = assertThrows(ExpectedException.class, () -> modifyAptitudeEvaluationScoreService.execute(memberId, aptitudeEvaluationScoreReqDto));
+                ExpectedException exception = assertThrows(ExpectedException.class, () -> modifyCompetencyEvaluationScoreService.execute(memberId, competencyEvaluationScoreReqDto));
 
                 assertEquals("존재하지 않는 지원자입니다. member ID: ", exception.getMessage());
                 assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyCompetencyEvaluationScoreServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyCompetencyEvaluationScoreServiceTest.java
@@ -48,7 +48,7 @@ public class ModifyCompetencyEvaluationScoreServiceTest {
         private final BigDecimal newScore = BigDecimal.valueOf(85);
 
         @Nested
-        @DisplayName("존재하는 회원 ID와 역량 검사 점수가 주어지면")
+        @DisplayName("존재하는 회원 ID와 역량검사 점수가 주어지면")
         class Context_with_existing_member_id_and_competency_evaluation_score {
             EntranceTestResult entranceTestResult;
 
@@ -73,7 +73,7 @@ public class ModifyCompetencyEvaluationScoreServiceTest {
             }
 
             @Test
-            @DisplayName("역량 검사 점수를 저장한다.")
+            @DisplayName("역량검사 점수를 저장한다.")
             void it_save_competency_evaluation_score() {
                 CompetencyEvaluationScoreReqDto competencyEvaluationScoreReqDto = new CompetencyEvaluationScoreReqDto(newScore);
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/ModifyRealOneseoArrivedYnServiceTest.java
@@ -10,7 +10,6 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.service.MemberService;
-import team.themoment.hellogsmv3.domain.oneseo.dto.request.AptitudeEvaluationScoreReqDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.ArrivedStatusResDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
@@ -18,8 +17,6 @@ import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
-
-import java.math.BigDecimal;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;

--- a/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/oneseo/service/SearchOneseoServiceTest.java
@@ -128,7 +128,7 @@ class SearchOneseoServiceTest {
                 assertEquals(oneseoPrivacyDetail.getGuardianPhoneNumber(), searchOneseoResDto.guardianPhoneNumber());
                 assertEquals(oneseoPrivacyDetail.getSchoolTeacherPhoneNumber(), searchOneseoResDto.schoolTeacherPhoneNumber());
                 assertEquals(entranceTestResult.getFirstTestPassYn(), searchOneseoResDto.firstTestPassYn());
-                assertEquals(entranceTestResult.getAptitudeEvaluationScore(), searchOneseoResDto.aptitudeEvaluationScore());
+                assertEquals(entranceTestResult.getCompetencyEvaluationScore(), searchOneseoResDto.competencyEvaluationScore());
                 assertEquals(entranceTestResult.getInterviewScore(), searchOneseoResDto.interviewScore());
                 assertEquals(entranceTestResult.getSecondTestPassYn(), searchOneseoResDto.secondTestPassYn());
             }
@@ -172,7 +172,7 @@ class SearchOneseoServiceTest {
                 .guardianPhoneNumber(oneseoPrivacyDetail.getGuardianPhoneNumber())
                 .schoolTeacherPhoneNumber(oneseoPrivacyDetail.getSchoolTeacherPhoneNumber())
                 .firstTestPassYn(entranceTestResult.getFirstTestPassYn())
-                .aptitudeEvaluationScore(entranceTestResult.getAptitudeEvaluationScore())
+                .competencyEvaluationScore(entranceTestResult.getCompetencyEvaluationScore())
                 .interviewScore(entranceTestResult.getInterviewScore())
                 .secondTestPassYn(entranceTestResult.getSecondTestPassYn())
                 .build();
@@ -182,7 +182,7 @@ class SearchOneseoServiceTest {
         return EntranceTestResult.builder()
                 .id(1L)
                 .firstTestPassYn(YES)
-                .aptitudeEvaluationScore(BigDecimal.TEN)
+                .competencyEvaluationScore(BigDecimal.TEN)
                 .interviewScore(BigDecimal.TEN)
                 .secondTestPassYn(YES)
                 .build();


### PR DESCRIPTION
## 개요

2026학년도 입학요강에서 ``직무적성 소양평가``가 ``역량평가``로 변경됨에 따라 ``oneseo`` 도메인의 클래스명,필드명,변수명,메서드명 등을 변경하였습니다

## 본문


2026학년도 입학요강에서 ``직무적성 소양평가``가 ``역량평가``로 명칭이 변경됨에 따라 ``oneseo`` 도메인과 ``common`` 도메인,``application.yml``에서 의 클래스명,필드명,변수명,메서드명 등을 변경하였습니다

### 변경
``aptitudeEvaluation``에서 ``competencyEvaluation``으로 명칭을 변경하였습니다

### 기타

아직 API문서와 환경변수 관련 문서는 수정하지 않았습니다
