### PR TITLE
[oneseo] CalculateGedScoreService에서 발생하던 npe 예외처리 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGedService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/CalculateGedService.java
@@ -30,6 +30,8 @@ public class CalculateGedService {
 
         // 검정고시 평균 점수
         BigDecimal averageScore = dto.gedAvgScore();
+        if(averageScore == null)
+            throw new ExpectedException("검정고시 평균점이 null입니다!", HttpStatus.BAD_REQUEST);
 
         if (averageScore.compareTo(BigDecimal.valueOf(60)) < 0 || averageScore.compareTo(BigDecimal.valueOf(100)) > 0)
             throw new ExpectedException("검정고시 평균점은 60점 이상, 100점 이하여야 합니다.", HttpStatus.BAD_REQUEST);


### PR DESCRIPTION
## 개요

FE에서 필요한 필드를 보내지 않았을때 NPE가 발생하던 문제에 대해, null 검사후 예외를 던지도록 해결하였습니다.

## 본문

gedAvgScore가 입학 전형에 따라, nullable이 바뀌는 필드이기 때문에 @NotNull validator를 사용하기에는 무리가 있었습니다.
추후에 다른 Dto를 포함하여, Dto 클래스를 위한 각각의 validator를 구현하는것으로 개선할 수 있을것 같습니다.
