### PR TITLE
[ci/cd] 개발 환경 배포 시 저장공간 확보를 위한 명령어 추가

### DIFF
--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -17,3 +17,5 @@ cd /home/ec2-user/builds/
 docker build -t $IMAGE_NAME -f $DOCKERFILE_NAME .
 
 docker run -d --name $CONTAINER_NAME -p 8080:8080 $IMAGE_NAME
+
+docker system prune -a --volumes -f


### PR DESCRIPTION
## 개요

개발 환경에 배포 시 인스턴스에 과거 버전의 이미지,컨테이너가 삭제되지 않고 누적되어 쌓여가는 문제가 있었습니다.이를 배포 시 해결하는 명령어를 스크립트에 추가하였습니다

## 본문

개발 환경에 배포 시 인스턴스에 과거 버전의 이미지,컨테이너가 삭제되지 않고 누적되어 쌓여가는 문제가 있었습니다.
이로 인하여 지속적으로 
<img width="468" height="158" alt="image" src="https://github.com/user-attachments/assets/76eb1aed-a432-4c6e-a7b6-7bc8b0eed660" />
경보 상태에 들어가 알림이 반복되며 개발자가 직접 인스턴스에 접속하여 Docker 정리 명령어를 입력하여 저장공간을 확보해주어야 하였습니다.

급기야 
```
[stderr]#7 ERROR: failed to copy files: userspace copy failed: write /var/lib/docker/overlay2/fgixhxuky412g7sn1zkdph94o/merged/hellogsm-server-v3/hellogsm-stage-server.jar: no space left on device
...
[stderr]ERROR: failed to solve: failed to copy files: userspace copy failed: write /var/lib/docker/overlay2/fgixhxuky412g7sn1zkdph94o/merged/hellogsm-server-v3/hellogsm-stage-server.jar: no space left on device
[stderr]docker: Error response from daemon: mkdir /var/lib/docker/overlay2/ba22b3b8f2ad9e4469e7f0d94adde8f1e93e781ab82fe3f68de2b9fee950e9a2-init: no space left on device.
```
다음 로그와 함께 2025년 8월 19일 14시56분경 개발 서버에 진행되던 CD가 저장공간 부족으로 중단되었습니다.

이러한 지속되는 문제를 해결하기 위하여 배포 스크립트 하단에 
```shell
docker system prune -a --volumes -f
```
다음 명령어를 추가하여 현재 사용되지 않는 Docker의 이미지,컨테이너,볼륨을 삭제하도록 하였습니다.

### 피드백

현재 적용한 명령어의 경우 Docker에서 현재 구동 중이지 않고 사용 중이지 않는 모든 이미지,컨테이너,볼륨 등을 삭제하는 급진적인 명령어인데 조금 더 안전한 방식으로,예를 들어 볼륨은 삭제하지 않는 식으로 변경할지 등의 의견 주시면 좋을 것 같습니다.
