### PR TITLE
[operation]: 일정 진행 여부가 존재 하지 않을 경우 방어로직 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/common/operation/repo/OperationTestResultRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/operation/repo/OperationTestResultRepository.java
@@ -4,7 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
 
+import java.util.Optional;
+
 public interface OperationTestResultRepository extends JpaRepository<OperationTestResult, Long> {
     @Query("SELECT o FROM OperationTestResult o WHERE o.id = 1")
-    OperationTestResult findTestResult();
+    Optional<OperationTestResult> findTestResult();
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceFirstTestResultService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceFirstTestResultService.java
@@ -26,7 +26,8 @@ public class AnnounceFirstTestResultService {
     public void execute() {
         validateFirstTestResultAnnouncementPeriod();
 
-        OperationTestResult testResult = operationTestResultRepository.findTestResult();
+        OperationTestResult testResult = operationTestResultRepository.findTestResult()
+                .orElseThrow(() -> new ExpectedException("시험 운영 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
         validateDuplicateAnnouncement(testResult);
 
         testResult.announceFirstTestResult();

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceSecondTestResultService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceSecondTestResultService.java
@@ -26,7 +26,8 @@ public class AnnounceSecondTestResultService {
     public void execute() {
         validateSecondTestResultAnnouncementPeriod();
 
-        OperationTestResult testResult = operationTestResultRepository.findTestResult();
+        OperationTestResult testResult = operationTestResultRepository.findTestResult()
+                .orElseThrow(() -> new ExpectedException("시험 운영 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
         validateDuplicateAnnouncement(testResult);
 
         testResult.announceSecondTestResult();

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/operation/service/QueryAnnounceTestResultService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/operation/service/QueryAnnounceTestResultService.java
@@ -1,11 +1,13 @@
 package team.themoment.hellogsmv3.domain.common.operation.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.common.operation.dto.response.AnnounceTestResultResDto;
 import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
 import team.themoment.hellogsmv3.domain.common.operation.repo.OperationTestResultRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
 @RequiredArgsConstructor
@@ -15,7 +17,8 @@ public class QueryAnnounceTestResultService {
 
     @Transactional(readOnly = true)
     public AnnounceTestResultResDto execute() {
-        OperationTestResult testResult = operationTestResultRepository.findTestResult();
+        OperationTestResult testResult = operationTestResultRepository.findTestResult()
+                .orElseThrow(() -> new ExpectedException("시험 운영 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
         return AnnounceTestResultResDto.builder()
                 .firstTestResultAnnouncementYn(testResult.getFirstTestResultAnnouncementYn())

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/OneseoService.java
@@ -3,7 +3,6 @@ package team.themoment.hellogsmv3.domain.oneseo.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
 import team.themoment.hellogsmv3.domain.common.operation.repo.OperationTestResultRepository;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.oneseo.dto.internal.MiddleSchoolAchievementCalcDto;
@@ -137,19 +136,19 @@ public class OneseoService {
     }
 
     public boolean validateFirstTestResultAnnouncement() {
-        OperationTestResult testResult = operationTestResultRepository.findTestResult();
-
-        return testResult.getFirstTestResultAnnouncementYn().equals(NO) ||
-                LocalDateTime.now().isBefore(scheduleEnv.firstResultsAnnouncement()) ||
-                entranceTestResultRepository.existsByFirstTestPassYnIsNull();
+        return operationTestResultRepository.findTestResult()
+                .map(testResult -> testResult.getFirstTestResultAnnouncementYn().equals(NO) ||
+                        LocalDateTime.now().isBefore(scheduleEnv.firstResultsAnnouncement()) ||
+                        entranceTestResultRepository.existsByFirstTestPassYnIsNull())
+                .orElse(true);
     }
 
     public boolean validateSecondTestResultAnnouncement() {
-        OperationTestResult testResult = operationTestResultRepository.findTestResult();
-
-        return testResult.getSecondTestResultAnnouncementYn().equals(NO) ||
-                LocalDateTime.now().isBefore(scheduleEnv.firstResultsAnnouncement()) ||
-                entranceTestResultRepository.existsByFirstTestPassYnIsNull();
+        return operationTestResultRepository.findTestResult()
+                .map(testResult -> testResult.getSecondTestResultAnnouncementYn().equals(NO) ||
+                        LocalDateTime.now().isBefore(scheduleEnv.firstResultsAnnouncement()) ||
+                        entranceTestResultRepository.existsByFirstTestPassYnIsNull())
+                .orElse(true);
     }
 
     public static void isValidMiddleSchoolInfo(OneseoReqDto reqDto) {


### PR DESCRIPTION
## 개요

시험 진행 여부를 저장하는 테이블에서 데이터가 INSERT 되지 않아 NULL일 때 방어로직이 없던 것을 개선하여 최소한의 방어로직을 추가하였습니다

## 본문

`Optioanl<>` 로 `orElse()`,`orElseThrow()` 를 이용하여 예외를 발행하거나 결과 발표 시기 이전인 것으로 처리하도록 하였습니다
