### PR TITLE
[member] QueryMyFirstTestResultService, QueryMySecondTestResultService 테스트 코드 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMyFirstTestResultService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/service/QueryMyFirstTestResultService.java
@@ -26,5 +26,4 @@ public class QueryMyFirstTestResultService {
         return new FoundMemberFirstTestResDto(entranceTestResult.getFirstTestPassYn());
     }
 
-
 }

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMyFirstTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMyFirstTestResultServiceTest.java
@@ -1,0 +1,95 @@
+package team.themoment.hellogsmv3.domain.member.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberFirstTestResDto;
+import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
+import team.themoment.hellogsmv3.domain.oneseo.service.OneseoService;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+@DisplayName("QueryMyFirstTestResultService 클래스의")
+public class QueryMyFirstTestResultServiceTest {
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private OneseoService oneseoService;
+
+    @InjectMocks
+    private QueryMyFirstTestResultService queryMyFirstTestResultService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Nested
+    @DisplayName("execute 메소드는")
+    class Describe_execute {
+
+        private final Long memberId = 1L;
+        private Member member;
+        private Oneseo oneseo;
+
+        @BeforeEach
+        void setUp() {
+            member = Member.builder()
+                    .id(memberId)
+                    .build();
+
+            oneseo = Oneseo.builder()
+                    .member(member)
+                    .entranceTestResult(EntranceTestResult.builder()
+                            .firstTestPassYn(YesNo.YES)
+                            .build())
+                    .build();
+
+            given(memberService.findByIdOrThrow(memberId)).willReturn(member);
+            given(oneseoService.findByMemberOrThrow(member)).willReturn(oneseo);
+        }
+
+        @Nested
+        @DisplayName("1차 테스트 결과가 발표된 경우")
+        class Context_with_first_test_result_announced {
+
+            @BeforeEach
+            void setUp() {
+                given(oneseoService.validateFirstTestResultAnnouncement()).willReturn(false);
+            }
+
+            @Test
+            @DisplayName("1차 테스트 결과를 반환한다")
+            void it_returns_first_test_result() {
+                FoundMemberFirstTestResDto result = queryMyFirstTestResultService.execute(memberId);
+                assertEquals(oneseo.getEntranceTestResult().getFirstTestPassYn(), result.firstTestPassYn());
+            }
+        }
+
+        @Nested
+        @DisplayName("1차 테스트 결과가 발표 되지 않은 경우")
+        class Context_with_first_test_result_not_announced {
+
+            @BeforeEach
+            void setUp() {
+                given(oneseoService.validateFirstTestResultAnnouncement()).willReturn(true);
+            }
+
+            @Test
+            @DisplayName("null을 반환한다")
+            void it_returns_null() {
+                FoundMemberFirstTestResDto result = queryMyFirstTestResultService.execute(memberId);
+                assertNull(result);
+            }
+        }
+    }
+}

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMySecondTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMySecondTestResultServiceTest.java
@@ -12,6 +12,7 @@ import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberSecondTes
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.Major;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
 import team.themoment.hellogsmv3.domain.oneseo.service.OneseoService;
 
@@ -53,6 +54,7 @@ public class QueryMySecondTestResultServiceTest {
                     .entranceTestResult(EntranceTestResult.builder()
                             .secondTestPassYn(YesNo.YES)
                             .build())
+                    .decidedMajor(Major.SW)
                     .build();
 
             given(memberService.findByIdOrThrow(memberId)).willReturn(member);
@@ -73,6 +75,7 @@ public class QueryMySecondTestResultServiceTest {
             void it_returns_second_test_result_and_decided_major() {
                 FoundMemberSecondTestResDto result = queryMySecondTestResultService.execute(memberId);
                 assertEquals(oneseo.getEntranceTestResult().getSecondTestPassYn(), result.secondTestPassYn());
+                assertEquals(oneseo.getDecidedMajor(), result.decidedMajor());
             }
         }
 

--- a/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMySecondTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/member/service/QueryMySecondTestResultServiceTest.java
@@ -1,0 +1,96 @@
+package team.themoment.hellogsmv3.domain.member.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberFirstTestResDto;
+import team.themoment.hellogsmv3.domain.member.dto.response.FoundMemberSecondTestResDto;
+import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.entity.type.YesNo;
+import team.themoment.hellogsmv3.domain.oneseo.service.OneseoService;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+@DisplayName("QueryMySecondTestResultService 클래스의")
+public class QueryMySecondTestResultServiceTest {
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private OneseoService oneseoService;
+
+    @InjectMocks
+    private QueryMySecondTestResultService queryMySecondTestResultService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Nested
+    @DisplayName("execute 메소드는")
+    class Describe_execute {
+
+        private final Long memberId = 1L;
+        private Member member;
+        private Oneseo oneseo;
+
+        @BeforeEach
+        void setUp() {
+            member = Member.builder()
+                    .id(memberId)
+                    .build();
+
+            oneseo = Oneseo.builder()
+                    .member(member)
+                    .entranceTestResult(EntranceTestResult.builder()
+                            .secondTestPassYn(YesNo.YES)
+                            .build())
+                    .build();
+
+            given(memberService.findByIdOrThrow(memberId)).willReturn(member);
+            given(oneseoService.findByMemberOrThrow(member)).willReturn(oneseo);
+        }
+
+        @Nested
+        @DisplayName("2차 테스트 결과가 발표된 경우")
+        class Context_with_second_test_result_announced {
+
+            @BeforeEach
+            void setUp() {
+                given(oneseoService.validateSecondTestResultAnnouncement()).willReturn(false);
+            }
+
+            @Test
+            @DisplayName("2차 테스트 결과와 배정된 학과를 반환한다")
+            void it_returns_second_test_result_and_decided_major() {
+                FoundMemberSecondTestResDto result = queryMySecondTestResultService.execute(memberId);
+                assertEquals(oneseo.getEntranceTestResult().getSecondTestPassYn(), result.secondTestPassYn());
+            }
+        }
+
+        @Nested
+        @DisplayName("2차 테스트 결과가 발표 되지 않은 경우")
+        class Context_with_second_test_result_not_announced {
+
+            @BeforeEach
+            void setUp() {
+                given(oneseoService.validateSecondTestResultAnnouncement()).willReturn(true);
+            }
+
+            @Test
+            @DisplayName("null을 반환한다")
+            void it_returns_null() {
+                FoundMemberSecondTestResDto result = queryMySecondTestResultService.execute(memberId);
+                assertNull(result);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요

내 1차, 2차 테스트 결과 조회 서비스에 테스트 코드를 추가하였습니다.

## 본문

1차 테스트 결과가 발표되었을 경우 1차 테스트 결과를 반환한다.
1차 테스트 결과가 발표되지 않았을 경우 null을 반환한다(204 no content)

2차 테스트 결과가 발표되었을 경우 2차 테스트 결과와 배정된 학과를 반환한다.
2차 테스트 결과가 발표되지 않았을 경우 null을 반환한다(204 no content)

### 기타 - optional

서비스 로직이 동일하여 하나의 브랜치에서 두 서비스를 동시에 작업했습니다.