### PR TITLE
[auth] 세션 관련 정책 설정 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationCodeTokenResponseClient;
 import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
 import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
@@ -90,7 +91,11 @@ public class SecurityConfig {
 
     private void basicSetting(HttpSecurity http) throws Exception {
         http.formLogin(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable);
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
+                        .sessionFixation().migrateSession()
+                );
     }
 
     private void cors(HttpSecurity http) throws Exception {


### PR DESCRIPTION
## 개요

세션 저장 시 `creationTime key must not be null` 문제를 해결하기 위하여 보안 설정에 `migrateSession `를 적용하였습니다

## 본문

Spring Security에서 `creationTime key must not be null` 문제가 발생하였는데 이러한 문제를 해결하기 위하여 #263 에서 세션 저장 시 검증을 강화하도록 하였습니다.
해당 조치에 이어서 보안 설정에서 세션을 아예 새로 생성하도록 설정을 추가하였습니다.

### 기타

해당 블로그를 참고하였습니다
- https://algorithm-master.tistory.com/174
