### PR TITLE
[oneseo] 원서 검색 및 엑셀 출력 시 수험번호 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/SearchOneseoResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/dto/response/SearchOneseoResDto.java
@@ -18,6 +18,7 @@ public record SearchOneseoResDto(
         String phoneNumber,
         String guardianPhoneNumber,
         String schoolTeacherPhoneNumber,
+        String examinationNumber,
         YesNo firstTestPassYn,
         BigDecimal competencyEvaluationScore,
         BigDecimal interviewScore,

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/repository/custom/impl/CustomOneseoRepositoryImpl.java
@@ -127,6 +127,7 @@ public class CustomOneseoRepositoryImpl implements CustomOneseoRepository {
                         oneseo.member.phoneNumber,
                         oneseo.oneseoPrivacyDetail.guardianPhoneNumber,
                         oneseo.oneseoPrivacyDetail.schoolTeacherPhoneNumber,
+                        oneseo.examinationNumber,
                         oneseo.entranceTestResult.firstTestPassYn,
                         oneseo.entranceTestResult.competencyEvaluationScore,
                         oneseo.entranceTestResult.interviewScore,

--- a/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/oneseo/service/DownloadExcelService.java
@@ -37,7 +37,7 @@ public class DownloadExcelService {
     private static final int ROW_ACCESS_WINDOW = 100;  // SXSSFWorkbook의 메모리 사용 최적화를 위한 행 접근 윈도우 크기
 
     private static final List<String> HEADER_NAMES = List.of(
-            "순번", "접수번호", "성명", "1지망", "2지망", "3지망", "생년월일", "성별", "상세주소", "출신학교",
+            "순번", "접수번호", "수험번호", "성명", "1지망", "2지망", "3지망", "생년월일", "성별", "상세주소", "출신학교",
             "학력", "초기전형", "적용되는 전형", "일반교과점수", "예체능점수", "출석점수", "봉사점수", "1차전형총점",
             "역량평가점수", "심층면접점수", "최종점수", "최종학과", "지원자연락처", "보호자연락처", "담임연락처", "1차전형결과", "2차전형결과"
     );
@@ -180,6 +180,7 @@ public class DownloadExcelService {
         return List.of(
                 String.valueOf(index),
                 formatSubmitCode(oneseo.getOneseoSubmitCode()),
+                safeToString(oneseo.getExaminationNumber()),
                 safeToString(oneseo.getMember().getName()),
                 firstDesiredMajor,
                 secondDesiredMajor,


### PR DESCRIPTION
## 개요

원서 검색 시와 엑셀 출력 시에 수험번호(`examination_number`)를 추가적으로 출력하도록 하였습니다

## 본문

원서 검색 시와 엑셀 출력 시 수험번호 필드를 추가적으로 쿼리하여 조회해 출력하도록 하였습니다
(출력된 [지원자 입학정보.xlsx](https://github.com/user-attachments/files/21987074/default.xlsx) 확인하기)
