### PR TITLE
[utility] 개발용 계정 권한 조정 유틸리티 API 구현

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/controller/UtilityController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/controller/UtilityController.java
@@ -4,12 +4,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import team.themoment.hellogsmv3.domain.common.utility.service.DeleteMemberService;
 import team.themoment.hellogsmv3.domain.common.utility.service.DeleteOneseoService;
+import team.themoment.hellogsmv3.domain.common.utility.service.ModifyMemberRoleService;
+import team.themoment.hellogsmv3.domain.member.entity.type.Role;
 import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 
 @RestController
@@ -21,6 +20,7 @@ public class UtilityController {
 
     private final DeleteOneseoService deleteOneseoService;
     private final DeleteMemberService deleteMemberService;
+    private final ModifyMemberRoleService modifyMemberRoleService;
 
     @Operation(summary = "원서 삭제", description = "입력된 접수 번호에 해당하는 원서를 삭제합니다.")
     @DeleteMapping("/oneseo")
@@ -37,6 +37,18 @@ public class UtilityController {
         deleteMemberService.execute(phoneNumber);
         return CommonApiResponse.success(
                 "입력된 전화 번호에 해당하는 계정을 탈퇴했습니다. 전화 번호: " + phoneNumber
+        );
+    }
+
+    @Operation(summary = "사용자 권한 수정", description = "입력된 전화 번호에 해당하는 사용자의 권한을 수정합니다.")
+    @PatchMapping("/member/role")
+    public CommonApiResponse updateMemberRole(
+            @RequestParam String phoneNumber,
+            @RequestParam Role role
+    ) {
+        modifyMemberRoleService.execute(phoneNumber, role);
+        return CommonApiResponse.success(
+                "입력된 전화 번호에 해당하는 사용자의 권한을 수정했습니다. 전화 번호: " + phoneNumber + ", 권한: " + role
         );
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/ModifyMemberRoleService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/ModifyMemberRoleService.java
@@ -1,0 +1,35 @@
+package team.themoment.hellogsmv3.domain.common.utility.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.hellogsmv3.domain.member.entity.Member;
+import team.themoment.hellogsmv3.domain.member.entity.type.Role;
+import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
+
+@Service
+@RequiredArgsConstructor
+@Profile("!prod")
+public class ModifyMemberRoleService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void execute(String phoneNumber, Role role) {
+        memberRepository.findByPhoneNumber(phoneNumber)
+                .ifPresent(member -> {
+                    Member.builder()
+                            .id(member.getId())
+                            .name(member.getName())
+                            .phoneNumber(member.getPhoneNumber())
+                            .email(member.getEmail())
+                            .role(role)
+                            .sex(member.getSex())
+                            .birth(member.getBirth())
+                            .authReferrerType(member.getAuthReferrerType())
+                            .build();
+                    memberRepository.save(member);
+                });
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/ModifyMemberRoleService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/common/utility/service/ModifyMemberRoleService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import team.themoment.hellogsmv3.domain.member.entity.Member;
 import team.themoment.hellogsmv3.domain.member.entity.type.Role;
 import team.themoment.hellogsmv3.domain.member.repository.MemberRepository;
 
@@ -19,17 +18,7 @@ public class ModifyMemberRoleService {
     public void execute(String phoneNumber, Role role) {
         memberRepository.findByPhoneNumber(phoneNumber)
                 .ifPresent(member -> {
-                    Member.builder()
-                            .id(member.getId())
-                            .name(member.getName())
-                            .phoneNumber(member.getPhoneNumber())
-                            .email(member.getEmail())
-                            .role(role)
-                            .sex(member.getSex())
-                            .birth(member.getBirth())
-                            .authReferrerType(member.getAuthReferrerType())
-                            .build();
-                    memberRepository.save(member);
+                    member.modifyMemberRole(role);
                 });
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/member/entity/Member.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/member/entity/Member.java
@@ -74,6 +74,10 @@ public class Member {
         return this;
     }
 
+    public void modifyMemberRole(Role role) {
+        this.role = role;
+    }
+
     @PrePersist
     private void prePersist() {
         this.role = this.role == null ? Role.UNAUTHENTICATED : this.role;


### PR DESCRIPTION
## 개요

전화번호를 입력받아 해당 계정에 특정 권한을 부여할 수 있는 API를 구현하였습니다.

## 본문

본 API는 전화번호와 권한을 쿼리 파라미터로 전달받아, 사용자 계정의 권한 정보를 변경할 수 있도록 개발되었습니다.  
아래와 같이 호출할 수 있으며, 상용 환경(`prod` 프로파일)에서는 동작하지 않도록 제한하였습니다.
```
utility/v3/member/role?phoneNumber=01012345678&role=APPLICANT
```
### 피드백 

이번 기능 구현 과정에서 엔티티에 직접 권한을 수정하는 메서드를 두는 것이 타당한지에 대한 의견이 궁금합니다.  
본 API는 일반 사용자가 사용하는 것이 아닌, 개발 과정에서 효율성을 높이기 위해 마련된 기능입니다. 다만 `modifyMemberRole`과 같은 메서드가 엔티티에 존재할 경우, 이후 다른 기능 개발 과정에서 불필요하게 활용되거나 위험한 코드로 이어질 가능성도 우려됩니다.  

또한 기존에는 빌더 패턴을 통해 권한 정보를 변경하였으나, 이번에는 별도의 메서드를 만들어 처리하면서 일관성을 유지해야 하는지 고민이 있습니다.
  
추가적으로 메서드 반환 타입에 대해서도 의견을 부탁드립니다. 현재는 `void`를 반환하도록 구현되어 있으나, 추후 다른 곳에서도 사용 가능성을 고려하여 `Member` 객체를 반환하도록 하는 것이 좋을지도 검토 부탁드립니다.

### 기타

브랜치 명칭은 원래 `ADMIN` 권한을 추가/제거하는 API 개발을 목적으로 했으나, 실제 구현은 원하는 권한을 부여할 수 있도록 확장되었습니다. 따라서 브랜치 이름과 실제 작업 내용이 일부 일치하지 않음을 참고 부탁드립니다.