### PR TITLE
[auth] OAuthAuthenticationService 방어 로직 강화 및 테스트 코드 작성

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/global/security/auth/service/OAuthAuthenticationService.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/auth/service/OAuthAuthenticationService.java
@@ -67,9 +67,10 @@ public class OAuthAuthenticationService {
     }
 
     private Map<String, Object> createUserAttributes(Member member, String provider, String email) {
+        Role memberRole = Optional.ofNullable(member.getRole()).orElse(Role.UNAUTHENTICATED);
         return Map.of(
                 "id", member.getId(),
-                "role", member.getRole(),
+                "role", memberRole,
                 "provider", provider,
                 "email", email,
                 "last_login_time", LocalDateTime.now()

--- a/src/test/java/team/themoment/hellogsmv3/domain/security/auth/service/OAuthAuthenticationServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/security/auth/service/OAuthAuthenticationServiceTest.java
@@ -1,0 +1,325 @@
+package team.themoment.hellogsmv3.domain.security.auth.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.member.entity.type.AuthReferrerType;
+import team.themoment.hellogsmv3.domain.member.entity.type.Role;
+import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
+import team.themoment.hellogsmv3.domain.security.auth.service.provider.OAuthProvider;
+import team.themoment.hellogsmv3.global.security.auth.dto.UserAuthInfo;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@DisplayName("OAuthAuthenticationService 클래스의")
+class OAuthAuthenticationServiceTest {
+
+    @Mock
+    private OAuthProviderFactory oAuthProviderFactory;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private OAuthProvider oAuthProvider;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpSession session;
+
+    @Mock
+    private SecurityContext securityContext;
+
+    private OAuthAuthenticationService oAuthAuthenticationService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        oAuthAuthenticationService = new OAuthAuthenticationService(oAuthProviderFactory, memberRepository);
+        SecurityContextHolder.setContext(securityContext);
+    }
+
+    @Nested
+    @DisplayName("execute 메소드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("유효한 provider와 code가 주어지고 기존 회원이 존재하면")
+        class Context_with_valid_provider_and_code_and_existing_member {
+
+            private final String provider = "google";
+            private final String code = "auth_code_123";
+            private final String email = "test@example.com";
+            private final AuthReferrerType authReferrerType = AuthReferrerType.GOOGLE;
+            private final Long memberId = 1L;
+
+            private Member existingMember;
+            private UserAuthInfo userAuthInfo;
+
+            @BeforeEach
+            void setUp() {
+                existingMember = Member.builder()
+                        .id(memberId)
+                        .email(email)
+                        .role(Role.APPLICANT)
+                        .authReferrerType(authReferrerType)
+                        .build();
+
+                userAuthInfo = new UserAuthInfo(email, provider, authReferrerType);
+
+                given(oAuthProviderFactory.getProvider(provider)).willReturn(oAuthProvider);
+                given(oAuthProvider.authenticate(code)).willReturn(userAuthInfo);
+                given(memberRepository.findByAuthReferrerTypeAndEmail(authReferrerType, email))
+                        .willReturn(Optional.of(existingMember));
+                given(request.getSession(false)).willReturn(session);
+                given(session.getLastAccessedTime()).willReturn(System.currentTimeMillis());
+            }
+
+            @Test
+            @DisplayName("OAuth 인증을 완료하고 보안 컨텍스트에 인증 정보를 설정한다")
+            void it_completes_oauth_authentication_and_sets_security_context() {
+                oAuthAuthenticationService.execute(provider, code, request);
+
+                verify(oAuthProviderFactory).getProvider(provider);
+                verify(oAuthProvider).authenticate(code);
+                verify(memberRepository).findByAuthReferrerTypeAndEmail(authReferrerType, email);
+                verify(memberRepository, never()).save(any(Member.class));
+
+                ArgumentCaptor<Authentication> authCaptor = ArgumentCaptor.forClass(Authentication.class);
+                verify(securityContext).setAuthentication(authCaptor.capture());
+
+                Authentication authentication = authCaptor.getValue();
+                assertTrue(authentication instanceof OAuth2AuthenticationToken);
+                OAuth2AuthenticationToken oAuthToken = (OAuth2AuthenticationToken) authentication;
+
+                assertEquals(provider, oAuthToken.getAuthorizedClientRegistrationId());
+                assertTrue(oAuthToken.getAuthorities().contains(new SimpleGrantedAuthority("OAUTH2_USER")));
+                assertTrue(oAuthToken.getAuthorities().contains(new SimpleGrantedAuthority("SCOPE_email")));
+                assertTrue(oAuthToken.getAuthorities().contains(new SimpleGrantedAuthority("APPLICANT")));
+
+                DefaultOAuth2User oAuth2User = (DefaultOAuth2User) oAuthToken.getPrincipal();
+                assertEquals(memberId, oAuth2User.getAttribute("id"));
+                assertEquals(Role.APPLICANT, oAuth2User.getAttribute("role"));
+                assertEquals(provider, oAuth2User.getAttribute("provider"));
+                assertEquals(email, oAuth2User.getAttribute("email"));
+                assertNotNull(oAuth2User.getAttribute("last_login_time"));
+
+                verify(session).setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
+            }
+        }
+
+        @Nested
+        @DisplayName("유효한 provider와 code가 주어지고 신규 회원이면")
+        class Context_with_valid_provider_and_code_and_new_member {
+
+            private final String provider = "google";
+            private final String code = "auth_code_123";
+            private final String email = "newuser@example.com";
+            private final AuthReferrerType authReferrerType = AuthReferrerType.GOOGLE;
+            private final Long newMemberId = 2L;
+
+            private Member newMember;
+            private UserAuthInfo userAuthInfo;
+
+            @BeforeEach
+            void setUp() {
+                newMember = Member.builder()
+                        .id(newMemberId)
+                        .email(email)
+                        .role(Role.UNAUTHENTICATED)
+                        .authReferrerType(authReferrerType)
+                        .build();
+
+                userAuthInfo = new UserAuthInfo(email, provider, authReferrerType);
+
+                given(oAuthProviderFactory.getProvider(provider)).willReturn(oAuthProvider);
+                given(oAuthProvider.authenticate(code)).willReturn(userAuthInfo);
+                given(memberRepository.findByAuthReferrerTypeAndEmail(authReferrerType, email))
+                        .willReturn(Optional.empty());
+                given(memberRepository.save(any(Member.class))).willReturn(newMember);
+                given(request.getSession(false)).willReturn(session);
+                given(session.getLastAccessedTime()).willReturn(System.currentTimeMillis());
+            }
+
+            @Test
+            @DisplayName("새로운 회원을 생성하고 OAuth 인증을 완료한다")
+            void it_creates_new_member_and_completes_oauth_authentication() {
+                oAuthAuthenticationService.execute(provider, code, request);
+
+                verify(oAuthProviderFactory).getProvider(provider);
+                verify(oAuthProvider).authenticate(code);
+                verify(memberRepository).findByAuthReferrerTypeAndEmail(authReferrerType, email);
+
+                ArgumentCaptor<Member> memberCaptor = ArgumentCaptor.forClass(Member.class);
+                verify(memberRepository).save(memberCaptor.capture());
+
+                Member savedMember = memberCaptor.getValue();
+                assertEquals(email, savedMember.getEmail());
+                assertEquals(authReferrerType, savedMember.getAuthReferrerType());
+
+                ArgumentCaptor<Authentication> authCaptor = ArgumentCaptor.forClass(Authentication.class);
+                verify(securityContext).setAuthentication(authCaptor.capture());
+
+                Authentication authentication = authCaptor.getValue();
+                assertTrue(authentication instanceof OAuth2AuthenticationToken);
+
+                verify(session).setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
+            }
+        }
+
+        @Nested
+        @DisplayName("세션이 무효화된 상태에서 요청이 오면")
+        class Context_with_invalidated_session {
+
+            private final String provider = "google";
+            private final String code = "auth_code_123";
+            private final String email = "test@example.com";
+            private final AuthReferrerType authReferrerType = AuthReferrerType.GOOGLE;
+
+            private Member existingMember;
+            private UserAuthInfo userAuthInfo;
+            private HttpSession newSession;
+
+            @BeforeEach
+            void setUp() {
+                existingMember = Member.builder()
+                        .id(1L)
+                        .email(email)
+                        .role(Role.APPLICANT)
+                        .authReferrerType(authReferrerType)
+                        .build();
+
+                userAuthInfo = new UserAuthInfo(email, provider, authReferrerType);
+                newSession = mock(HttpSession.class);
+
+                given(oAuthProviderFactory.getProvider(provider)).willReturn(oAuthProvider);
+                given(oAuthProvider.authenticate(code)).willReturn(userAuthInfo);
+                given(memberRepository.findByAuthReferrerTypeAndEmail(authReferrerType, email))
+                        .willReturn(Optional.of(existingMember));
+                given(request.getSession(false)).willReturn(session);
+                given(session.getLastAccessedTime()).willThrow(new IllegalStateException("Session invalidated"));
+                given(request.getSession(true)).willReturn(newSession);
+            }
+
+            @Test
+            @DisplayName("새로운 세션을 생성하고 보안 컨텍스트를 설정한다")
+            void it_creates_new_session_and_sets_security_context() {
+                oAuthAuthenticationService.execute(provider, code, request);
+
+                verify(session).getLastAccessedTime();
+                verify(request).getSession(true);
+                verify(newSession).setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
+            }
+        }
+
+        @Nested
+        @DisplayName("세션이 없는 상태에서 요청이 오면")
+        class Context_with_no_session {
+
+            private final String provider = "google";
+            private final String code = "auth_code_123";
+            private final String email = "test@example.com";
+            private final AuthReferrerType authReferrerType = AuthReferrerType.GOOGLE;
+
+            private Member existingMember;
+            private UserAuthInfo userAuthInfo;
+            private HttpSession newSession;
+
+            @BeforeEach
+            void setUp() {
+                existingMember = Member.builder()
+                        .id(1L)
+                        .email(email)
+                        .role(Role.APPLICANT)
+                        .authReferrerType(authReferrerType)
+                        .build();
+
+                userAuthInfo = new UserAuthInfo(email, provider, authReferrerType);
+                newSession = mock(HttpSession.class);
+
+                given(oAuthProviderFactory.getProvider(provider)).willReturn(oAuthProvider);
+                given(oAuthProvider.authenticate(code)).willReturn(userAuthInfo);
+                given(memberRepository.findByAuthReferrerTypeAndEmail(authReferrerType, email))
+                        .willReturn(Optional.of(existingMember));
+                given(request.getSession(false)).willReturn(null);
+                given(request.getSession(true)).willReturn(newSession);
+            }
+
+            @Test
+            @DisplayName("새로운 세션을 생성하고 보안 컨텍스트를 설정한다")
+            void it_creates_new_session_and_sets_security_context() {
+                oAuthAuthenticationService.execute(provider, code, request);
+
+                verify(request).getSession(false);
+                verify(request).getSession(true);
+                verify(newSession).setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
+            }
+        }
+
+        @Nested
+        @DisplayName("회원의 role이 null인 경우")
+        class Context_with_null_member_role {
+
+            private final String provider = "google";
+            private final String code = "auth_code_123";
+            private final String email = "test@example.com";
+            private final AuthReferrerType authReferrerType = AuthReferrerType.GOOGLE;
+
+            private Member memberWithNullRole;
+            private UserAuthInfo userAuthInfo;
+
+            @BeforeEach
+            void setUp() {
+                memberWithNullRole = Member.builder()
+                        .id(1L)
+                        .email(email)
+                        .role(null)
+                        .authReferrerType(authReferrerType)
+                        .build();
+
+                userAuthInfo = new UserAuthInfo(email, provider, authReferrerType);
+
+                given(oAuthProviderFactory.getProvider(provider)).willReturn(oAuthProvider);
+                given(oAuthProvider.authenticate(code)).willReturn(userAuthInfo);
+                given(memberRepository.findByAuthReferrerTypeAndEmail(authReferrerType, email))
+                        .willReturn(Optional.of(memberWithNullRole));
+                given(request.getSession(false)).willReturn(session);
+                given(session.getLastAccessedTime()).willReturn(System.currentTimeMillis());
+            }
+
+            @Test
+            @DisplayName("기본 권한 UNAUTHENTICATED를 설정한다")
+            void it_sets_default_unauthenticated_authority() {
+                oAuthAuthenticationService.execute(provider, code, request);
+
+                ArgumentCaptor<Authentication> authCaptor = ArgumentCaptor.forClass(Authentication.class);
+                verify(securityContext).setAuthentication(authCaptor.capture());
+
+                Authentication authentication = authCaptor.getValue();
+                assertTrue(authentication instanceof OAuth2AuthenticationToken);
+                OAuth2AuthenticationToken oAuthToken = (OAuth2AuthenticationToken) authentication;
+
+                assertTrue(oAuthToken.getAuthorities().contains(new SimpleGrantedAuthority("UNAUTHENTICATED")));
+            }
+        }
+    }
+}

--- a/src/test/java/team/themoment/hellogsmv3/domain/security/auth/service/OAuthAuthenticationServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/security/auth/service/OAuthAuthenticationServiceTest.java
@@ -20,7 +20,9 @@ import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.entity.type.AuthReferrerType;
 import team.themoment.hellogsmv3.domain.member.entity.type.Role;
 import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
-import team.themoment.hellogsmv3.domain.security.auth.service.provider.OAuthProvider;
+import team.themoment.hellogsmv3.global.security.auth.service.OAuthAuthenticationService;
+import team.themoment.hellogsmv3.global.security.auth.service.OAuthProviderFactory;
+import team.themoment.hellogsmv3.global.security.auth.service.provider.OAuthProvider;
 import team.themoment.hellogsmv3.global.security.auth.dto.UserAuthInfo;
 
 import java.util.Optional;

--- a/src/test/java/team/themoment/hellogsmv3/domain/security/auth/service/OAuthAuthenticationServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/security/auth/service/OAuthAuthenticationServiceTest.java
@@ -110,7 +110,7 @@ class OAuthAuthenticationServiceTest {
                 verify(securityContext).setAuthentication(authCaptor.capture());
 
                 Authentication authentication = authCaptor.getValue();
-                assertTrue(authentication instanceof OAuth2AuthenticationToken);
+                assertInstanceOf(OAuth2AuthenticationToken.class, authentication);
                 OAuth2AuthenticationToken oAuthToken = (OAuth2AuthenticationToken) authentication;
 
                 assertEquals(provider, oAuthToken.getAuthorizedClientRegistrationId());
@@ -182,7 +182,7 @@ class OAuthAuthenticationServiceTest {
                 verify(securityContext).setAuthentication(authCaptor.capture());
 
                 Authentication authentication = authCaptor.getValue();
-                assertTrue(authentication instanceof OAuth2AuthenticationToken);
+                assertInstanceOf(OAuth2AuthenticationToken.class, authentication);
 
                 verify(session).setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
             }
@@ -317,7 +317,7 @@ class OAuthAuthenticationServiceTest {
                 verify(securityContext).setAuthentication(authCaptor.capture());
 
                 Authentication authentication = authCaptor.getValue();
-                assertTrue(authentication instanceof OAuth2AuthenticationToken);
+                assertInstanceOf(OAuth2AuthenticationToken.class, authentication);
                 OAuth2AuthenticationToken oAuthToken = (OAuth2AuthenticationToken) authentication;
 
                 assertTrue(oAuthToken.getAuthorities().contains(new SimpleGrantedAuthority("UNAUTHENTICATED")));

--- a/src/test/java/team/themoment/hellogsmv3/domain/security/auth/service/OAuthAuthenticationServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/security/auth/service/OAuthAuthenticationServiceTest.java
@@ -116,7 +116,7 @@ class OAuthAuthenticationServiceTest {
                 assertEquals(provider, oAuthToken.getAuthorizedClientRegistrationId());
                 assertTrue(oAuthToken.getAuthorities().contains(new SimpleGrantedAuthority("OAUTH2_USER")));
                 assertTrue(oAuthToken.getAuthorities().contains(new SimpleGrantedAuthority("SCOPE_email")));
-                assertTrue(oAuthToken.getAuthorities().contains(new SimpleGrantedAuthority("APPLICANT")));
+                assertTrue(oAuthToken.getAuthorities().contains(new SimpleGrantedAuthority(Role.APPLICANT.name())));
 
                 DefaultOAuth2User oAuth2User = (DefaultOAuth2User) oAuthToken.getPrincipal();
                 assertEquals(memberId, oAuth2User.getAttribute("id"));
@@ -320,7 +320,7 @@ class OAuthAuthenticationServiceTest {
                 assertInstanceOf(OAuth2AuthenticationToken.class, authentication);
                 OAuth2AuthenticationToken oAuthToken = (OAuth2AuthenticationToken) authentication;
 
-                assertTrue(oAuthToken.getAuthorities().contains(new SimpleGrantedAuthority("UNAUTHENTICATED")));
+                assertTrue(oAuthToken.getAuthorities().contains(new SimpleGrantedAuthority(Role.UNAUTHENTICATED.name())));
             }
         }
     }


### PR DESCRIPTION
## 개요

- #243 에서 정의된 ``OAuthAuthenticationService`` 서비스 클래스의 테스트 코드를 작성하고 테스트 코드를 작성하면서 발견한 로직의 취약점을 보강하였습니다.

## 본문

OAuth 인증/인가를 처리하는 서비스 클래스의 로직을 테스트하는 코드를 작성하였습니다
테스트 케이스는 다음과 같습니다
- 유효한 provider와 code가 주어지고 기존 회원이 존재하면 OAuth 인증을 완료하고 보안 컨텍스트에 인증 정보를 설정한다
- 유효한 provider와 code가 주어지고 신규 회원이면 새로운 회원을 생성하고 OAuth 인증을 완료한다
- 세션이 무효화된 상태에서 요청이 오면 새로운 세션을 생성하고 보안 컨텍스트를 설정한다
- 세션이 없는 상태에서 요청이 오면 새로운 세션을 생성하고 보안 컨텍스트를 설정한다
- 회원의 role이 null인 경우 기본 권한 UNAUTHENTICATED를 설정한다


또한 사용자의 `role`이 null 일 경우 `Map.of()`로 유저 정보를 구성하는 과정에서 NPE가 발생할 수 있는 취약점을 확인하여 방어 로직을 구현하였습니다