### PR TITLE
[oneseo] 입학요강과 상이했던 점수 소수점 자리 반영

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestFactorsDetail.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestFactorsDetail.java
@@ -18,37 +18,37 @@ public class EntranceTestFactorsDetail {
     @Column(name = "entrance_test_factors_detail_id")
     private Long id;
 
-    @Column(name = "general_subjects_score",scale = 3)
+    @Column(name = "general_subjects_score", scale = 3)
     private BigDecimal generalSubjectsScore;
 
-    @Column(name = "arts_physical_subjects_score",scale = 3)
+    @Column(name = "arts_physical_subjects_score", scale = 3)
     private BigDecimal artsPhysicalSubjectsScore;
 
-    @Column(name = "total_subjects_score",scale = 3)
+    @Column(name = "total_subjects_score", scale = 3)
     private BigDecimal totalSubjectsScore;
 
-    @Column(name = "attendance_score",scale = 3)
+    @Column(name = "attendance_score", scale = 3)
     private BigDecimal attendanceScore;
 
-    @Column(name = "volunteer_score",scale = 3)
+    @Column(name = "volunteer_score", scale = 3)
     private BigDecimal volunteerScore;
 
-    @Column(name = "total_non_subjects_score",scale = 3)
+    @Column(name = "total_non_subjects_score", scale = 3)
     private BigDecimal totalNonSubjectsScore;
 
-    @Column(name = "score_1_2",scale = 3)
+    @Column(name = "score_1_2", scale = 3)
     private BigDecimal score1_2;
 
-    @Column(name = "score_2_1",scale = 3)
+    @Column(name = "score_2_1", scale = 3)
     private BigDecimal score2_1;
 
-    @Column(name = "score_2_2",scale = 3)
+    @Column(name = "score_2_2", scale = 3)
     private BigDecimal score2_2;
 
-    @Column(name = "score_3_1",scale = 3)
+    @Column(name = "score_3_1", scale = 3)
     private BigDecimal score3_1;
 
-    @Column(name = "score_3_2",scale = 3)
+    @Column(name = "score_3_2", scale = 3)
     private BigDecimal score3_2;
 
     public void updateGradeEntranceTestFactorsDetail(

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestFactorsDetail.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestFactorsDetail.java
@@ -18,37 +18,37 @@ public class EntranceTestFactorsDetail {
     @Column(name = "entrance_test_factors_detail_id")
     private Long id;
 
-    @Column(name = "general_subjects_score")
+    @Column(name = "general_subjects_score",scale = 3)
     private BigDecimal generalSubjectsScore;
 
-    @Column(name = "arts_physical_subjects_score")
+    @Column(name = "arts_physical_subjects_score",scale = 3)
     private BigDecimal artsPhysicalSubjectsScore;
 
-    @Column(name = "total_subjects_score")
+    @Column(name = "total_subjects_score",scale = 3)
     private BigDecimal totalSubjectsScore;
 
-    @Column(name = "attendance_score")
+    @Column(name = "attendance_score",scale = 3)
     private BigDecimal attendanceScore;
 
-    @Column(name = "volunteer_score")
+    @Column(name = "volunteer_score",scale = 3)
     private BigDecimal volunteerScore;
 
-    @Column(name = "total_non_subjects_score")
+    @Column(name = "total_non_subjects_score",scale = 3)
     private BigDecimal totalNonSubjectsScore;
 
-    @Column(name = "score_1_2")
+    @Column(name = "score_1_2",scale = 3)
     private BigDecimal score1_2;
 
-    @Column(name = "score_2_1")
+    @Column(name = "score_2_1",scale = 3)
     private BigDecimal score2_1;
 
-    @Column(name = "score_2_2")
+    @Column(name = "score_2_2",scale = 3)
     private BigDecimal score2_2;
 
-    @Column(name = "score_3_1")
+    @Column(name = "score_3_1",scale = 3)
     private BigDecimal score3_1;
 
-    @Column(name = "score_3_2")
+    @Column(name = "score_3_2",scale = 3)
     private BigDecimal score3_2;
 
     public void updateGradeEntranceTestFactorsDetail(

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestResult.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestResult.java
@@ -30,14 +30,14 @@ public class EntranceTestResult {
     @JoinColumn(name = "entrance_test_factors_detail_id")
     private EntranceTestFactorsDetail entranceTestFactorsDetail;
 
-    @Column(name = "document_evaluation_score",scale = 3)
+    @Column(name = "document_evaluation_score", scale = 3)
     private BigDecimal documentEvaluationScore;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "first_test_pass_yn")
     private YesNo firstTestPassYn;
 
-    @Column(name = "competency_evaluation_score",scale = 3)
+    @Column(name = "competency_evaluation_score", scale = 3)
     private BigDecimal competencyEvaluationScore;
 
     @Column(name = "interview_score")

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestResult.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestResult.java
@@ -30,14 +30,14 @@ public class EntranceTestResult {
     @JoinColumn(name = "entrance_test_factors_detail_id")
     private EntranceTestFactorsDetail entranceTestFactorsDetail;
 
-    @Column(name = "document_evaluation_score")
+    @Column(name = "document_evaluation_score",scale = 3)
     private BigDecimal documentEvaluationScore;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "first_test_pass_yn")
     private YesNo firstTestPassYn;
 
-    @Column(name = "competency_evaluation_score")
+    @Column(name = "competency_evaluation_score",scale = 3)
     private BigDecimal competencyEvaluationScore;
 
     @Column(name = "interview_score")

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
@@ -80,6 +80,6 @@ public class MiddleSchoolAchievement {
     @Column(name = "free_semester")
     private String freeSemester;
 
-    @Column(name = "ged_avg_score")
+    @Column(name = "ged_avg_score", scale = 2)
     private BigDecimal gedAvgScore;
 }


### PR DESCRIPTION
## 개요

입학요강과 상이했던 소수점자리 계산을 일치하도록 변경했습니다.



## 본문

입항요강상 환산 점수는 소수점 넷째 자리에서 반올림해서, 소수점 세자리까지 나타내야합니다.
하지만 Hibernate에서 mysql에 BigDecimal을 나타내기 위해 기본적으로 Number(38,2) 타입을 사용하여, 소수점 둘째 자리까지만 저장됩니다.
이번 변경에서는 소수점 셋째 자리까지 저장해야하는 필드들의 scale을 3으로 변경하고, 일부 둘째 자리까지 저장하도록 하는 필드도 scale을 2로 명시하도록 변경하였습니다.

### 기타
Merge할때 db column을 변경된 코드에 맞게 변경해야합니다.
