### PR TITLE
[oneseo] 2차전형 엑셀 점수 업로드 api

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/controller/OneseoController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.*;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.*;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.ScreeningCategory;
@@ -49,6 +50,7 @@ public class OneseoController {
     private final OneseoTempStorageService oneseoTempStorageService;
     private final ModifyEntranceIntentionService modifyEntranceIntentionService;
     private final QueryOneseoEditabilityService queryOneseoEditabilityService;
+    private final UploadExcelService uploadExcelService;
 
     @Operation(summary = "내 원서 등록", description = "원서를 등록합니다.")
     @PostMapping("/oneseo/me")
@@ -167,6 +169,15 @@ public class OneseoController {
     ) {
         oneseoTempStorageService.execute(reqDto, step, memberId);
         return CommonApiResponse.success("임시저장되었습니다.");
+    }
+
+    @Operation(summary = "엑셀 업로드", description = "엑셀 파일을 업로드하여 2차전형 점수를 입력합니다.")
+    @PostMapping("/excel")
+    public CommonApiResponse uploadExcel(
+            @RequestParam("file") MultipartFile file
+    ){
+        uploadExcelService.execute(file);
+        return CommonApiResponse.success("엑셀 파일이 성공적으로 업로드되었습니다.");
     }
 
     @Operation(summary = "엑셀 출력", description = "모든 원서의 정보를 엑셀 파일로 반환합니다.")

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/internal/SecondTestResultDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/internal/SecondTestResultDto.java
@@ -1,0 +1,9 @@
+package team.themoment.hellogsmv3.domain.oneseo.dto.internal;
+
+import java.math.BigDecimal;
+
+public record SecondTestResultDto(
+    BigDecimal competencyEvaluationScore,
+    BigDecimal interviewScore
+) {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
@@ -1,6 +1,7 @@
 package team.themoment.hellogsmv3.domain.oneseo.repository.custom;
 
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.SearchOneseoResDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import org.springframework.data.domain.Page;
@@ -35,4 +36,6 @@ public interface CustomOneseoRepository {
 
     List<Oneseo> findAllByScreeningWithAllDetails(Screening screening);
     List<Oneseo> findAllFailedWithAllDetails();
+
+    Optional<EntranceTestResult> findEntranceTestResultByExaminationNumber(String examinationNumber);
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/CustomOneseoRepository.java
@@ -13,6 +13,7 @@ import team.themoment.hellogsmv3.domain.oneseo.dto.response.AdmissionTicketsResD
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface CustomOneseoRepository {
@@ -37,5 +38,5 @@ public interface CustomOneseoRepository {
     List<Oneseo> findAllByScreeningWithAllDetails(Screening screening);
     List<Oneseo> findAllFailedWithAllDetails();
 
-    Optional<EntranceTestResult> findEntranceTestResultByExaminationNumber(String examinationNumber);
+    Map<String,EntranceTestResult> findEntranceTestResultByExaminationNumbersIn(List<String> examinationNumbers);
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
@@ -20,7 +20,9 @@ import team.themoment.hellogsmv3.domain.oneseo.repository.custom.CustomOneseoRep
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.querydsl.core.types.ExpressionUtils.anyOf;
 import static team.themoment.hellogsmv3.domain.member.entity.QMember.member;
@@ -302,12 +304,18 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
         }
     }
     @Override
-    public Optional<EntranceTestResult> findEntranceTestResultByExaminationNumber(String examinationNumber) {
-        return Optional.ofNullable(
-                queryFactory.selectFrom(entranceTestResult)
-                        .join(entranceTestResult.oneseo, oneseo)
-                        .where(oneseo.examinationNumber.eq(examinationNumber))
-                        .fetchOne()
-        );
+    public Map<String,EntranceTestResult> findEntranceTestResultByExaminationNumbersIn(List<String> examinationNumbers) {
+        return queryFactory.selectFrom(entranceTestResult)
+                .select(oneseo.examinationNumber, entranceTestResult)
+                .join(entranceTestResult.oneseo, oneseo)
+                .where(oneseo.examinationNumber.in(examinationNumbers))
+                .fetch()
+                .stream()
+                .collect(
+                        Collectors.toMap(
+                                tuple -> tuple.get(oneseo.examinationNumber),
+                                tuple -> tuple.get(entranceTestResult)
+                        )
+                );
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Repository;
 import team.themoment.hellogsmv3.domain.oneseo.dto.request.TestResultTag;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.AdmissionTicketsResDto;
 import team.themoment.hellogsmv3.domain.oneseo.dto.response.SearchOneseoResDto;
+import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.Screening;
 import team.themoment.hellogsmv3.domain.oneseo.entity.type.ScreeningCategory;
@@ -299,5 +300,14 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
                             entranceTestResult.secondTestPassYn.eq(NO)
                     );
         }
+    }
+    @Override
+    public Optional<EntranceTestResult> findEntranceTestResultByExaminationNumber(String examinationNumber) {
+        return Optional.ofNullable(
+                queryFactory.selectFrom(entranceTestResult)
+                        .join(entranceTestResult.oneseo, oneseo)
+                        .where(oneseo.examinationNumber.eq(examinationNumber))
+                        .fetchOne()
+        );
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelService.java
@@ -2,10 +2,7 @@ package team.themoment.hellogsmv3.domain.oneseo.service;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.apache.poi.ss.usermodel.Row;
-import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.ss.usermodel.Workbook;
-import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.apache.poi.ss.usermodel.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -80,6 +77,8 @@ public class UploadExcelService {
     private String readCell(Row row, CellIndex cellIndex){
         if (row.getCell(cellIndex.getIndex()) == null) {
             throw new ExpectedException("엑셀 파일에 필수 정보가 누락되었습니다.", HttpStatus.BAD_REQUEST);
+        }else if(row.getCell(cellIndex.getIndex()).getCellType() != CellType.STRING){
+            throw new ExpectedException("엑셀 파일의 셀 타입이 잘못되었습니다. 문자열 타입이어야 합니다.", HttpStatus.BAD_REQUEST);
         }
         return row.getCell(cellIndex.getIndex()).getStringCellValue();
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelService.java
@@ -1,0 +1,86 @@
+package team.themoment.hellogsmv3.domain.oneseo.service;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+@Service
+@RequiredArgsConstructor
+public class UploadExcelService {
+
+    private final EntranceTestResultRepository entranceTestResultRepository;
+    private final OneseoRepository oneseoRepository;
+
+    @Getter
+    private enum CellIndex {
+        EXAMINATION_NUMBER(0),
+        COMPETENCY_EVALUATION_SCORE(1),
+        INTERVIEW_SCORE(2);
+        private final int index;
+        CellIndex(int index) {
+            this.index = index;
+        }
+    }
+
+    public void execute(MultipartFile file) {
+        Workbook workbook = createWorkbookFromFile(file);
+        Sheet sheet = workbook.getSheetAt(0);
+        // 0번쨰 행은 헤더
+        for(int i = 1;i<sheet.getLastRowNum();i++) {
+            Row row = sheet.getRow(i);
+            if(row == null) break;
+            String examinationNumber = readCell(row, CellIndex.EXAMINATION_NUMBER);
+            BigDecimal competencyEvaluationScore = readScoreCell(row, CellIndex.COMPETENCY_EVALUATION_SCORE);
+            BigDecimal interviewScore = readScoreCell(row, CellIndex.INTERVIEW_SCORE);
+            saveSecondTestResult(examinationNumber, competencyEvaluationScore, interviewScore);
+        }
+    }
+
+    private void saveSecondTestResult(String examinationNumber, BigDecimal competencyEvaluationScore, BigDecimal interviewScore) {
+        oneseoRepository.findEntranceTestResultByExaminationNumber(examinationNumber)
+                .ifPresentOrElse(
+                        entranceTestResult -> {
+                            entranceTestResult.modifyInterviewScore(interviewScore);
+                            entranceTestResult.modifyCompetencyEvaluationScore(competencyEvaluationScore);
+                            entranceTestResultRepository.save(entranceTestResult);
+                        },
+                        () -> {
+                            throw new ExpectedException("해당 수험번호에 대한 응시결과(원서)가 존재하지 않습니다.", HttpStatus.NOT_FOUND);
+                        }
+                );
+    }
+
+    private Workbook createWorkbookFromFile(MultipartFile file){
+        if (file.isEmpty()) {
+            throw new ExpectedException("엑셀 파일이 비어있습니다.", HttpStatus.BAD_REQUEST);
+        }
+        try {
+            return WorkbookFactory.create(file.getInputStream());
+        } catch (IOException e) {
+            throw new ExpectedException("엑셀 파일을 읽는 데 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+    private BigDecimal readScoreCell(Row row, CellIndex cellIndex) {
+        String cellValue = readCell(row, cellIndex);
+        return (new BigDecimal(cellValue)).setScale(2, RoundingMode.HALF_UP);
+    }
+    private String readCell(Row row, CellIndex cellIndex){
+        if (row.getCell(cellIndex.getIndex()) == null) {
+            throw new ExpectedException("엑셀 파일에 필수 정보가 누락되었습니다.", HttpStatus.BAD_REQUEST);
+        }
+        return row.getCell(cellIndex.getIndex()).getStringCellValue();
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.poi.ss.usermodel.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import team.themoment.hellogsmv3.domain.oneseo.dto.internal.SecondTestResultDto;
 import team.themoment.hellogsmv3.domain.oneseo.entity.EntranceTestResult;
@@ -39,6 +40,7 @@ public class UploadExcelService {
         }
     }
 
+    @Transactional
     public void execute(MultipartFile file) {
         Workbook workbook = createWorkbookFromFile(file);
         Sheet sheet = workbook.getSheetAt(0);

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelService.java
@@ -72,7 +72,11 @@ public class UploadExcelService {
     }
     private BigDecimal readScoreCell(Row row, CellIndex cellIndex) {
         String cellValue = readCell(row, cellIndex);
-        return (new BigDecimal(cellValue)).setScale(2, RoundingMode.HALF_UP);
+        BigDecimal score = new BigDecimal(cellValue).setScale(2, RoundingMode.HALF_UP);
+        if(score.compareTo(BigDecimal.ZERO) < 0 || score.compareTo(new BigDecimal("100")) > 0) {
+            throw new ExpectedException("점수는 0 이상 100 이하의 값이어야 합니다.", HttpStatus.BAD_REQUEST);
+        }
+        return score;
     }
     private String readCell(Row row, CellIndex cellIndex){
         if (row.getCell(cellIndex.getIndex()) == null) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/UploadExcelService.java
@@ -39,9 +39,9 @@ public class UploadExcelService {
         Workbook workbook = createWorkbookFromFile(file);
         Sheet sheet = workbook.getSheetAt(0);
         // 0번쨰 행은 헤더
-        for(int i = 1;i<sheet.getLastRowNum();i++) {
+        for(int i = 1;i<=sheet.getLastRowNum();i++) {
             Row row = sheet.getRow(i);
-            if(row == null) break;
+            if(row == null) continue;
             String examinationNumber = readCell(row, CellIndex.EXAMINATION_NUMBER);
             BigDecimal competencyEvaluationScore = readScoreCell(row, CellIndex.COMPETENCY_EVALUATION_SCORE);
             BigDecimal interviewScore = readScoreCell(row, CellIndex.INTERVIEW_SCORE);

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -203,6 +203,9 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.PUT, "/oneseo/v3/final-submit").hasAnyAuthority(
                         Role.APPLICANT.name()
                 )
+                .requestMatchers(HttpMethod.POST, "/oneseo/v3/excel").hasAnyAuthority(
+                        Role.ADMIN.name()
+                )
                 .requestMatchers(HttpMethod.GET, "/oneseo/v3/excel").hasAnyAuthority(
                         Role.ADMIN.name()
                 )


### PR DESCRIPTION
## 개요

2차 전형 점수를 엑셀 파일로 업로드 할 수 있도록 하였습니다.

## 본문

1번째 열은 수험번호
2번째 열은 역검점수
3번째 열은 면접점수를 나타냅니다.
첫번째 행은 헤더 행으로 간주하여 읽지 않습니다.

점수를 BigDecimal 형태로 읽고 각 응시자별로 점수를 저장합니다.
Excel은 기본적으로 숫자 행을 double 형태로 저장하여 추후에 부동소수점으로 인한 손실을 고려하여
문자열 행으로 입력 받도록 구현하였습니다.

### 피드백 - optional

현재 코드상으로 엑셀에 입력된 각 행별로 jpa 쿼리가 실행됩니다.
비효율적임을 인지했으나 각각의 다른 데이터를 입력하는데에 있어서 querydsl과 jpa만으로 힘들다고 생각하였고,
다른 방법을 사용해서 구현하더라도 매우 긴 쿼리와 ORM 미사용이 단점이 될 수 있다고 우려했습니다.
결과적으로 어드민이 매우 적은 횟수로 사용하게될 api이고 하고, 위와 같은 이유로 여러번의 쿼리를 날리는 형태로 구현하게 되었습니다.
이에 대해 적절한 해결책이나 피드백이 있다면 해주시면 좋겠습니다!

### 사용방법 - optional
<img width="670" height="718" alt="image" src="https://github.com/user-attachments/assets/3a273ed3-417c-437c-879c-8405b2b51334" />

점수를 입력할 때 숫자 행이 아닌 문자열 행으로 입력해야 합니다.
서식에서 행 타입을 텍스트로 지정할 수 있습니다.

