### PR TITLE
[utility] 원서삭제 및 회원탈퇴 기능 구현

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/controller/UtilityController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/controller/UtilityController.java
@@ -26,4 +26,12 @@ public class UtilityController {
                 "입력된 접수 번호에 해당하는 원서를 삭제했습니다. 접수 번호: " + submitCode
         );
     }
+
+    @Operation(summary = "회원 탈퇴", description = "입력된 전화 번호에 해당하는 계정을 탈퇴시킵니다.")
+    @DeleteMapping("/member")
+    public CommonApiResponse deleteMember(@RequestParam String phoneNumber) {
+        return CommonApiResponse.success(
+                "입력된 전화 번호에 해당하는 계정을 탈퇴했습니다. 전화 번호: " + phoneNumber
+        );
+    }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/controller/UtilityController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/controller/UtilityController.java
@@ -1,0 +1,25 @@
+package team.themoment.hellogsmv3.domain.common.utility.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
+
+@RestController
+@RequestMapping
+@Tag(name = "Utility API", description = "개발용 유틸리티 API입니다.")
+@RequiredArgsConstructor
+public class UtilityController {
+
+
+    @Operation(summary = "원서 삭제", description = "입력된 접수 번호에 해당하는 원서를 삭제합니다.")
+    public CommonApiResponse deleteOneseo(@RequestParam String submitCode) {
+        return CommonApiResponse.success(
+                "입력된 접수 번호에 해당하는 원서를 삭제했습니다. 접수 번호: " + submitCode
+        );
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/controller/UtilityController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/controller/UtilityController.java
@@ -1,23 +1,27 @@
 package team.themoment.hellogsmv3.domain.common.utility.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import team.themoment.hellogsmv3.domain.common.utility.service.DeleteOneseoService;
 import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 
 @RestController
-@RequestMapping
+@RequestMapping("/utility/v3")
 @Tag(name = "Utility API", description = "개발용 유틸리티 API입니다.")
 @RequiredArgsConstructor
 public class UtilityController {
 
+    private final DeleteOneseoService deleteOneseoService;
 
     @Operation(summary = "원서 삭제", description = "입력된 접수 번호에 해당하는 원서를 삭제합니다.")
+    @DeleteMapping("/oneseo")
     public CommonApiResponse deleteOneseo(@RequestParam String submitCode) {
+        deleteOneseoService.execute(submitCode);
         return CommonApiResponse.success(
                 "입력된 접수 번호에 해당하는 원서를 삭제했습니다. 접수 번호: " + submitCode
         );

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/controller/UtilityController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/controller/UtilityController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import team.themoment.hellogsmv3.domain.common.utility.service.DeleteMemberService;
 import team.themoment.hellogsmv3.domain.common.utility.service.DeleteOneseoService;
 import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 
@@ -17,6 +18,7 @@ import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 public class UtilityController {
 
     private final DeleteOneseoService deleteOneseoService;
+    private final DeleteMemberService deleteMemberService;
 
     @Operation(summary = "원서 삭제", description = "입력된 접수 번호에 해당하는 원서를 삭제합니다.")
     @DeleteMapping("/oneseo")
@@ -30,6 +32,7 @@ public class UtilityController {
     @Operation(summary = "회원 탈퇴", description = "입력된 전화 번호에 해당하는 계정을 탈퇴시킵니다.")
     @DeleteMapping("/member")
     public CommonApiResponse deleteMember(@RequestParam String phoneNumber) {
+        deleteMemberService.execute(phoneNumber);
         return CommonApiResponse.success(
                 "입력된 전화 번호에 해당하는 계정을 탈퇴했습니다. 전화 번호: " + phoneNumber
         );

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/controller/UtilityController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/controller/UtilityController.java
@@ -3,6 +3,7 @@ package team.themoment.hellogsmv3.domain.common.utility.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -15,6 +16,7 @@ import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 @RequestMapping("/utility/v3")
 @Tag(name = "Utility API", description = "개발용 유틸리티 API입니다.")
 @RequiredArgsConstructor
+@Profile("!prod")
 public class UtilityController {
 
     private final DeleteOneseoService deleteOneseoService;

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteMemberService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteMemberService.java
@@ -1,0 +1,42 @@
+package team.themoment.hellogsmv3.domain.common.utility.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
+import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+import java.util.Optional;
+
+import static team.themoment.hellogsmv3.domain.oneseo.service.OneseoService.ONESEO_CACHE_VALUE;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteMemberService {
+
+    private final MemberRepository memberRepository;
+    private final OneseoRepository oneseoRepository;
+    private final CodeRepository codeRepository;
+
+    @Transactional(rollbackFor = Exception.class)
+    @CacheEvict(value = ONESEO_CACHE_VALUE, key = "#result")
+    public Long execute(String phoneNumber) {
+        Member member = memberRepository.findByPhoneNumber(phoneNumber)
+                .orElseThrow(() -> new ExpectedException(
+                        "해당 전화 번호에 해당하는 계정이 존재하지 않습니다.",
+                        HttpStatus.NOT_FOUND
+                ));
+        Long memberId = member.getId();
+        Optional<Oneseo> oneseo = oneseoRepository.findByMember(member);
+        oneseo.ifPresent(oneseoRepository::delete);
+        codeRepository.deleteByMemberId(memberId);
+        memberRepository.delete(member);
+        return memberId;
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteMemberService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteMemberService.java
@@ -5,7 +5,9 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType;
 import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
 import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
@@ -35,8 +37,15 @@ public class DeleteMemberService {
         Long memberId = member.getId();
         Optional<Oneseo> oneseo = oneseoRepository.findByMember(member);
         oneseo.ifPresent(oneseoRepository::delete);
-        codeRepository.deleteByMemberId(memberId);
+        deleteAuthenticationCodes(memberId);
         memberRepository.delete(member);
         return memberId;
+    }
+    
+    private void deleteAuthenticationCodes(Long memberId) {
+        for (AuthCodeType authCodeType : AuthCodeType.values()) {
+            Optional<AuthenticationCode> authCode = codeRepository.findByMemberIdAndAuthCodeType(memberId, authCodeType);
+            authCode.ifPresent(codeRepository::delete);
+        }
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteMemberService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteMemberService.java
@@ -2,6 +2,7 @@ package team.themoment.hellogsmv3.domain.common.utility.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +21,7 @@ import static team.themoment.hellogsmv3.domain.oneseo.service.OneseoService.ONES
 
 @Service
 @RequiredArgsConstructor
+@Profile("!prod")
 public class DeleteMemberService {
 
     private final MemberRepository memberRepository;

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoService.java
@@ -17,15 +17,11 @@ public class DeleteOneseoService {
     private final OneseoRepository oneseoRepository;
 
     @Transactional(rollbackFor = Exception.class)
-    public void execute(String submitCode) {
+    @CacheEvict(value = ONESEO_CACHE_VALUE, key = "#result")
+    public Long execute(String submitCode) {
         Long memberId = oneseoRepository.findMemberIdByOneseoSubmitCode(submitCode)
                 .orElseThrow(() -> new ExpectedException("해당 접수 번호에 해당하는 원서가 존재하지 않습니다.", HttpStatus.NOT_FOUND));
         oneseoRepository.deleteByOneseoSubmitCode(submitCode);
-        evictOneseoCache(memberId);
-    }
-
-    // Redis 캐시에서 해당 memberId에 대한 원서 정보를 제거하기 위한 메서드입니다
-    @CacheEvict(value = ONESEO_CACHE_VALUE, key = "#memberId")
-    public void evictOneseoCache(Long memberId) {
+        return memberId;
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoService.java
@@ -1,10 +1,12 @@
 package team.themoment.hellogsmv3.domain.common.utility.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.hellogsmv3.domain.oneseo.service.OneseoService;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 @Service
@@ -15,8 +17,16 @@ public class DeleteOneseoService {
 
     @Transactional(rollbackFor = Exception.class)
     public void execute(String submitCode) {
+        Long memberId = oneseoRepository.findMemberIdByOneseoSubmitCode(submitCode)
+                .orElseThrow(() -> new ExpectedException("해당 접수 번호에 해당하는 원서가 존재하지 않습니다.", HttpStatus.NOT_FOUND));
         if (oneseoRepository.deleteByOneseoSubmitCode(submitCode) == 0) {
-            throw new ExpectedException("해당 접수 번호에 해당하는 원서가 존재하지 않습니다.", HttpStatus.NOT_FOUND);
+            throw new ExpectedException("원서 삭제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
         }
+        evictOneseoCache(memberId);
+    }
+
+    // Redis 캐시에서 해당 memberId에 대한 원서 정보를 제거하기 위한 메서드입니다
+    @CacheEvict(value = OneseoService.ONESEO_CACHE_VALUE, key = "#memberId")
+    public void evictOneseoCache(Long memberId) {
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoService.java
@@ -3,6 +3,7 @@ package team.themoment.hellogsmv3.domain.common.utility.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
@@ -12,6 +13,7 @@ public class DeleteOneseoService {
 
     private final OneseoRepository oneseoRepository;
 
+    @Transactional(rollbackFor = Exception.class)
     public void execute(String submitCode) {
         if (oneseoRepository.deleteByOneseoSubmitCode(submitCode)) {
             throw new ExpectedException("해당 접수 번호에 해당하는 원서가 존재하지 않습니다.", HttpStatus.NOT_FOUND);

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoService.java
@@ -2,6 +2,7 @@ package team.themoment.hellogsmv3.domain.common.utility.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,6 +13,7 @@ import static team.themoment.hellogsmv3.domain.oneseo.service.OneseoService.ONES
 
 @Service
 @RequiredArgsConstructor
+@Profile("!prod")
 public class DeleteOneseoService {
 
     private final OneseoRepository oneseoRepository;

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoService.java
@@ -1,0 +1,20 @@
+package team.themoment.hellogsmv3.domain.common.utility.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteOneseoService {
+
+    private final OneseoRepository oneseoRepository;
+
+    public void execute(String submitCode) {
+        if (oneseoRepository.deleteByOneseoSubmitCode(submitCode)) {
+            throw new ExpectedException("해당 접수 번호에 해당하는 원서가 존재하지 않습니다.", HttpStatus.NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoService.java
@@ -15,7 +15,7 @@ public class DeleteOneseoService {
 
     @Transactional(rollbackFor = Exception.class)
     public void execute(String submitCode) {
-        if (oneseoRepository.deleteByOneseoSubmitCode(submitCode)) {
+        if (oneseoRepository.deleteByOneseoSubmitCode(submitCode) == 0) {
             throw new ExpectedException("해당 접수 번호에 해당하는 원서가 존재하지 않습니다.", HttpStatus.NOT_FOUND);
         }
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoService.java
@@ -6,8 +6,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
-import team.themoment.hellogsmv3.domain.oneseo.service.OneseoService;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+import static team.themoment.hellogsmv3.domain.oneseo.service.OneseoService.ONESEO_CACHE_VALUE;
 
 @Service
 @RequiredArgsConstructor
@@ -19,14 +20,12 @@ public class DeleteOneseoService {
     public void execute(String submitCode) {
         Long memberId = oneseoRepository.findMemberIdByOneseoSubmitCode(submitCode)
                 .orElseThrow(() -> new ExpectedException("해당 접수 번호에 해당하는 원서가 존재하지 않습니다.", HttpStatus.NOT_FOUND));
-        if (oneseoRepository.deleteByOneseoSubmitCode(submitCode) == 0) {
-            throw new ExpectedException("원서 삭제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        oneseoRepository.deleteByOneseoSubmitCode(submitCode);
         evictOneseoCache(memberId);
     }
 
     // Redis 캐시에서 해당 memberId에 대한 원서 정보를 제거하기 위한 메서드입니다
-    @CacheEvict(value = OneseoService.ONESEO_CACHE_VALUE, key = "#memberId")
+    @CacheEvict(value = ONESEO_CACHE_VALUE, key = "#memberId")
     public void evictOneseoCache(Long memberId) {
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/repository/CodeRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/repository/CodeRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 public interface CodeRepository extends CrudRepository<AuthenticationCode, String> {
     Optional<AuthenticationCode> findByMemberIdAndAuthCodeType(Long memberId, AuthCodeType authCodeType);
     Optional<AuthenticationCode> findByCode(String code);
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/repository/CodeRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/repository/CodeRepository.java
@@ -9,5 +9,4 @@ import java.util.Optional;
 public interface CodeRepository extends CrudRepository<AuthenticationCode, String> {
     Optional<AuthenticationCode> findByMemberIdAndAuthCodeType(Long memberId, AuthCodeType authCodeType);
     Optional<AuthenticationCode> findByCode(String code);
-    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoRepository.java
@@ -15,5 +15,5 @@ public interface OneseoRepository extends JpaRepository<Oneseo, Long>, CustomOne
     boolean existsByMember(Member member);
     Optional<Oneseo> findByMember(Member member);
 
-    boolean deleteByOneseoSubmitCode(String oneseoSubmitCode);
+    long deleteByOneseoSubmitCode(String oneseoSubmitCode);
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoRepository.java
@@ -14,6 +14,4 @@ import java.util.Optional;
 public interface OneseoRepository extends JpaRepository<Oneseo, Long>, CustomOneseoRepository {
     boolean existsByMember(Member member);
     Optional<Oneseo> findByMember(Member member);
-    @Query("SELECT o FROM Oneseo o JOIN FETCH o.member WHERE o.member.name = :memberName AND o.member.birth = :memberBirth")
-    Optional<Oneseo> findByMemberNameAndMemberBirth(String memberName, LocalDate memberBirth);
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoRepository.java
@@ -2,6 +2,7 @@ package team.themoment.hellogsmv3.domain.oneseo.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
 import team.themoment.hellogsmv3.domain.oneseo.repository.custom.CustomOneseoRepository;
@@ -14,6 +15,8 @@ import java.util.Optional;
 public interface OneseoRepository extends JpaRepository<Oneseo, Long>, CustomOneseoRepository {
     boolean existsByMember(Member member);
     Optional<Oneseo> findByMember(Member member);
+    @Query("SELECT o.member.id FROM Oneseo o WHERE o.oneseoSubmitCode = :submitCode")
+    Optional<Long> findMemberIdByOneseoSubmitCode(@Param("submitCode") String submitCode);
 
     long deleteByOneseoSubmitCode(String oneseoSubmitCode);
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoRepository.java
@@ -18,5 +18,5 @@ public interface OneseoRepository extends JpaRepository<Oneseo, Long>, CustomOne
     @Query("SELECT o.member.id FROM Oneseo o WHERE o.oneseoSubmitCode = :submitCode")
     Optional<Long> findMemberIdByOneseoSubmitCode(@Param("submitCode") String submitCode);
 
-    long deleteByOneseoSubmitCode(String oneseoSubmitCode);
+    void deleteByOneseoSubmitCode(String oneseoSubmitCode);
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/OneseoRepository.java
@@ -14,4 +14,6 @@ import java.util.Optional;
 public interface OneseoRepository extends JpaRepository<Oneseo, Long>, CustomOneseoRepository {
     boolean existsByMember(Member member);
     Optional<Oneseo> findByMember(Member member);
+
+    boolean deleteByOneseoSubmitCode(String oneseoSubmitCode);
 }

--- a/src/main/java/team/themoment/hellogsmv3/global/config/SwaggerConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/config/SwaggerConfig.java
@@ -32,7 +32,7 @@ public class SwaggerConfig {
     public GroupedOpenApi api(OperationCustomizer operationCustomizer) {
         return GroupedOpenApi.builder()
                 .group("Hello, GSM 2024 API")
-                .pathsToMatch("/member/**", "/oneseo/**", "/auth/**", "/date", "/operation/**", "/test-result/**")
+                .pathsToMatch("/utility/**" ,"/member/**", "/oneseo/**", "/auth/**", "/date", "/operation/**", "/test-result/**")
                 .addOperationCustomizer(operationCustomizer)
                 .build();
     }

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceFirstTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceFirstTestResultServiceTest.java
@@ -1,4 +1,4 @@
-package team.themoment.hellogsmv3.domain.common.service;
+package team.themoment.hellogsmv3.domain.common.operation.service;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -10,7 +10,6 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
 import team.themoment.hellogsmv3.domain.common.operation.repository.OperationTestResultRepository;
-import team.themoment.hellogsmv3.domain.common.operation.service.AnnounceFirstTestResultService;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceSecondTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/AnnounceSecondTestResultServiceTest.java
@@ -1,4 +1,4 @@
-package team.themoment.hellogsmv3.domain.common.service;
+package team.themoment.hellogsmv3.domain.common.operation.service;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -10,7 +10,6 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
 import team.themoment.hellogsmv3.domain.common.operation.repository.OperationTestResultRepository;
-import team.themoment.hellogsmv3.domain.common.operation.service.AnnounceSecondTestResultService;
 import team.themoment.hellogsmv3.domain.oneseo.repository.EntranceTestResultRepository;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.security.data.ScheduleEnvironment;

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/QueryAnnounceTestResultServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/operation/service/QueryAnnounceTestResultServiceTest.java
@@ -1,4 +1,4 @@
-package team.themoment.hellogsmv3.domain.common.service;
+package team.themoment.hellogsmv3.domain.common.operation.service;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -11,7 +11,6 @@ import org.springframework.http.HttpStatus;
 import team.themoment.hellogsmv3.domain.common.operation.dto.response.AnnounceTestResultResDto;
 import team.themoment.hellogsmv3.domain.common.operation.entity.OperationTestResult;
 import team.themoment.hellogsmv3.domain.common.operation.repository.OperationTestResultRepository;
-import team.themoment.hellogsmv3.domain.common.operation.service.QueryAnnounceTestResultService;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 
 import java.util.Optional;

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteMemberServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteMemberServiceTest.java
@@ -1,0 +1,147 @@
+package team.themoment.hellogsmv3.domain.common.utility.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import team.themoment.hellogsmv3.domain.member.entity.AuthenticationCode;
+import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.member.entity.type.AuthCodeType;
+import team.themoment.hellogsmv3.domain.member.repository.CodeRepository;
+import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
+import team.themoment.hellogsmv3.domain.oneseo.entity.Oneseo;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@DisplayName("DeleteMemberService 클래스의")
+class DeleteMemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private OneseoRepository oneseoRepository;
+    @Mock
+    private CodeRepository codeRepository;
+
+    @InjectMocks
+    private DeleteMemberService deleteMemberService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Nested
+    @DisplayName("execute 메소드는")
+    class Describe_execute {
+
+        private final String phoneNumber = "01012345678";
+        private final Long memberId = 1L;
+
+        @Nested
+        @DisplayName("유효한 전화번호가 주어지면")
+        class Context_with_valid_phone_number {
+
+            private Member existingMember;
+            private Oneseo existingOneseo;
+            private AuthenticationCode existingAuthCode;
+
+            @BeforeEach
+            void setUp() {
+                existingMember = mock(Member.class);
+                existingOneseo = mock(Oneseo.class);
+                existingAuthCode = new AuthenticationCode(
+                        memberId,
+                        "123456",
+                        phoneNumber,
+                        LocalDateTime.now(),
+                        AuthCodeType.SIGNUP,
+                        true
+                );
+
+                given(existingMember.getId()).willReturn(memberId);
+                given(memberRepository.findByPhoneNumber(phoneNumber)).willReturn(Optional.of(existingMember));
+                given(oneseoRepository.findByMember(existingMember)).willReturn(Optional.of(existingOneseo));
+                given(codeRepository.findByMemberIdAndAuthCodeType(memberId, AuthCodeType.SIGNUP))
+                        .willReturn(Optional.of(existingAuthCode));
+                given(codeRepository.findByMemberIdAndAuthCodeType(memberId, AuthCodeType.TEST_RESULT))
+                        .willReturn(Optional.empty());
+            }
+
+            @Test
+            @DisplayName("회원과 관련된 모든 데이터를 삭제하고 memberId를 반환한다")
+            void it_deletes_all_member_data_and_returns_member_id() {
+                Long result = deleteMemberService.execute(phoneNumber);
+
+                verify(oneseoRepository).delete(existingOneseo);
+                verify(codeRepository).delete(existingAuthCode);
+                verify(memberRepository).delete(existingMember);
+                assertEquals(memberId, result);
+            }
+        }
+
+        @Nested
+        @DisplayName("Oneseo가 존재하지 않는 회원의 전화번호가 주어지면")
+        class Context_with_member_without_oneseo {
+
+            private Member existingMember;
+
+            @BeforeEach
+            void setUp() {
+                existingMember = mock(Member.class);
+
+                given(existingMember.getId()).willReturn(memberId);
+                given(memberRepository.findByPhoneNumber(phoneNumber)).willReturn(Optional.of(existingMember));
+                given(oneseoRepository.findByMember(existingMember)).willReturn(Optional.empty());
+
+                for (AuthCodeType authCodeType : AuthCodeType.values()) {
+                    given(codeRepository.findByMemberIdAndAuthCodeType(memberId, authCodeType))
+                            .willReturn(Optional.empty());
+                }
+            }
+
+            @Test
+            @DisplayName("회원만 삭제하고 memberId를 반환한다")
+            void it_deletes_only_member_and_returns_member_id() {
+                Long result = deleteMemberService.execute(phoneNumber);
+
+                verify(oneseoRepository, never()).delete(any(Oneseo.class));
+                verify(codeRepository, never()).delete(any(AuthenticationCode.class));
+                verify(memberRepository).delete(existingMember);
+                assertEquals(memberId, result);
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 전화번호가 주어지면")
+        class Context_with_non_existing_phone_number {
+
+            @BeforeEach
+            void setUp() {
+                given(memberRepository.findByPhoneNumber(phoneNumber)).willReturn(Optional.empty());
+            }
+
+            @Test
+            @DisplayName("ExpectedException을 던진다")
+            void it_throws_expected_exception() {
+                ExpectedException exception = assertThrows(ExpectedException.class,
+                        () -> deleteMemberService.execute(phoneNumber));
+
+                assertEquals("해당 전화 번호에 해당하는 계정이 존재하지 않습니다.", exception.getMessage());
+                assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+            }
+        }
+    }
+}

--- a/src/test/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoServiceTest.java
+++ b/src/test/java/team/themoment/hellogsmv3/domain/common/utility/service/DeleteOneseoServiceTest.java
@@ -1,0 +1,83 @@
+package team.themoment.hellogsmv3.domain.common.utility.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import team.themoment.hellogsmv3.domain.oneseo.repository.OneseoRepository;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("DeleteOneseoService 클래스의")
+class DeleteOneseoServiceTest {
+
+    @Mock
+    private OneseoRepository oneseoRepository;
+
+    @InjectMocks
+    private DeleteOneseoService deleteOneseoService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Nested
+    @DisplayName("execute 메소드는")
+    class Describe_execute {
+
+        private final String submitCode = "A-1";
+        private final Long memberId = 1L;
+
+        @Nested
+        @DisplayName("유효한 접수 번호가 주어지면")
+        class Context_with_valid_submit_code {
+
+            @BeforeEach
+            void setUp() {
+                given(oneseoRepository.findMemberIdByOneseoSubmitCode(submitCode))
+                        .willReturn(Optional.of(memberId));
+            }
+
+            @Test
+            @DisplayName("원서를 삭제하고 memberId를 반환한다")
+            void it_deletes_oneseo_and_returns_member_id() {
+                Long result = deleteOneseoService.execute(submitCode);
+
+                verify(oneseoRepository).deleteByOneseoSubmitCode(submitCode);
+                assertEquals(memberId, result);
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 접수 번호가 주어지면")
+        class Context_with_non_existing_submit_code {
+
+            @BeforeEach
+            void setUp() {
+                given(oneseoRepository.findMemberIdByOneseoSubmitCode(submitCode))
+                        .willReturn(Optional.empty());
+            }
+
+            @Test
+            @DisplayName("ExpectedException을 던진다")
+            void it_throws_expected_exception() {
+                ExpectedException exception = assertThrows(ExpectedException.class,
+                        () -> deleteOneseoService.execute(submitCode));
+
+                assertEquals("해당 접수 번호에 해당하는 원서가 존재하지 않습니다.", exception.getMessage());
+                assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요

개발 상황에서 팀원들이 필요할 때 원서와 계정을 삭제할 수 있도록 API 2종을 구현하고 테스트 코드를 작성하였습니다

## 본문

원서 삭제 API와 회원 탈퇴 API를 구현하였습니다.
`common/utility` 패키지를 생성하여 구현하였으며 새로운 도메인으로 `utility`를 추가하였습니다.
원서 삭제 시 원서와 더불어 Redis에 캐싱된 정보까지 삭제하도록 하였으며 회원 탈퇴시에는 작성된 원서와 저장된 인증용 코드까지 삭제하도록 하였습니다.해당 API들의 비즈니스 로직을 검증하는 테스트 코드까지 작성하였습니다.

해당 엔드포인트는 프로파일이 `prod` 라면 Bean으로 등록되지 않아 동작하지 않습니다.

부가적으로 기존에 존재하던 `common.operation`의 하위 서비스 클래스들을 테스트하던 테스트 코드들이 `test` 패키지에서 `common.service`에 존재하던 것을 `utility` 패키지의 추가로 인하여 `common.operation.service`로 이전하였습니다.

### 사용방법 

원서 삭제 시 원서의 접수 번호를 이용합니다
```
DELETE /utility/v3/oneseo?submitCode=A-1
```
다음과 같이 `submitCode` 쿼리파라미터 까지 전달한다면 `A-1` 원서를 삭제합니다.

회원 탈퇴 시 계정의 전화번호를 이용합니다
```
DELETE /utility/v3/member?phoneNumber=01012345678
```
다음과 같이 `phoneNumber` 쿼리파라미터를 전달한다면 해당하는 전화번호를 가진 계정과 계정의 원서,인증코드까지 삭제합니다.