### PR TITLE
[oneseo] BigDecimal JPA Column 소수점, 정확도 명시

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestFactorsDetail.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestFactorsDetail.java
@@ -18,37 +18,37 @@ public class EntranceTestFactorsDetail {
     @Column(name = "entrance_test_factors_detail_id")
     private Long id;
 
-    @Column(name = "general_subjects_score", scale = 3)
+    @Column(name = "general_subjects_score", precision = 6, scale = 3)
     private BigDecimal generalSubjectsScore;
 
-    @Column(name = "arts_physical_subjects_score", scale = 3)
+    @Column(name = "arts_physical_subjects_score", precision = 6, scale = 3)
     private BigDecimal artsPhysicalSubjectsScore;
 
-    @Column(name = "total_subjects_score", scale = 3)
+    @Column(name = "total_subjects_score", precision = 6, scale = 3)
     private BigDecimal totalSubjectsScore;
 
-    @Column(name = "attendance_score", scale = 3)
+    @Column(name = "attendance_score", precision = 6, scale = 3)
     private BigDecimal attendanceScore;
 
-    @Column(name = "volunteer_score", scale = 3)
+    @Column(name = "volunteer_score", precision = 6, scale = 3)
     private BigDecimal volunteerScore;
 
-    @Column(name = "total_non_subjects_score", scale = 3)
+    @Column(name = "total_non_subjects_score", precision = 6, scale = 3)
     private BigDecimal totalNonSubjectsScore;
 
-    @Column(name = "score_1_2", scale = 3)
+    @Column(name = "score_1_2", precision = 6, scale = 3)
     private BigDecimal score1_2;
 
-    @Column(name = "score_2_1", scale = 3)
+    @Column(name = "score_2_1", precision = 6, scale = 3)
     private BigDecimal score2_1;
 
-    @Column(name = "score_2_2", scale = 3)
+    @Column(name = "score_2_2", precision = 6, scale = 3)
     private BigDecimal score2_2;
 
-    @Column(name = "score_3_1", scale = 3)
+    @Column(name = "score_3_1", precision = 6, scale = 3)
     private BigDecimal score3_1;
 
-    @Column(name = "score_3_2", scale = 3)
+    @Column(name = "score_3_2", precision = 6, scale = 3)
     private BigDecimal score3_2;
 
     public void updateGradeEntranceTestFactorsDetail(

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestResult.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestResult.java
@@ -37,7 +37,7 @@ public class EntranceTestResult {
     @Column(name = "first_test_pass_yn")
     private YesNo firstTestPassYn;
 
-    @Column(name = "competency_evaluation_score", scale = 3)
+    @Column(name = "competency_evaluation_score")
     private BigDecimal competencyEvaluationScore;
 
     @Column(name = "interview_score")

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestResult.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/EntranceTestResult.java
@@ -30,7 +30,7 @@ public class EntranceTestResult {
     @JoinColumn(name = "entrance_test_factors_detail_id")
     private EntranceTestFactorsDetail entranceTestFactorsDetail;
 
-    @Column(name = "document_evaluation_score", scale = 3)
+    @Column(name = "document_evaluation_score", precision = 6, scale = 3)
     private BigDecimal documentEvaluationScore;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/entity/MiddleSchoolAchievement.java
@@ -80,6 +80,6 @@ public class MiddleSchoolAchievement {
     @Column(name = "free_semester")
     private String freeSemester;
 
-    @Column(name = "ged_avg_score", scale = 2)
+    @Column(name = "ged_avg_score", precision = 5, scale = 2)
     private BigDecimal gedAvgScore;
 }


### PR DESCRIPTION
## 개요

점수를 나타내는 필드들의 소수점과 정확도를 알맞게 명시하였습니다.

## 본문

- #256 PR에서 jpa에서 scale만 명시할시 precision과 scale 모두 기본값이 들어가는 문제가 있어, precision을 명시하였습니다.
- 역량검사 점수가 정수형, 100점 만점 형식의 자료형으로 확인되어서 scale 부분을 삭제하였습니다.
  추후에 정수형으로 바꾸는것도 고려할 수 있을것 같습니다.